### PR TITLE
fluxbudget: sampling uncertainty + fluxprofile Ṁ(R) (better statistics)

### DIFF
--- a/docs/src/fluxbudget.md
+++ b/docs/src/fluxbudget.md
@@ -97,6 +97,35 @@ sum(fmd.map)  # == fluxbudget(...).rates.mass.net   — the surface map closes t
 maps each bin's mass-flux contribution (Msol/yr), and its sum equals the net flux. `fluxmap` returns the
 arrays (heatmap them with any backend); it is *not* `projection` — different axes, no LOS superposition.
 
+## Statistics: uncertainty and the radial profile
+
+Two ways to improve the statistics of a flux measurement, both built in:
+
+**More cells per shell** — a wider `shell_width` puts more cells in the sum (the standard
+statistics-vs-localization tradeoff). Note `fluxbudget` does the **cell-by-cell sum** `Σ mᵢ·v_r,i`, which
+captures the density–velocity correlation exactly — *not* `⟨ρ⟩·⟨v_r⟩` over the shell, which would lose
+that correlation and bias the answer.
+
+**Sampling uncertainty** — each rate carries `err_in`/`err_out`/`err_net`: the shot-noise standard error
+of the cell-sum. It is large when a few cells dominate the flux (an under-resolved or sparsely-sampled
+shell), so it tells you when a number is trustworthy:
+
+```julia
+fb = fluxbudget(gas; surface=:sphere, radius=30.0, shell_width=2.0, range_unit=:kpc)
+fb.rates.mass.net, fb.rates.mass.err_net      # e.g. 0.03 ± 0.96  → consistent with balance
+```
+
+**Radial flux profile** — [`fluxprofile`](@ref) runs the budget across many radii at once, so you see
+*where* the flux is launched or converges and can pick a converged radius/width:
+
+```julia
+fp = fluxprofile(gas; surface=:sphere, radii=5:5:50, shell_width=2.0, range_unit=:kpc)
+fp.radius, fp.net, fp.err_net      # net Ṁ(R) ± sampling error [Msol/yr]
+# e.g. net < 0 in the disk (inflow) → net > 0 in the halo (outflow); a huge err flags a bad shell
+```
+
+For the dominant snapshot-to-snapshot noise, time-average instead (see below).
+
 ## Time evolution
 
 [`fluxtimeseries`](@ref) maps `fluxbudget` over a snapshot series and assembles the rate versus time —
@@ -118,7 +147,7 @@ suite, in the same spirit as Mera's projection/covering-grid conservation oracle
 
 ## API
 
-The functions [`fluxbudget`](@ref), [`fluxtimeseries`](@ref), [`fluxshell`](@ref), [`fluxmap`](@ref) and
-the result types [`FluxBudgetType`](@ref) / [`FluxMapType`](@ref) are documented in the
-[API reference](api.md). See also
+The functions [`fluxbudget`](@ref), [`fluxprofile`](@ref), [`fluxtimeseries`](@ref),
+[`fluxshell`](@ref), [`fluxmap`](@ref) and the result types [`FluxBudgetType`](@ref) /
+[`FluxMapType`](@ref) are documented in the [API reference](api.md). See also
 [`shellregion`](@ref) (the shell selection underneath) and [Profiles & Phase Diagrams](15_multi_Profiles_Phase.md).

--- a/src/Mera.jl
+++ b/src/Mera.jl
@@ -166,6 +166,7 @@ export
     CoveringGridResult,
     fluxbudget,
     fluxtimeseries,
+    fluxprofile,
     fluxshell,
     fluxmap,
     FluxBudgetType,

--- a/src/functions/flux.jl
+++ b/src/functions/flux.jl
@@ -21,8 +21,9 @@ const _FLUX_NORMAL = Dict(:sphere => :vr_sphere, :cylinder => :vr_cylinder)
 """    FluxBudgetType
 
 Result of [`fluxbudget`](@ref). `rates` is a `NamedTuple` keyed by quantity (`:mass`, `:momentum`,
-`:energy`, `:metals`), each an `(in=, out=, net=, unit=)` NamedTuple (`in ≤ 0` inflow, `out ≥ 0`
-outflow, `net = in + out`). `components` is `nothing` or a per-phase `NamedTuple` of the same.
+`:energy`, `:metals`), each an `(in, out, net, err_in, err_out, err_net, n_in, n_out, unit)` NamedTuple
+(`in ≤ 0` inflow, `out ≥ 0` outflow, `net = in + out`; `err_*` is the sampling/shot-noise standard error
+of the cell-sum — large when a few cells dominate). `components` is `nothing` or a per-phase NamedTuple.
 `surface`/`radius`/`shell_width`/`center` record the definition; `n_cells` the shell cell count;
 `shell_mass_Msol` and `residual` the conservation check."""
 struct FluxBudgetType
