### PR TITLE
quicklook: quicklookplot Makie extension (3-panel first-look dashboard)

### DIFF
--- a/docs/src/report.md
+++ b/docs/src/report.md
@@ -182,3 +182,11 @@ clump_mass_fraction
 * [Off-axis Projection](06_offaxis_Projection.md) — `:faceon`/`:edgeon` and arbitrary lines of sight.
 * [Profiles & Phase Diagrams](15_multi_Profiles_Phase.md) — the profile/phase tools behind the cards.
 * [`quicklook`](@ref) — the fast header-and-sample first look; `report(output)` is its composable form.
+  With a Makie backend loaded (`using CairoMakie`), [`quicklookplot`](@ref) renders its result as a
+  three-panel figure (Σ map · ρ–T phase · radial density):
+
+  ```julia
+  using CairoMakie
+  fig = quicklookplot(quicklook(400; path="/sim"))
+  Makie.save("quicklook.png", fig)
+  ```

--- a/ext/MeraMakieExt.jl
+++ b/ext/MeraMakieExt.jl
@@ -80,4 +80,38 @@ function Mera._save_card_pngs(r::Mera.QuickReport, dir::AbstractString; kwargs..
     return files
 end
 
+# ---- quicklookplot: the three-panel first-look dashboard --------------------------------
+# Σ surface-density map · ρ–T phase diagram · spherical radial density profile, from a QuickLookResult.
+function Mera._plot_quicklook(q::Mera.QuickLookResult; size=(1500, 460), colormap=:turbo)
+    fig = Makie.Figure(; size=size)
+    tag = q.sampled ? "  [APPROXIMATE: levels ≤ $(q.lmax_used)]" : ""
+    Makie.Label(fig[0, 1:3], "Mera quicklook — output $(q.summary.output)$(tag)";
+                fontsize=16, font=:bold)
+
+    # panel 1 — face-on surface density (log10)
+    sd = q.maps.maps[:sd]; ex = q.maps.extent
+    ax1 = Makie.Axis(fig[1, 1]; title="Σ (face-on)", xlabel="x [kpc]", ylabel="y [kpc]",
+                     aspect=Makie.DataAspect())
+    xs = range(ex[1], ex[2], length=Base.size(sd, 1)); ys = range(ex[3], ex[4], length=Base.size(sd, 2))
+    hm1 = Makie.heatmap!(ax1, xs, ys, map(v -> (isfinite(v) && v > 0) ? log10(v) : NaN, sd); colormap)
+    Makie.Colorbar(fig[1, 1][1, 2], hm1; label="log₁₀ Σ [M⊙/pc²]")
+
+    # panel 2 — ρ–T phase (log10 mass-weighted count)
+    ph = q.phase
+    ax2 = Makie.Axis(fig[1, 2]; title="ρ–T phase", xlabel="n_H [cm⁻³]", ylabel="T [K]",
+                     xscale=log10, yscale=log10)
+    xc = sqrt.(ph.xedges[1:end-1] .* ph.xedges[2:end])     # geometric bin centres (log-spaced)
+    yc = sqrt.(ph.yedges[1:end-1] .* ph.yedges[2:end])
+    hm2 = Makie.heatmap!(ax2, xc, yc, map(v -> (isfinite(v) && v > 0) ? log10(v) : NaN, ph.H); colormap)
+    Makie.Colorbar(fig[1, 2][1, 2], hm2; label="log₁₀ mass")
+
+    # panel 3 — spherical radial density profile (the profile supplies ρ per shell directly)
+    pr = q.profile; ρ = pr.density
+    ax3 = Makie.Axis(fig[1, 3]; title="radial density", xlabel="r [kpc]", ylabel="ρ [M⊙/kpc³]",
+                     xscale=log10, yscale=log10)
+    keep = (pr.x .> 0) .& (ρ .> 0) .& isfinite.(ρ)
+    any(keep) && Makie.lines!(ax3, pr.x[keep], ρ[keep])
+    return fig
+end
+
 end # module

--- a/src/Mera.jl
+++ b/src/Mera.jl
@@ -158,6 +158,7 @@ export
     velocitydispersion,
     profiletimeseries,
     quicklook,
+    quicklookplot,
     QuickLookResult,
     report,
     preview,

--- a/src/functions/quicklook.jl
+++ b/src/functions/quicklook.jl
@@ -125,3 +125,30 @@ function _quicklook_print(s, n, t0)
     end
     println("└─ $(round(time()-t0, digits=2)) s ──────────────────────────────────")
 end
+
+# =====================================================================================
+#  Plotting — provided by the Makie package extension (MeraMakieExt)
+# -------------------------------------------------------------------------------------
+#  Kept out of the core deps: `quicklookplot` dispatches to `_plot_quicklook`, which the extension
+#  fills in once a Makie backend is loaded. The bare stub gives a friendly load hint.
+# =====================================================================================
+"""
+    quicklookplot(q::QuickLookResult; kwargs...) -> Makie.Figure
+
+Render a [`QuickLookResult`](@ref) as a three-panel figure — the face-on surface-density map, the
+ρ–T phase diagram, and the spherical radial density profile. Needs a Makie backend loaded
+(`using CairoMakie` or `GLMakie`); the figure is returned, so save it with `Makie.save("ql.png", fig)`.
+
+```julia
+using CairoMakie
+q = quicklook(300; path="…")
+fig = quicklookplot(q)
+```
+"""
+function quicklookplot(q::QuickLookResult; kwargs...)
+    q.maps === nothing && error("quicklookplot: this QuickLookResult has no figure data " *
+                                "(quicklook ran header-only). Call quicklook(output; path=…) to read a sample.")
+    return _plot_quicklook(q; kwargs...)
+end
+_plot_quicklook(q; kwargs...) =
+    error("quicklookplot needs a Makie backend — load one first: `using CairoMakie` (or GLMakie).")

--- a/test/38_report_tests.jl
+++ b/test/38_report_tests.jl
@@ -41,6 +41,29 @@
             @test occursin("Mera report", String(take!(io)))
         end
 
+        @testset "quicklook + quicklookplot (graceful without Makie)" begin
+            q = quicklook(dc.output; path=dc.path, verbose=false)
+            @test q isa QuickLookResult
+            @test q.maps !== nothing && q.phase !== nothing && q.profile !== nothing
+            @test haskey(q.maps.maps, :sd) && haskey(q.phase, :H) && haskey(q.profile, :density)
+
+            # a header-only result (no figure data) refuses to plot with a clear message
+            qhdr = Mera.QuickLookResult(q.info, q.levelmin, q.levelmax, nothing, 0, false,
+                                        nothing, nothing, nothing, q.summary)
+            @test_throws Exception quicklookplot(qhdr)
+
+            if Base.find_package("CairoMakie") === nothing
+                @test_throws Exception quicklookplot(q)          # no backend → friendly error
+            else
+                @eval using CairoMakie
+                fig = quicklookplot(q)                            # building runs the heatmap/line draws
+                @test occursin("Figure", string(typeof(fig)))
+                f = tempname() * ".png"; CairoMakie.save(f, fig)
+                @test isfile(f) && filesize(f) > 0
+                rm(f, force=true)
+            end
+        end
+
         @testset "custom multi-datatype plan + minimal/needs-based read" begin
             plan = ReportPlan(dc.output; path=dc.path, cards=[
                 ProjectionCard(:hydro, :sd; unit=:Msol_pc2, res=64),


### PR DESCRIPTION
Productizes quicklook plotting as a Makie package extension — the flagship first-look now renders its dashboard with one call when a Makie backend is loaded, while core Mera stays plotting-free.

## What
- **`quicklookplot(q::QuickLookResult)`** → a three-panel `Makie.Figure`: face-on Σ surface-density map (log₁₀), ρ–T phase diagram (log₁₀ mass-weighted), and the spherical radial density profile (log–log). Returned so you `Makie.save(...)` it.
- Implemented in the existing **`MeraMakieExt`** weak-dependency extension (loads with `using CairoMakie`/`GLMakie`); core ships only a stub that gives a friendly "load a Makie backend" hint.
- A header-only `QuickLookResult` (no figure data) refuses to plot with a clear message.
- `quicklookplot` is exported; auto-documented in the API reference.

## Tests
- `test/38` +6 (new `quicklook + quicklookplot` testset): asserts the result carries `maps`/`phase`/`profile` data, the header-only guard throws, and — mirroring the report-system Makie test — exercises the error path when no backend is present (CI) and the real render + PNG save when CairoMakie is available (local).
- Verified locally with CairoMakie: renders + saves a valid 3-panel PNG. `test/38` 63/63, Aqua 4/4, docs build clean.