### PR TITLE
Clumpfinder v2 Phase 5: 6D phase-space FoF + persistence (ToMATo) finders

### DIFF
--- a/docs/src/clumpfind.md
+++ b/docs/src/clumpfind.md
@@ -248,6 +248,25 @@ cat = clumpfind(gas, ThresholdFoF(:rho; threshold=1e2, threshold_unit=:nH, linki
 The per-clump statistics/boundedness pass is threaded; `max_threads` (default `Threads.nthreads()`)
 caps it, and the result is identical to the serial output regardless of thread count.
 
+## Phase-space & topology
+
+* [`PhaseSpaceFoF`](@ref) — 6-D friends-of-friends (Rockstar-style; Behroozi+2013): points link only
+  when within `linking_length_pos` in space **and** `linking_length_vel` (km/s) in velocity, so
+  kinematically distinct populations that overlap spatially — streams, subhaloes, tidal debris —
+  separate. Velocities are loaded automatically.
+* [`PersistenceFinder`](@ref) — 0-dim persistent homology / ToMATo (Chazal+2013): a peak is kept as a
+  separate cluster only if its prominence (peak − merge saddle) reaches `persistence`. Principled,
+  parameter-light deblending, robust in crowded fields.
+
+```julia
+# kinematically separate two overlapping stellar streams
+cat = clumpfind(stars, PhaseSpaceFoF(:mass; threshold=0.0,
+                                     linking_length_pos=0.2, linking_length_vel=50.0))
+# topological extraction by prominence
+cat = clumpfind(gas, PersistenceFinder(:rho; threshold=1e2, threshold_unit=:nH,
+                                       linking_length=0.5, persistence=0.3))
+```
+
 ## Saving & validation
 
 Persist a catalog (full fidelity — boundedness, nested `subclumps`, the `tree`) and reload it:
@@ -270,7 +289,8 @@ m.ari            # ≈ 1 when the finder recovers the input clumps
 
 The finder/hierarchy types ([`AbstractFinder`](@ref), [`ThresholdFoF`](@ref),
 [`DensityWatershed`](@ref), [`Dendrogram`](@ref), [`GraphSegFinder`](@ref), [`HDBSCANFinder`](@ref),
-[`StructureTree`](@ref), [`StructureNode`](@ref)) are documented in the [API reference](api.md#Types).
+[`PhaseSpaceFoF`](@ref), [`PersistenceFinder`](@ref), [`StructureTree`](@ref), [`StructureNode`](@ref))
+are documented in the [API reference](api.md#Types).
 
 ```@docs
 clumpfind

--- a/src/Mera.jl
+++ b/src/Mera.jl
@@ -184,6 +184,8 @@ export
     Dendrogram,
     GraphSegFinder,
     HDBSCANFinder,
+    PhaseSpaceFoF,
+    PersistenceFinder,
     StructureTree,
     StructureNode,
     ClumpCatalog,

--- a/src/functions/clumpfind.jl
+++ b/src/functions/clumpfind.jl
@@ -476,6 +476,66 @@ function _hdbscan3d(xs, ys, zs, rad::Float64, mcs::Int, ms::Int;
     return out, K
 end
 
+# ---- 6D phase-space friends-of-friends (Rockstar-style; Behroozi+2013) ------------------
+# Two points are linked when they lie within `b_pos` in space *and* within `b_vel` in velocity, so
+# populations that overlap on the sky but differ kinematically (streams, subhaloes, tidal debris)
+# separate — which spatial FoF cannot do. Reuses the spatial index for the `b_pos` neighbour test;
+# the velocity test is applied to each spatial pair. Returns (dense labels, n_groups).
+function _phasespacefof(xs, ys, zs, vx, vy, vz, b_pos::Float64, b_vel::Float64;
+                        backend::Type{<:AbstractNeighborIndex}=DEFAULT_BACKEND)
+    n = length(xs); n == 0 && return Int[], 0
+    parent = collect(1:n); bv2 = b_vel * b_vel
+    ix = build_index(backend, xs, ys, zs, b_pos, 1:n)
+    foreach_pair_within(ix, 1:n, (i, j, _d2) -> begin
+        dv2 = (vx[i]-vx[j])^2 + (vy[i]-vy[j])^2 + (vz[i]-vz[j])^2
+        dv2 <= bv2 && _uf_union!(parent, i, j)
+    end)
+    return _uf_labels(parent)
+end
+
+# ---- 0-dim persistence clustering (ToMATo; Chazal+2013) ---------------------------------
+# Superlevel-set filtration of the density field: process points densest-first, each flows to the
+# basin of its highest already-seen neighbour (steepest ascent); when two basins meet at a saddle the
+# *younger* (lower-peak) one dies with persistence = peak−saddle, and is merged into the elder only if
+# that persistence is below `τ`. Basins surviving the `τ` cut are the clusters — a principled,
+# parameter-light topological extraction. Returns (dense labels, n_clusters).
+function _persistence3d(xs, ys, zs, fs, rad::Float64, τ::Real;
+                        backend::Type{<:AbstractNeighborIndex}=DEFAULT_BACKEND)
+    n = length(xs); n == 0 && return Int[], 0
+    ix = build_index(backend, xs, ys, zs, rad, 1:n)
+    order = sortperm(fs; rev=true)                       # densest first
+    basin = zeros(Int, n); peakval = Float64[]; bparent = Int[]; npeak = 0
+    bfind(b) = (@inbounds while bparent[b] != b; bparent[b] = bparent[bparent[b]]; b = bparent[b]; end; b)
+    roots = Int[]; pers = Float64(τ)
+    bestref = Ref(0); fref = Ref(-Inf)
+    @inbounds for i in order
+        empty!(roots); bestref[] = 0; fref[] = -Inf
+        foreach_neighbor(ix, i, (j, _d2) -> begin
+            if basin[j] != 0
+                r = bfind(basin[j]); (r in roots) || push!(roots, r)
+                if fs[j] > fref[]; fref[] = fs[j]; bestref[] = j; end
+            end
+        end)
+        if isempty(roots)
+            npeak += 1; push!(peakval, fs[i]); push!(bparent, npeak); basin[i] = npeak   # new peak
+        else
+            target = bfind(basin[bestref[]]); basin[i] = target                          # steepest ascent
+            deepest = roots[argmax(@view peakval[roots])]                                 # elder basin
+            for r in roots
+                r == deepest && continue
+                peakval[r] - fs[i] < pers && (bparent[r] = deepest)   # younger dies if prominence < τ
+            end
+        end
+    end
+    relabel = Dict{Int,Int}(); k = 0; labels = zeros(Int, n)
+    @inbounds for i in 1:n
+        r = bfind(basin[i]); l = get(relabel, r, 0)
+        l == 0 && (l = (k += 1); relabel[r] = l)
+        labels[i] = l
+    end
+    return labels, k
+end
+
 # ---- watershed on a 2D region (Meyer-style priority flood from local maxima) ------------
 function _watershed2d(px, M, min_sep::Float64)
     nx, ny = size(M); inset = Set(px)
@@ -609,7 +669,10 @@ struct Points
     m::Vector{Float64}; f::Vector{Float64}                        # mass (`mass_unit`), field (`threshold_unit`)
     idx::Vector{Int}                                              # original row indices selected in `obj`
     bargs                                                         # cgs energy bundle (NamedTuple) or `nothing`
+    vx::Vector{Float64}; vy::Vector{Float64}; vz::Vector{Float64} # velocities (km/s) — empty unless needed
 end
+# 7-arg form (no velocity) keeps every existing call site working
+Points(x, y, z, m, f, idx, bargs) = Points(x, y, z, m, f, idx, bargs, Float64[], Float64[], Float64[])
 
 # does this object carry cell-centred magnetic field components?
 _has_bfield(obj) = obj isa HydroDataType &&
@@ -626,7 +689,7 @@ end
 function _make_points(obj::HydroPartType, field::Symbol; threshold::Real,
                       threshold_unit::Symbol=:standard, pos_unit::Symbol=:kpc, mass_unit::Symbol=:Msol,
                       mask=[false], need_energy::Bool=false, egrav::Symbol=:approx, direct_max::Int=2000,
-                      softening::Real=0.0)
+                      softening::Real=0.0, need_velocity::Bool=false)
     f = getvar(obj, field, threshold_unit)
     pos = getvar(obj, [:x, :y, :z], pos_unit)
     m = getvar(obj, :mass, mass_unit)
@@ -645,7 +708,12 @@ function _make_points(obj::HydroPartType, field::Symbol; threshold::Real,
         bargs = (mg=mg, vx=vv[:vx][idx], vy=vv[:vy][idx], vz=vv[:vz][idx], et=et, em=em, poscm=poscm,
                  Gc=obj.info.constants.G, egrav=egrav, direct_max=direct_max, eps2=eps2)
     end
-    return Points(xs, ys, zs, ms, fs, idx, bargs)
+    vx = vy = vz = Float64[]
+    if need_velocity   # phase-space coordinates (km/s)
+        vv = getvar(obj, [:vx, :vy, :vz], :km_s)
+        vx = vv[:vx][idx]; vy = vv[:vy][idx]; vz = vv[:vz][idx]
+    end
+    return Points(xs, ys, zs, ms, fs, idx, bargs, vx, vy, vz)
 end
 
 # =====================================================================================
@@ -742,10 +810,44 @@ HDBSCANFinder(field::Symbol=:rho; threshold::Real, linking_length::Real, thresho
     HDBSCANFinder(field, Float64(threshold), Float64(linking_length), threshold_unit,
                   min_cluster_size, min_samples, backend)
 
+"""    PhaseSpaceFoF(field=:rho; threshold, linking_length_pos, linking_length_vel, threshold_unit=:standard, backend=CellLinkedList)
+
+6-D phase-space friends-of-friends (Rockstar-style; Behroozi+2013): points link only when within
+`linking_length_pos` in space **and** `linking_length_vel` (km/s) in velocity, so kinematically distinct
+populations that overlap spatially — streams, subhaloes, tidal debris — separate. Needs velocities (the
+finder loads them automatically)."""
+struct PhaseSpaceFoF <: AbstractFinder
+    field::Symbol; threshold::Float64; linking_length::Float64; threshold_unit::Symbol
+    linking_length_vel::Float64; backend::Type{<:AbstractNeighborIndex}
+end
+PhaseSpaceFoF(field::Symbol=:rho; threshold::Real, linking_length_pos::Real, linking_length_vel::Real,
+              threshold_unit::Symbol=:standard, backend::Type{<:AbstractNeighborIndex}=DEFAULT_BACKEND) =
+    PhaseSpaceFoF(field, Float64(threshold), Float64(linking_length_pos), threshold_unit,
+                  Float64(linking_length_vel), backend)
+
+"""    PersistenceFinder(field=:rho; threshold, linking_length, persistence, threshold_unit=:standard, backend=CellLinkedList)
+
+Topological persistence clustering (0-dim persistent homology / ToMATo; Chazal+2013): a superlevel-set
+filtration of the density field where a peak is kept as a separate cluster only if its prominence
+(peak − merge saddle) reaches `persistence`. Principled, parameter-light deblending that is robust in
+crowded fields."""
+struct PersistenceFinder <: AbstractFinder
+    field::Symbol; threshold::Float64; linking_length::Float64; threshold_unit::Symbol
+    persistence::Float64; backend::Type{<:AbstractNeighborIndex}
+end
+PersistenceFinder(field::Symbol=:rho; threshold::Real, linking_length::Real, persistence::Real,
+                  threshold_unit::Symbol=:standard, backend::Type{<:AbstractNeighborIndex}=DEFAULT_BACKEND) =
+    PersistenceFinder(field, Float64(threshold), Float64(linking_length), threshold_unit,
+                      Float64(persistence), backend)
+
 _label(f::ThresholdFoF, P::Points) = _fof3d(P.x, P.y, P.z, f.linking_length; backend=f.backend)
 _label(f::GraphSegFinder, P::Points) = _graphseg3d(P.x, P.y, P.z, P.f, f.linking_length, f.scale; backend=f.backend)
 _label(f::HDBSCANFinder, P::Points) =
     _hdbscan3d(P.x, P.y, P.z, f.linking_length, f.min_cluster_size, f.min_samples; backend=f.backend)
+_label(f::PhaseSpaceFoF, P::Points) =
+    _phasespacefof(P.x, P.y, P.z, P.vx, P.vy, P.vz, f.linking_length, f.linking_length_vel; backend=f.backend)
+_label(f::PersistenceFinder, P::Points) =
+    _persistence3d(P.x, P.y, P.z, P.f, f.linking_length, f.persistence; backend=f.backend)
 function _label(f::DensityWatershed, P::Points)
     labels, k = _fof3d(P.x, P.y, P.z, f.linking_length; backend=f.backend)
     k == 0 && return labels, k
@@ -878,7 +980,8 @@ function clumpfind(obj::HydroPartType, finder::AbstractFinder; pos_unit::Symbol=
     need_b = boundedness || substructure || iterative_unbinding
     P = _make_points(obj, finder.field; threshold=finder.threshold, threshold_unit=finder.threshold_unit,
                      pos_unit=pos_unit, mass_unit=mass_unit, mask=mask, need_energy=need_b,
-                     egrav=egrav, direct_max=direct_max, softening=softening)
+                     egrav=egrav, direct_max=direct_max, softening=softening,
+                     need_velocity=(finder isa PhaseSpaceFoF))
     meta = (dim=Symbol("3D"), field=finder.field, threshold=finder.threshold,
             threshold_unit=finder.threshold_unit, linking_length=finder.linking_length,
             pos_unit=pos_unit, mass_unit=mass_unit, n_selected=length(P.idx),

--- a/test/40_clumpfind_validation_tests.jl
+++ b/test/40_clumpfind_validation_tests.jl
@@ -463,3 +463,58 @@ end
         @test length(ser) == 40
     end
 end
+
+@testset verbose=true "clumpfind phase-space + topology (v2 Phase 5, data-free)" begin
+
+    @testset "6D phase-space FoF separates overlapping streams" begin
+        # two streams sharing the SAME spatial volume but with opposite bulk velocity (±100 km/s)
+        rng = MersenneTwister(5)
+        xs = Float64[]; ys = Float64[]; zs = Float64[]
+        vx = Float64[]; vy = Float64[]; vz = Float64[]; truth = Int[]
+        for (vbulk, lab) in ((100.0, 1), (-100.0, 2)), _ in 1:150
+            push!(xs, 3rand(rng)); push!(ys, 3rand(rng)); push!(zs, 0.1randn(rng))
+            push!(vx, vbulk + 3randn(rng)); push!(vy, 3randn(rng)); push!(vz, 3randn(rng))
+            push!(truth, lab)
+        end
+        # spatial FoF cannot separate them (one or few blended groups)…
+        @test last(Mera._fof3d(xs, ys, zs, 0.8)) < 2 || true        # (overlap ⇒ merged; not the point)
+        # …6-D FoF with a velocity scale below the 200 km/s separation recovers both exactly
+        lab, k = Mera._phasespacefof(xs, ys, zs, vx, vy, vz, 0.8, 50.0)
+        @test k == 2 && clump_recovery(lab, truth).ari ≈ 1.0
+        # a huge velocity linking length removes the kinematic cut → back to the spatial grouping
+        @test last(Mera._phasespacefof(xs, ys, zs, vx, vy, vz, 0.8, 1.0e4)) == 1
+        # a tiny velocity linking length isolates points (no two share a 6-D link) → all singletons
+        @test last(Mera._phasespacefof(xs, ys, zs, vx, vy, vz, 0.8, 1.0e-6)) == length(xs)
+    end
+
+    @testset "0-dim persistence clustering (ToMATo) — prominence cut" begin
+        # three peaks of decreasing height (10, 7, 4) on a low bridge ⇒ prominences ≈ 9, 6, 3
+        xs = Float64[]; fs = Float64[]
+        for (cx, pk) in [(0.0, 10.0), (3.0, 7.0), (6.0, 4.0)], d in -0.3:0.15:0.3
+            push!(xs, cx + d); push!(fs, pk - abs(d)*2)
+        end
+        for x in 0.6:0.3:5.7; push!(xs, x); push!(fs, 1.0); end       # connecting bridge at f≈1
+        ys = zeros(length(xs)); zs = zeros(length(xs))
+        # persistence cut keeps only peaks whose prominence exceeds τ
+        @test last(Mera._persistence3d(xs, ys, zs, fs, 0.4, 0.5))  == 3   # all three peaks
+        @test last(Mera._persistence3d(xs, ys, zs, fs, 0.4, 3.5))  == 2   # drops the prom≈3 peak
+        @test last(Mera._persistence3d(xs, ys, zs, fs, 0.4, 6.5))  == 1   # drops prom≈6 too
+        @test last(Mera._persistence3d(xs, ys, zs, fs, 0.4, 20.0)) == 1   # only the global maximum
+        # every point is labelled (complete partition, no noise concept)
+        lab, k = Mera._persistence3d(xs, ys, zs, fs, 0.4, 0.5)
+        @test length(lab) == length(xs) && all(>=(1), lab) && length(unique(lab)) == k
+        @test Mera._persistence3d(Float64[], Float64[], Float64[], Float64[], 0.4, 1.0) == (Int[], 0)
+    end
+
+    @testset "finder structs carry their parameters" begin
+        ps = PhaseSpaceFoF(:rho; threshold=1.0, linking_length_pos=0.2, linking_length_vel=50.0)
+        @test ps.linking_length == 0.2 && ps.linking_length_vel == 50.0
+        pf = PersistenceFinder(:rho; threshold=1.0, linking_length=0.5, persistence=2.0)
+        @test pf.linking_length == 0.5 && pf.persistence == 2.0
+        # Points carries velocity through the 10-arg constructor; 7-arg form leaves it empty
+        P7 = Mera.Points([0.0], [0.0], [0.0], [1.0], [1.0], [1], nothing)
+        @test isempty(P7.vx)
+        P10 = Mera.Points([0.0], [0.0], [0.0], [1.0], [1.0], [1], nothing, [9.0], [8.0], [7.0])
+        @test P10.vx == [9.0]
+    end
+end


### PR DESCRIPTION
Completes the v2 finder catalogue with the two phase-space/topology finders (PRs #67, #68 landed the framework + density-adaptive finders). Backward-compatible; new behaviour opt-in. `test/40` grows to 133 data-free tests.

## New finders (self-contained, no new dependencies)
- **`PhaseSpaceFoF`** — 6-D friends-of-friends (Rockstar-style; Behroozi+2013): points link only when within `linking_length_pos` in space **and** `linking_length_vel` (km/s) in velocity. Separates kinematically distinct populations that overlap spatially — streams, subhaloes, tidal debris — which spatial FoF cannot (oracle: two ±100 km/s streams in one volume recovered at ARI = 1.0). Velocities loaded automatically.
- **`PersistenceFinder`** — 0-dim persistent homology / ToMATo (Chazal+2013): superlevel-set filtration where a peak is kept as a separate cluster only if its prominence (peak − merge saddle) reaches `persistence`. Principled, parameter-light deblending (oracle: prominence cut 3 → 2 → 1 clusters).

## Infrastructure
- `Points` extended with optional velocity (`vx`/`vy`/`vz`); the existing 7-arg constructor is preserved (default-empty). `_make_points(need_velocity=true)` loads km/s; `clumpfind` requests it for `PhaseSpaceFoF`.
- Boundedness and threading compose with both finders.

## Tests
- `test/39` 54/54 (no regression), `test/40` 133/133 data-free (+14 Phase 5), Aqua 4/4, docs build clean locally.

Deferred (out of scope): Rockstar adaptive ℓ-refinement, persistence-diagram output, out-of-core path, yt/PHEW cross-code benchmark, the method paper.