@@ -46,31 +47,42 @@ function Base.show(io::IO, f::FluxBudgetType)
     for q in keys(f.rates)
         r = f.rates[q]
         println(io, "  $(rpad(string(q), 9)): in $(round(r.in, sigdigits=4))  out $(round(r.out, sigdigits=4))  " *
-                    "net $(round(r.net, sigdigits=4))  [$(r.unit)]")
+                    "net $(round(r.net, sigdigits=4)) ± $(round(r.err_net, sigdigits=2))  [$(r.unit)]")
     end
     f.components !== nothing && println(io, "  phases: $(collect(keys(f.components)))")
 end
 
 # ---- pure reduction kernel (data-free testable) -----------------------------------------
-# Σ over inflow cells (v⊥ < 0) and outflow cells (v⊥ ≥ 0) of carried·v⊥ — the un-normalized,
-# un-converted flux sums. Caller divides by Δr and converts to physical units.
+# Σ over inflow cells (v⊥ < 0) and outflow cells (v⊥ ≥ 0) of carried·v⊥ (the un-normalized flux sums),
+# plus the per-side count and Σ of squares — enough for the sum's sampling standard error.
 function _flux_reduce(vn::AbstractVector, carried::AbstractVector)
-    sin = 0.0; sout = 0.0
+    sin = 0.0; sout = 0.0; qin = 0.0; qout = 0.0; nin = 0; nout = 0
     @inbounds for i in eachindex(vn)
         f = carried[i] * vn[i]
-        (isfinite(f)) || continue
-        vn[i] < 0 ? (sin += f) : (sout += f)
+        isfinite(f) || continue
+        if vn[i] < 0
+            sin += f; qin += f*f; nin += 1
+        else
+            sout += f; qout += f*f; nout += 1
+        end
     end
-    return sin, sout                                   # sin ≤ 0 (inflow), sout ≥ 0 (outflow)
+    return sin, sout, qin, qout, nin, nout
 end
+
+# standard error of a sum of n terms with Σx=s, Σx²=q : √(n·sample_var) = √(n/(n-1)·(q − s²/n))
+_sum_se(s, q, n) = n > 1 ? sqrt(max(0.0, n/(n-1) * (q - s*s/n))) : 0.0
 
 _funit(info, u) = u === :standard ? 1.0 : getunit(info, u)   # code→unit factor (1 for :standard)
 
-# one quantity's (in, out, net) in physical units, from CGS carried-array + normal velocity
+# one quantity's (in, out, net, err_*, unit) in physical units, from CGS carried-array + normal velocity.
+# err_* is the SAMPLING (shot-noise) standard error of the cell-sum — large when a few cells dominate.
 function _flux_quantity(vn_cms, carried_cgs, dr_cm, conv, unit_label)
