### PR TITLE
covering_grid / slice: AMR → uniform fixed-resolution buffer (with a memory estimator)

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -53,6 +53,8 @@ makedocs(modules = [Mera],
 
                           "Clump Finding"       => "clumpfind.md",
 
+                          "Covering Grid / FRB" => "covering_grid.md",
+
                           "Mask/Filter/Meta"    => Any[ "Tutorial"    => "05_multi_Masking_Filtering.md",
                                                         "API Reference" => "api/masking_filtering.md"],
 

--- a/docs/src/covering_grid.md
+++ b/docs/src/covering_grid.md
@@ -1,0 +1,71 @@
+# Covering Grid / Fixed-Resolution Buffer
+
+[`covering_grid`](@ref) resamples the sparse AMR leaf cells onto a **dense, uniform `Nx×Ny×Nz`
+array** at a chosen refinement level — every output cell sampled, *not* integrated (unlike
+[`projection`](@ref), which sums along a line of sight). [`slice`](@ref) is the 2-D, single-cell-thick
+version (a fixed-resolution buffer through a plane).
+
+Use it to feed analyses that need a regular grid: power spectra, FFTs, structure functions, volume
+rendering / VTK export, machine-learning inputs, or simple `array`-style indexing.
+
+!!! warning "Size it first — a uniform grid can be far larger than the AMR data"
+    AMR stores cells only where the simulation refined; a covering grid fills **every** cell at the
+    target level. Resampling a sparsely-refined region to its finest level can blow up the cell count
+    by orders of magnitude. Always estimate the size with [`covering_grid_memory`](@ref) before
+    building — and `covering_grid` itself refuses to allocate past `max_bytes` (default 4 GB).
+
+## Estimate the memory first
+
+```julia
+gas = gethydro(getinfo(output, path))            # e.g. AMR lmin 3 … lmax 7
+
+covering_grid_memory(gas, [:rho, :T]; lmax=7)
+# covering_grid memory estimate:
+#   level 7  dims (128, 128, 128)  (2097152 cells × 2 var(s))
+#   per array : 16.8 MB
+#   result    : 33.6 MB
+#   peak build: 50.3 MB
+#   AMR cells : 590311   blow-up ×3.553
+```
+
+The returned `NamedTuple` has `dims`, `ncells`, `bytes_per_array`, `result_bytes`, `peak_bytes` (the
+construction high-water mark — `nvars + 1` arrays, since one geometric weight grid is shared), and the
+`blowup` factor (output cells ÷ AMR cells). Pass an `InfoType` to size a grid *before* even reading the
+data (then the AMR-relative `blowup` is `missing`).
+
+## Build the 3-D grid
+
+```julia
+cg = covering_grid(gas, [:rho, :T], [:nH, :K]; lmax=7)   # units optional (default: code units)
+cg[:rho]                       # the 128×128×128 array, n_H in cm⁻³
+cg.cellsize                    # physical cell size (pos_unit)
+cg.extent                      # [x0,x1,y0,y1,z0,z1] (pos_unit)
+```
+
+Restrict to a sub-box (in any unit) and the grid is built only there — much cheaper:
+
+```julia
+cg = covering_grid(gas, :rho; lmax=10, center=[:bc],
+                   xrange=[-2,2], yrange=[-2,2], zrange=[-1,1], range_unit=:kpc)
+```
+
+**Resampling rule (volume-conservative).** A leaf coarser than the target level is *replicated* to fill
+the block of output cells it covers; leaves finer than the target are *volume-averaged* down. Because
+the AMR leaves tile space, `Σ value·volume` is preserved exactly at any target level — `covering_grid`
+of `:rho` conserves total mass whether you up- or down-sample. Output cells that fall outside the data
+are `NaN`.
+
+## 2-D slice (FRB)
+
+```julia
+sl = slice(gas, :rho, :nH; slice_axis=:z, slice_pos=0.5)   # mid-plane n_H cut
+sl[:rho]                       # a 2-D array (single-cell-thick, non-integrated)
+```
+
+`slice_pos` is in `slice_unit` (`:standard` ⇒ a fraction of the box). The slice equals the
+corresponding layer of the full covering grid, but only that layer is built.
+
+## API
+
+The functions ([`covering_grid`](@ref), [`covering_grid_memory`](@ref), [`slice`](@ref)) and the
+result type [`CoveringGridResult`](@ref) are documented in the [API reference](api.md).

--- a/src/Mera.jl
+++ b/src/Mera.jl
@@ -160,6 +160,10 @@ export
     quicklook,
     quicklookplot,
     QuickLookResult,
+    covering_grid,
+    covering_grid_memory,
+    slice,
+    CoveringGridResult,
     report,
     preview,
     render,
@@ -391,6 +395,7 @@ include("functions/regions/shellregion_particles.jl")
 include("functions/regions/shellregion_clumps.jl")
 include("functions/profile.jl")
 include("functions/quicklook.jl")
+include("functions/covering_grid.jl")
 include("functions/sfr.jl")
 include("functions/report/report.jl")
 include("functions/report/report_render.jl")

--- a/src/functions/covering_grid.jl
+++ b/src/functions/covering_grid.jl
@@ -1,0 +1,235 @@
+# =====================================================================================
+#  covering_grid — resample AMR data onto a uniform (fixed-resolution) grid
+# -------------------------------------------------------------------------------------
+#  A "covering grid" (yt term) / fixed-resolution buffer (FRB) turns the sparse AMR leaf
+#  cells into a dense, uniform Nx×Ny×Nz array at a chosen level — every output cell sampled,
+#  not integrated (unlike `projection`). `slice` is the 2-D single-layer FRB.
+#
+#  Resampling is volume-conservative:
+#    * a leaf coarser than the target level (ℓ ≤ L) is **replicated** to fill the (2^{L-ℓ})³
+#      block of output cells it covers (standard covering-grid behaviour);
+#    * leaves finer than the target (ℓ > L) are **volume-averaged** down into their output cell.
+#  Both fall out of one weighted accumulation with per-cell weight 8^{-ℓ} (∝ cell volume), since
+#  the AMR leaves tile space: each output cell is covered either by one coarse leaf or by several
+#  fine leaves, never both.
+#
+#  ⚠ A uniform grid can be MUCH larger than the AMR data (dense vs sparse). Always size it first
+#  with `covering_grid_memory`; `covering_grid` itself refuses to allocate past `max_bytes`.
+# =====================================================================================
+
+"""    CoveringGridResult
+
+Result of [`covering_grid`](@ref) / [`slice`](@ref). `grid` maps each variable to its uniform array
+(3-D for a covering grid, 2-D for a slice); `level` is the uniform refinement level, `dims` the array
+size, `extent` the physical bounds `[x0,x1,y0,y1,z0,z1]` and `cellsize` the physical cell size (both in
+`pos_unit`). Index `grid[:rho]` for the array."""
+struct CoveringGridResult
+    grid::Dict{Symbol,Array{Float64}}
+    grid_unit::Dict{Symbol,Symbol}
+    level::Int
+    dims::Tuple
+    extent::Vector{Float64}
+    cellsize::Float64
+    pos_unit::Symbol
+    ranges::Vector{Float64}        # normalized [0,1] box actually covered
+    slice_axis::Union{Nothing,Symbol}
+    info
+end
+Base.getindex(c::CoveringGridResult, v::Symbol) = c.grid[v]
+Base.keys(c::CoveringGridResult) = keys(c.grid)
+function Base.show(io::IO, c::CoveringGridResult)
+    kind = c.slice_axis === nothing ? "covering_grid" : "slice($(c.slice_axis))"
+    println(io, "CoveringGridResult [$kind]  level $(c.level)  dims $(c.dims)")
+    println(io, "  vars: $(collect(keys(c.grid)))")
+    println(io, "  cellsize $(round(c.cellsize, sigdigits=4)) [$(c.pos_unit)]  " *
+                "extent $(round.(c.extent, sigdigits=4)) [$(c.pos_unit)]")
+end
+
+# normalized box → global level-L integer-index offset and per-axis cell count
+function _grid_dims(ranges::Vector{Float64}, L::Int)
+    N = 2.0^L
+    g0 = (round(Int, ranges[1]*N), round(Int, ranges[3]*N), round(Int, ranges[5]*N))
+    g1 = (round(Int, ranges[2]*N), round(Int, ranges[4]*N), round(Int, ranges[6]*N))
+    dims = (max(1, g1[1]-g0[1]), max(1, g1[2]-g0[2]), max(1, g1[3]-g0[3]))
+    return g0, dims
+end
+
+"""
+    covering_grid_memory(obj, [vars]; lmax=obj.lmax, center=[0.,0.,0.], xrange=[missing,missing],
+                         yrange=[missing,missing], zrange=[missing,missing], range_unit=:standard,
+                         verbose=true) -> NamedTuple
+
+Predict the size of the [`covering_grid`](@ref) **before allocating it** — a uniform grid is dense and
+can dwarf the sparse AMR data, so size it first. Returns `(; level, dims, ncells, nvars, bytes_per_array,
+result_bytes, peak_bytes, amr_ncells, blowup)`: `result_bytes` is the returned arrays, `peak_bytes` the
+transient high-water mark during construction (`(nvars+1)` arrays — one shared geometric weight), and
+`blowup` = output cells ÷ AMR cells. `vars` only sets `nvars` (default 1). Pass an `InfoType` to size
+without loading data (then `amr_ncells`/`blowup` are `missing`)."""
+function covering_grid_memory(obj, vars=:rho; lmax::Int=_cg_default_lmax(obj),
+                              center=[0.,0.,0.], xrange=[missing,missing], yrange=[missing,missing],
+                              zrange=[missing,missing], range_unit::Symbol=:standard, verbose::Bool=true)
+    info = obj isa InfoType ? obj : obj.info
+    ranges = prepranges(info, range_unit, false, collect(xrange), collect(yrange), collect(zrange), collect(center))
+    _, dims = _grid_dims(ranges, lmax)
+    nvars = vars isa Symbol ? 1 : length(vars)
+    ncells = prod(dims)
+    bpa = ncells * sizeof(Float64)
+    result_bytes = bpa * nvars
+    peak_bytes = bpa * (nvars + 1)                 # per-var accumulators + one shared weight grid
+    amr = obj isa InfoType ? missing : length(obj.data)
+    blowup = amr === missing ? missing : ncells / amr
+    res = (level=lmax, dims=dims, ncells=ncells, nvars=nvars, bytes_per_array=bpa,
+           result_bytes=result_bytes, peak_bytes=peak_bytes, amr_ncells=amr, blowup=blowup)
+    verbose && _print_cg_memory(res)
+    return res
+end
+
+_human_bytes(b) = b < 1e3 ? "$(b) B" : b < 1e6 ? "$(round(b/1e3,digits=1)) KB" :
+                  b < 1e9 ? "$(round(b/1e6,digits=1)) MB" :
+                  b < 1e12 ? "$(round(b/1e9,digits=2)) GB" : "$(round(b/1e12,digits=2)) TB"
+
+function _print_cg_memory(r)
+    println("covering_grid memory estimate:")
+    println("  level $(r.level)  dims $(r.dims)  ($(r.ncells) cells × $(r.nvars) var(s))")
+    println("  per array : $(_human_bytes(r.bytes_per_array))")
+    println("  result    : $(_human_bytes(r.result_bytes))")
+    println("  peak build: $(_human_bytes(r.peak_bytes))")
+    if r.amr_ncells !== missing
+        println("  AMR cells : $(r.amr_ncells)   blow-up ×$(round(r.blowup, sigdigits=4))")
+    end
+end
+
+_cg_default_lmax(obj) = obj isa InfoType ? obj.levelmax : obj.lmax
+
+# accumulate AMR leaves into the uniform grid(s); shared geometric weight `wsum` (∝ cell volume)
+function _cg_paint!(grids::Vector{<:Array{Float64}}, wsum::Array{Float64}, cxs, cys, czs, lvls,
+                    vmats, L::Int, g0, dims)
+    nx, ny, nz = dims; gx0, gy0, gz0 = g0; nv = length(vmats)
+    @inbounds for i in eachindex(lvls)
+        ℓ = Int(lvls[i]); w = 8.0^(-ℓ)
+        if ℓ <= L
+            s = 1 << (L - ℓ)
+            ixa = max(1, (cxs[i]-1)*s + 1 - gx0); ixb = min(nx, cxs[i]*s - gx0); ixa > ixb && continue
+            iya = max(1, (cys[i]-1)*s + 1 - gy0); iyb = min(ny, cys[i]*s - gy0); iya > iyb && continue
+            iza = max(1, (czs[i]-1)*s + 1 - gz0); izb = min(nz, czs[i]*s - gz0); iza > izb && continue
+            for kz in iza:izb, ky in iya:iyb, kx in ixa:ixb
+                wsum[kx,ky,kz] += w
+                for vi in 1:nv; grids[vi][kx,ky,kz] += vmats[vi][i]*w; end
+            end
+        else
+            d = ℓ - L
+            ox = ((cxs[i]-1) >> d) + 1 - gx0; (1 <= ox <= nx) || continue
+            oy = ((cys[i]-1) >> d) + 1 - gy0; (1 <= oy <= ny) || continue
+            oz = ((czs[i]-1) >> d) + 1 - gz0; (1 <= oz <= nz) || continue
+            wsum[ox,oy,oz] += w
+            for vi in 1:nv; grids[vi][ox,oy,oz] += vmats[vi][i]*w; end
+        end
+    end
+    return nothing
+end
+
+# shared core: build the (3-D) uniform grids over `ranges` at level `L` for `vars`/`units`
+function _covering_core(obj, vars::Vector{Symbol}, units::Vector{Symbol}, L::Int, ranges::Vector{Float64},
+                        pos_unit::Symbol, max_bytes::Real, slice_axis, verbose::Bool)
+    g0, dims = _grid_dims(ranges, L)
+    nv = length(vars)
+    peak = prod(dims) * sizeof(Float64) * (nv + 1)
+    if peak > max_bytes
+        est = covering_grid_memory(obj, vars; lmax=L, verbose=false)   # dims via full box differ; recompute below
+        error("covering_grid would need ~$(_human_bytes(peak)) (peak) for dims $(dims) × $(nv) var(s), " *
+              "above max_bytes=$(_human_bytes(max_bytes)). Reduce lmax, narrow the range, or raise max_bytes.")
+    end
+    cxs = select(obj.data, :cx); cys = select(obj.data, :cy); czs = select(obj.data, :cz)
+    lvls = in(:level, propertynames(obj.data.columns)) ? select(obj.data, :level) : fill(obj.lmax, length(cxs))
+    vmats = [Float64.(getvar(obj, v, u)) for (v, u) in zip(vars, units)]
+    grids = [zeros(Float64, dims) for _ in 1:nv]
+    wsum = zeros(Float64, dims)
+    _cg_paint!(grids, wsum, cxs, cys, czs, lvls, vmats, L, g0, dims)
+    @inbounds for vi in 1:nv, idx in eachindex(wsum)
+        grids[vi][idx] = wsum[idx] > 0 ? grids[vi][idx]/wsum[idx] : NaN   # uncovered output cells → NaN
+    end
+    boxcm = obj.boxlen * (pos_unit === :standard ? 1.0 : getfield(obj.scale, pos_unit))
+    extent = [ranges[1], ranges[2], ranges[3], ranges[4], ranges[5], ranges[6]] .* boxcm
+    cellsize = boxcm / 2.0^L
+    gdict = Dict{Symbol,Array{Float64}}(); udict = Dict{Symbol,Symbol}()
+    for (vi, v) in enumerate(vars)
+        arr = slice_axis === nothing ? grids[vi] : dropdims(grids[vi]; dims=_axis_dim(slice_axis))
+        gdict[v] = arr; udict[v] = units[vi]
+    end
+    odims = slice_axis === nothing ? dims : Tuple(d for (a, d) in enumerate(dims) if a != _axis_dim(slice_axis))
+    res = CoveringGridResult(gdict, udict, L, odims, extent, cellsize, pos_unit, ranges, slice_axis, obj.info)
+    verbose && show(stdout, res)
+    return res
+end
+
+_axis_dim(ax::Symbol) = ax === :x ? 1 : ax === :y ? 2 : 3
+
+"""
+    covering_grid(obj, var, [unit]; lmax=obj.lmax, center=[0.,0.,0.],
+                  xrange=[missing,missing], yrange=[missing,missing], zrange=[missing,missing],
+                  range_unit=:standard, max_bytes=4e9, pos_unit=:standard, verbose=true) -> CoveringGridResult
+
+Resample the AMR data onto a **uniform Nx×Ny×Nz grid** at refinement level `lmax` over the (optional)
+sub-box — every output cell sampled (not integrated). `var` may be a `Symbol` or a vector; `unit`
+likewise (defaults to code units). Coarse leaves are replicated, fine leaves volume-averaged; output
+cells outside the data are `NaN`.
+
+A uniform grid is dense and can be far larger than the AMR data — call [`covering_grid_memory`](@ref)
+first; this errors rather than allocate past `max_bytes`.
+
+```julia
+gas = gethydro(getinfo(output, path))
+covering_grid_memory(gas, [:rho, :T]; lmax=8)          # check size first
+cg  = covering_grid(gas, [:rho, :T], [:nH, :K]; lmax=8) # then build
+cg[:rho]                                                # the 3-D array
+```
+"""
+covering_grid(obj, var::Symbol, unit::Symbol=:standard; kwargs...) = covering_grid(obj, [var], [unit]; kwargs...)
+covering_grid(obj, vars::AbstractVector{Symbol}; kwargs...) =
+    covering_grid(obj, vars, fill(:standard, length(vars)); kwargs...)
+function covering_grid(obj, vars::AbstractVector{Symbol}, units::AbstractVector{Symbol};
+                       lmax::Int=obj.lmax, center=[0.,0.,0.], xrange=[missing,missing],
+                       yrange=[missing,missing], zrange=[missing,missing], range_unit::Symbol=:standard,
+                       max_bytes::Real=4e9, pos_unit::Symbol=:standard, verbose::Bool=true)
+    length(units) == length(vars) || throw(ArgumentError("units length must match vars"))
+    ranges = prepranges(obj.info, range_unit, false, collect(xrange), collect(yrange), collect(zrange), collect(center))
+    return _covering_core(obj, collect(Symbol, vars), collect(Symbol, units), lmax, ranges, pos_unit,
+                          max_bytes, nothing, verbose)
+end
+
+"""
+    slice(obj, var, [unit]; slice_axis=:z, slice_pos=0.5, slice_unit=:standard, lmax=obj.lmax,
+          center=[0.,0.,0.], xrange=…, yrange=…, zrange=…, range_unit=:standard,
+          max_bytes=4e9, pos_unit=:standard, verbose=true) -> CoveringGridResult
+
+A **2-D fixed-resolution buffer**: a single-cell-thick, non-integrated cut through the AMR data at
+`slice_pos` along `slice_axis` (`:x`/`:y`/`:z`), resampled to level `lmax` (cf. [`covering_grid`](@ref)
+for the 3-D version, `projection` for the integrated map). `slice_pos` is in `slice_unit` (`:standard`
+⇒ a fraction of the box). The result's `grid[var]` is a 2-D array.
+
+```julia
+sl = slice(gas, :rho, :nH; slice_axis=:z, slice_pos=0.5)   # mid-plane n_H map
+sl[:rho]                                                    # 2-D array
+```
+"""
+slice(obj, var::Symbol, unit::Symbol=:standard; kwargs...) = slice(obj, [var], [unit]; kwargs...)
+slice(obj, vars::AbstractVector{Symbol}; kwargs...) = slice(obj, vars, fill(:standard, length(vars)); kwargs...)
+function slice(obj, vars::AbstractVector{Symbol}, units::AbstractVector{Symbol};
+               slice_axis::Symbol=:z, slice_pos::Real=0.5, slice_unit::Symbol=:standard,
+               lmax::Int=obj.lmax, center=[0.,0.,0.], xrange=[missing,missing], yrange=[missing,missing],
+               zrange=[missing,missing], range_unit::Symbol=:standard, max_bytes::Real=4e9,
+               pos_unit::Symbol=:standard, verbose::Bool=true)
+    length(units) == length(vars) || throw(ArgumentError("units length must match vars"))
+    slice_axis in (:x, :y, :z) || throw(ArgumentError("slice_axis must be :x, :y or :z"))
+    ranges = prepranges(obj.info, range_unit, false, collect(xrange), collect(yrange), collect(zrange), collect(center))
+    # collapse the slice axis to one level-L cell at slice_pos (normalized fraction of the box)
+    p = slice_unit === :standard ? Float64(slice_pos) :
+        Float64(slice_pos) / (obj.boxlen * getfield(obj.scale, slice_unit))
+    p = clamp(p, 0.0, 1.0 - 2.0^(-lmax))
+    d = _axis_dim(slice_axis); lo = 2d - 1
+    icell = floor(Int, p * 2.0^lmax)                       # global level-L index of the slab
+    ranges[lo]   = icell / 2.0^lmax
+    ranges[lo+1] = (icell + 1) / 2.0^lmax
+    return _covering_core(obj, collect(Symbol, vars), collect(Symbol, units), lmax, ranges, pos_unit,
+                          max_bytes, slice_axis, verbose)
+end

--- a/test/41_covering_grid_tests.jl
+++ b/test/41_covering_grid_tests.jl
@@ -1,0 +1,127 @@
+# 41_covering_grid_tests.jl  --  covering_grid / slice (fixed-resolution buffer)
+# ==============================================================================
+# The paint kernel (_cg_paint!) and dims math (_grid_dims) are pure array ops → tested
+# data-free for volume-conservation and replication/downsample correctness. The public
+# covering_grid / slice / covering_grid_memory are exercised on :spiral_clumps (AMR) when
+# simulation data is available.
+
+@testset verbose=true "covering_grid" begin
+
+    @testset "grid dims + memory math (data-free)" begin
+        # full box at level L → 2^L cells per axis, offset 0
+        g0, dims = Mera._grid_dims([0.0,1.0, 0.0,1.0, 0.0,1.0], 5)
+        @test g0 == (0, 0, 0) && dims == (32, 32, 32)
+        # a sub-box maps to a global-index offset and a smaller count
+        g0b, dimsb = Mera._grid_dims([0.25,0.5, 0.0,1.0, 0.0,0.5], 4)
+        @test g0b == (4, 0, 0) && dimsb == (4, 16, 8)
+        @test Mera._human_bytes(512) == "512 B"
+        @test Mera._human_bytes(2_500_000) == "2.5 MB"
+    end
+
+    @testset "paint kernel: volume-conservation + replication + downsample (data-free)" begin
+        # synthetic AMR: a 2×2×2 block of level-1 leaves (cx,cy,cz ∈ {1,2}) tiling the unit box,
+        # each with a distinct density. The leaves tile space, so resampling must conserve mass
+        # ΣρV at any target level and reproduce values at the leaves' own level.
+        cxs = Int[]; cys = Int[]; czs = Int[]; vals = Float64[]
+        v = 0.0
+        for cx in 1:2, cy in 1:2, cz in 1:2
+            push!(cxs, cx); push!(cys, cy); push!(czs, cz); push!(vals, (v += 1.0))
+        end
+        lvls = fill(1, 8)
+        amr_mass = sum(vals) * (1/2)^3                      # each level-1 cell has volume (1/2)^3
+
+        function build(L)
+            g0, dims = Mera._grid_dims([0.0,1.0,0.0,1.0,0.0,1.0], L)
+            grids = [zeros(Float64, dims)]; w = zeros(Float64, dims)
+            Mera._cg_paint!(grids, w, cxs, cys, czs, lvls, [vals], L, g0, dims)
+            @inbounds for i in eachindex(w); grids[1][i] = w[i] > 0 ? grids[1][i]/w[i] : NaN; end
+            return grids[1], dims
+        end
+
+        # at the leaves' own level L=1 → exactly the 8 values, mass conserved
+        g1, d1 = build(1); @test d1 == (2,2,2)
+        @test g1[1,1,1] ≈ vals[1] && g1[2,2,2] ≈ vals[8]
+        @test sum(g1) * (1/2)^3 ≈ amr_mass
+
+        # replication up to L=2 → 4^3=64 cells; each leaf fills a 2×2×2 block with its value; mass conserved
+        g2, d2 = build(2); @test d2 == (4,4,4)
+        @test all(≈(vals[1]), g2[1:2, 1:2, 1:2])            # leaf (1,1,1) replicated into its block
+        @test sum(g2) * (1/4)^3 ≈ amr_mass
+
+        # downsample to L=0 → a single cell = volume-weighted mean of all leaves; mass conserved
+        g0arr, d0 = build(0); @test d0 == (1,1,1)
+        @test g0arr[1,1,1] ≈ sum(vals)/8                    # equal-volume leaves → plain mean
+        @test g0arr[1,1,1] * 1.0^3 ≈ amr_mass               # single cell, volume 1
+    end
+
+    if !DATA_AVAILABLE
+        @warn "Skipping data-backed covering_grid tests - simulation data not available"
+        @test_skip "Simulation data not available"
+    else
+        dc = DATASETS[:spiral_clumps]                       # AMR: lmin 3, lmax 7
+        info = getinfo(dc.output, dc.path, verbose=false)
+        gas = gethydro(info, verbose=false, show_progress=false)
+
+        @testset "memory estimator predicts the real array size" begin
+            est = covering_grid_memory(gas, [:rho, :T]; lmax=6, verbose=false)
+            @test est.level == 6 && est.dims == (64, 64, 64)
+            @test est.ncells == 64^3 && est.nvars == 2
+            @test est.bytes_per_array == 64^3 * 8
+            @test est.result_bytes == est.bytes_per_array * 2
+            @test est.peak_bytes == est.bytes_per_array * 3      # nvars + 1 (shared weight)
+            @test est.amr_ncells == length(gas.data) && est.blowup ≈ est.ncells/length(gas.data)
+            # estimated dims == the actual grid's dims
+            cg = covering_grid(gas, :rho; lmax=6, verbose=false)
+            @test size(cg[:rho]) == est.dims
+            # estimator also works from an InfoType (no data) — blow-up unknown
+            einfo = covering_grid_memory(info; lmax=6, verbose=false)
+            @test einfo.dims == (64, 64, 64) && einfo.amr_ncells === missing
+        end
+
+        @testset "mass conservation across resample levels (replication + downsample)" begin
+            box = gas.boxlen
+            amr_mass = sum(getvar(gas, :rho) .* getvar(gas, :volume))
+            for L in (gas.lmin, gas.lmax - 1, gas.lmax)
+                cg = covering_grid(gas, :rho; lmax=L, verbose=false)
+                V = (box / 2.0^L)^3
+                gm = sum(x -> isnan(x) ? 0.0 : x*V, cg[:rho])
+                @test isapprox(gm, amr_mass; rtol=1e-10)          # exact volume-conservation
+                @test count(isnan, cg[:rho]) == 0                 # full box fully covered
+                @test size(cg[:rho]) == ntuple(_ -> 2^L, 3)
+            end
+        end
+
+        @testset "value correctness, units, multi-var" begin
+            cx = Int.(getvar(gas, :cx)); cy = Int.(getvar(gas, :cy)); cz = Int.(getvar(gas, :cz))
+            lev = getvar(gas, :level); rho = getvar(gas, :rho)
+            cg = covering_grid(gas, [:rho, :T], [:nH, :K]; lmax=gas.lmax, verbose=false)
+            @test Set(keys(cg)) == Set([:rho, :T]) && cg.grid_unit[:rho] == :nH
+            @test size(cg[:rho]) == size(cg[:T])
+            rho_nH = getvar(gas, :rho, :nH)
+            # a finest-level (lmax) leaf maps one-to-one to its output cell
+            kfin = findfirst(==(gas.lmax), lev)
+            @test cg[:rho][cx[kfin], cy[kfin], cz[kfin]] ≈ rho_nH[kfin]
+        end
+
+        @testset "slice = 2D fixed-resolution buffer" begin
+            sl = slice(gas, :rho, :nH; slice_axis=:z, slice_pos=0.5, lmax=gas.lmax, verbose=false)
+            @test sl.slice_axis === :z
+            @test ndims(sl[:rho]) == 2 && length(sl.dims) == 2
+            @test sl.dims == (2^gas.lmax, 2^gas.lmax)
+            # the slice equals the corresponding z-layer of the full covering grid
+            cg = covering_grid(gas, :rho, :nH; lmax=gas.lmax, verbose=false)
+            kz = floor(Int, 0.5 * 2^gas.lmax) + 1
+            @test isequal(sl[:rho], cg[:rho][:, :, kz])       # isequal so NaNs compare equal
+            @test_throws ArgumentError slice(gas, :rho; slice_axis=:w)
+        end
+
+        @testset "memory budget guard refuses oversize grids" begin
+            # a level-12 full-box grid = 4096^3 ≈ 5.5 TB ≫ the tiny max_bytes → error, no allocation
+            @test_throws Exception covering_grid(gas, :rho; lmax=12, max_bytes=1e7, verbose=false)
+            # the same request fits with a sub-box; estimator confirms it shrank
+            est = covering_grid_memory(gas, :rho; lmax=12, xrange=[0.49,0.51], yrange=[0.49,0.51],
+                                       zrange=[0.49,0.51], verbose=false)
+            @test 0 < prod(est.dims) < 4096^3     # vastly smaller than the full-box level-12 grid (4096³)
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -100,6 +100,7 @@ if isempty(_focus)
         include("38_report_tests.jl")              # composable report system (Phase 1): cards, engine, ascii/jld2
         include("39_clumpfind_tests.jl")           # density-threshold clumpfinder (FoF 3D + connected-components 2D)
         include("40_clumpfind_validation_tests.jl") # structure-finder framework (v2 Phase 1): backend/oracle/invariance, data-free
+        include("41_covering_grid_tests.jl")        # covering_grid / slice (fixed-resolution buffer): paint/conservation data-free + AMR-backed
         include("07_regions.jl")
     end
 


### PR DESCRIPTION
Adds the most-requested yt-parity primitive: resample sparse AMR leaf cells onto a **dense, uniform grid** at a fixed level — non-integrated (unlike `projection`). `slice` is the 2-D single-layer FRB.

## Why the memory estimator is front-and-centre
A uniform grid fills *every* cell at the target level, while AMR stores cells only where the run refined — so an FRB can be orders of magnitude larger than the source data. **`covering_grid_memory`** predicts `dims`/`bytes`/`peak`/`blow-up` from `boxlen + ranges + lmax` *before* allocating (works on a loaded object or a bare `InfoType`), and `covering_grid` itself **refuses to allocate past `max_bytes`** (default 4 GB), erroring with the estimate instead of OOM-killing.

```julia
covering_grid_memory(gas, [:rho,:T]; lmax=7)   # check first  → e.g. blow-up ×3.55, 33.6 MB
cg = covering_grid(gas, [:rho,:T], [:nH,:K]; lmax=7)
cg[:rho]                                        # the 128³ array
sl = slice(gas, :rho, :nH; slice_axis=:z, slice_pos=0.5)   # 2-D FRB
```

## Correctness
Volume-conservative resampling: coarse leaves are **replicated** to fill their block, fine leaves **volume-averaged** down — both from one weighted accumulation (per-cell weight ∝ volume). Since AMR leaves tile space, `Σ value·volume` is preserved **exactly** at any target level (verified: a `:rho` grid conserves total mass when up- *and* down-sampling, on both a uniform sim and a genuine AMR sim with mixed levels 5–7). Output cells outside the data are `NaN`.

## Tests (`test/41`, +40)
- **Data-free**: dims/offset math; a synthetic-AMR paint-kernel oracle proving volume-conservation, coarse-leaf replication, and fine-leaf downsampling.
- **AMR-backed** (`:spiral_clumps`): estimator predicts the real array size; mass conserved across resample levels; value correctness vs `getvar`; 2-D `slice` equals the matching covering-grid layer; the `max_bytes` guard refuses an oversize grid.
- `test/39`/`test/40` unaffected, Aqua 4/4, docs build clean locally.