-    sin, sout = _flux_reduce(vn_cms, carried_cgs)
-    fin = sin / dr_cm * conv; fout = sout / dr_cm * conv
-    return (in=fin, out=fout, net=fin + fout, unit=unit_label)
+    sin, sout, qin, qout, nin, nout = _flux_reduce(vn_cms, carried_cgs)
+    k = conv / dr_cm
+    fin = sin*k; fout = sout*k
+    ein = _sum_se(sin, qin, nin)*abs(k); eout = _sum_se(sout, qout, nout)*abs(k)
+    return (in=fin, out=fout, net=fin + fout, err_in=ein, err_out=eout,
+            err_net=sqrt(ein^2 + eout^2), n_in=nin, n_out=nout, unit=unit_label)
 end
 
 """
@@ -313,4 +325,38 @@ function fluxtimeseries(loadfn, outputs, surface::Symbol=:sphere; radius::Real, 
     return (outputs=collect(outputs), t=ts, in=fin, out=fout, net=fnet,
             quantity=quantity, unit=unit, surface=surface, radius=Float64(radius),
             shell_width=Float64(shell_width), time_unit=time_unit)
+end
+
+# =====================================================================================
+#  fluxprofile — Ṁ(R) across many shells (radial flux profile)
+# =====================================================================================
+"""
+    fluxprofile(obj::HydroDataType; surface=:sphere, radii, shell_width, quantity=:mass,
+                center=[:bc], range_unit=:kpc, verbose=true) -> NamedTuple
+
+Radial **flux profile**: run [`fluxbudget`](@ref) for `quantity` at each radius in `radii` (a vector
+or range, in `range_unit`) and assemble the inflow / outflow / net rate — with its sampling
+uncertainty — versus radius. Shows *where* the flux is launched or converges and lets you pick a
+converged radius and shell width. `shell_width` is the (constant) Δr of every shell.
+
+Returns `(; radius, in, out, net, err_net, n_cells, unit, surface, shell_width, quantity)`.
+
+```julia
+fp = fluxprofile(gas; surface=:sphere, radii=5:5:50, shell_width=2.0, range_unit=:kpc)
+fp.radius, fp.net, fp.err_net      # net Ṁ(R) ± sampling error [Msol/yr]
+```
+"""
+function fluxprofile(obj::HydroDataType; surface::Symbol=:sphere, radii, shell_width::Real,
+                     quantity::Symbol=:mass, center=[:bc], range_unit::Symbol=:kpc, verbose::Bool=true)
+    Rs = collect(Float64, radii)
+    fin = Float64[]; fout = Float64[]; fnet = Float64[]; enet = Float64[]; nc = Int[]; unit = :_
+    for R in Rs
+        fb = fluxbudget(obj; surface=surface, radius=R, shell_width=shell_width, quantities=[quantity],
+                        center=center, range_unit=range_unit, verbose=false)
+        r = fb.rates[quantity]; unit = r.unit
+        push!(fin, r.in); push!(fout, r.out); push!(fnet, r.net); push!(enet, r.err_net); push!(nc, fb.n_cells)
+    end
+    verbose && println("fluxprofile [$surface, $quantity]: $(length(Rs)) shells over R=$(first(Rs))–$(last(Rs)) $range_unit, Δr=$shell_width")
+    return (radius=Rs, in=fin, out=fout, net=fnet, err_net=enet, n_cells=nc,
+            unit=unit, surface=surface, shell_width=Float64(shell_width), quantity=quantity)
 end

--- a/test/43_fluxbudget_tests.jl
+++ b/test/43_fluxbudget_tests.jl
@@ -7,20 +7,21 @@
 
 @testset verbose=true "fluxbudget" begin
 
-    @testset "reduction kernel: inflow/outflow split (data-free)" begin
+    @testset "reduction kernel: inflow/outflow split + counts (data-free)" begin
+        # _flux_reduce returns (Σin, Σout, Σin², Σout², n_in, n_out)
         vn = [-2.0, 3.0, -1.0, 4.0]; carried = ones(4)
-        sin_, sout_ = Mera._flux_reduce(vn, carried)
-        @test sin_ == -3.0                 # Σ over v<0 of carried·v = -2-1
-        @test sout_ == 7.0                 # Σ over v≥0 of carried·v = 3+4
-        # weighted carried
-        s_in, s_out = Mera._flux_reduce([-2.0, 5.0], [3.0, 2.0])
-        @test s_in == -6.0 && s_out == 10.0
-        # non-finite contributions are skipped
-        si, so = Mera._flux_reduce([-1.0, NaN, 2.0], [1.0, 1.0, 1.0])
-        @test si == -1.0 && so == 2.0
-        # all-inflow / all-outflow
-        @test Mera._flux_reduce([-1.0,-2.0], ones(2)) == (-3.0, 0.0)
-        @test Mera._flux_reduce([1.0,2.0], ones(2)) == (0.0, 3.0)
+        sin_, sout_, qin, qout, nin, nout = Mera._flux_reduce(vn, carried)
+        @test sin_ == -3.0 && sout_ == 7.0                 # Σ over v<0 = -2-1 ; v≥0 = 3+4
+        @test qin == 5.0 && qout == 25.0                   # Σ of squares: 4+1 ; 9+16
+        @test nin == 2 && nout == 2
+        @test Mera._flux_reduce([-2.0, 5.0], [3.0, 2.0])[1:2] == (-6.0, 10.0)   # weighted carried
+        @test Mera._flux_reduce([-1.0, NaN, 2.0], ones(3))[1:2] == (-1.0, 2.0)  # non-finite skipped
+        @test Mera._flux_reduce([-1.0,-2.0], ones(2))[1:2] == (-3.0, 0.0)       # all inflow
+        @test Mera._flux_reduce([1.0,2.0], ones(2))[1:2] == (0.0, 3.0)          # all outflow
+        # standard error of a sum √(n/(n-1)·(q−s²/n)): 0 for ≤1 term or equal terms; else >0
+        @test Mera._sum_se(5.0, 25.0, 1) == 0.0
+        @test Mera._sum_se(4.0, 8.0, 2) == 0.0          # x=[2,2] (q=8) → no spread → SE 0
+        @test Mera._sum_se(4.0, 10.0, 2) ≈ 2.0          # x=[1,3] → √(2·(10−8)) = 2
     end
 
     @testset "thin-shell estimator → analytic ∮ρv⊥dA (data-free)" begin
@@ -121,6 +122,31 @@
             # the shell is projectable (the whole point of returning it)
             mp = projection(sh, :sd, :Msol_pc2; res=32, center=[:bc], verbose=false, show_progress=false)
             @test haskey(mp.maps, :sd)
+        end
+
+        @testset "sampling uncertainty on the rates" begin
+            fb = fluxbudget(gas; surface=:sphere, radius=10.0, shell_width=2.0, range_unit=:kpc, verbose=false)
+            r = fb.rates.mass
+            @test r.err_in >= 0 && r.err_out >= 0 && r.err_net >= 0
+            @test r.err_net ≈ sqrt(r.err_in^2 + r.err_out^2)     # in/out independent
+            @test r.n_in > 0 && r.n_out > 0 && r.n_in + r.n_out == fb.n_cells
+            # an under-resolved (few-cell-dominated) shell has a larger relative error than a thick one
+            fbu = fluxbudget(gas; surface=:sphere, radius=10.0, shell_width=0.25, range_unit=:kpc, verbose=false)
+            relerr(x) = x.err_net / max(abs(x.out), 1e-30)
+            @test relerr(fbu.rates.mass) > relerr(r)
+        end
+
+        @testset "fluxprofile assembles Ṁ(R) with errors" begin
+            fp = fluxprofile(gas; surface=:sphere, radii=6:4:22, shell_width=2.0, range_unit=:kpc, verbose=false)
+            n = length(6:4:22)
+            @test length(fp.radius) == n && length(fp.net) == n && length(fp.err_net) == n
+            @test fp.unit === :Msol_yr && fp.quantity === :mass
+            @test all(fp.net .≈ fp.in .+ fp.out)                 # net = in + out at every radius
+            @test all(fp.err_net .>= 0) && all(fp.n_cells .> 0)
+            # a single-radius profile matches a direct fluxbudget there
+            fb = fluxbudget(gas; surface=:sphere, radius=10.0, shell_width=2.0, range_unit=:kpc, verbose=false)
+            fp1 = fluxprofile(gas; surface=:sphere, radii=[10.0], shell_width=2.0, range_unit=:kpc, verbose=false)
+            @test fp1.net[1] ≈ fb.rates.mass.net && fp1.err_net[1] ≈ fb.rates.mass.err_net
         end
 
         @testset "fluxmap: surface map closes to the budget" begin


### PR DESCRIPTION
Follow-up to the FluxBudget flagship (#74): the two "better statistics" extensions, motivated by the question of how studies get robust flux estimates rather than relying on a single thin shell.

## Sampling uncertainty per rate
Each rate now carries `err_in`/`err_out`/`err_net` — the **shot-noise standard error of the cell-sum** (`√(n/(n-1)·(Σx²−(Σx)²/n))`). It is large when a few cells dominate the flux (an under-resolved or sparsely-sampled shell), so it tells you when a number is trustworthy. Shown as `net ± err`. The kernel `_flux_reduce` now also returns Σx² and the per-side counts; `_sum_se` is the (data-free testable) SE helper.

```julia
fb.rates.mass.net, fb.rates.mass.err_net   # e.g. 0.03 ± 0.96 → consistent with balance
```

## `fluxprofile` — Ṁ(R) across many shells
Runs the budget at each radius and assembles in/out/net + error vs R, so you see *where* the flux is launched or converges and can pick a converged radius/width:

```julia
fp = fluxprofile(gas; surface=:sphere, radii=5:5:50, shell_width=2.0, range_unit=:kpc)
fp.radius, fp.net, fp.err_net      # net Ṁ(R) ± sampling error [Msol/yr]
```
On the test galaxy this cleanly shows inflow in the disk (net < 0) turning to outflow in the halo (net > 0), with the innermost (few-cell) shell flagged unreliable by a large error — exactly the diagnostic intent.

## Methods note (documented)
`fluxbudget` does the **cell-by-cell sum** `Σ mᵢ·v_r,i`, which captures the density–velocity correlation exactly — *not* `⟨ρ⟩·⟨v_r⟩` over a thick shell, which would lose that correlation and bias the result. Thicker shells add more terms to a correct sum; for snapshot noise, time-average via `fluxtimeseries`.

## Tests / docs
`test/43` → **78** (kernel counts + `_sum_se` data-free, uncertainty relations, `fluxprofile` assembly + match to `fluxbudget`). Aqua 4/4, docs build clean (new "Statistics" section).