### PR TITLE
fluxbudget follow-ups: off-axis/L-aligned surfaces, fluxmapplot, bootstrap CIs

### DIFF
--- a/docs/src/fluxbudget.md
+++ b/docs/src/fluxbudget.md
@@ -61,6 +61,37 @@ fb.components.hot.mass.out       # hot-gas outflow rate
 # cold.out + hot.out == fb.rates.mass.out   (conservation across the partition)
 ```
 
+## Off-axis surfaces (tilted cylinder, plane)
+
+`fluxbudget` is a 3-D measurement, so the surface can be tilted. A **sphere** is orientation-free. A
+**cylinder** can be aligned to an arbitrary `axis` — a 3-vector, or `:angmom` (the gas net angular
+momentum `L = Σ m·h`, e.g. a galaxy's spin) — and a **`:plane`** surface (normal to `axis`, at
+along-axis position `radius`) measures the flux crossing a plane (disk in-/outflow):
+
+```julia
+# disk-edge flux in the angular-momentum frame
+fb = fluxbudget(gas; surface=:cylinder, radius=15.0, shell_width=2.0, range_unit=:kpc, axis=:angmom)
+# fountain/wind crossing a plane 5 kpc above the disk
+fb = fluxbudget(gas; surface=:plane, radius=5.0, shell_width=2.0, range_unit=:kpc, axis=[0.,0.,1.])
+```
+
+Off-axis selection is **cell-centre based** (vs the axis-aligned path's cell-volume intersection), so it
+differs by ~10–15 % for thin shells — prefer `shell_width` ≥ a couple of cells. A cylinder's vertical
+extent defaults to `2·rout`; override with `height`.
+
+## Bootstrap confidence intervals
+
+Beyond the analytic standard error, pass `bootstrap=N` to attach **percentile confidence intervals**
+(resampling the shell cells with replacement; reproducible via `bootstrap_seed`, level set by
+`ci_level`, default 0.95):
+
+```julia
+fb = fluxbudget(gas; surface=:sphere, radius=30.0, shell_width=2.0, range_unit=:kpc, bootstrap=1000)
+fb.rates.mass.net, fb.rates.mass.ci_net      # e.g. 0.03, (-1.94, 1.86) → consistent with balance
+```
+
+Each rate gains `ci_in`/`ci_out`/`ci_net` `(lo, hi)` (≈ NaN without bootstrap).
+
 ## Visualizing the shell
 
 [`fluxshell`](@ref) returns the **exact thin shell** that `fluxbudget` measured, as an ordinary
@@ -95,7 +126,16 @@ sum(fmd.map)  # == fluxbudget(...).rates.mass.net   — the surface map closes t
 
 `quantity=:vr` maps the mass-weighted mean normal velocity (inflow < 0, outflow > 0); `quantity=:mdot`
 maps each bin's mass-flux contribution (Msol/yr), and its sum equals the net flux. `fluxmap` returns the
-arrays (heatmap them with any backend); it is *not* `projection` — different axes, no LOS superposition.
+arrays; it is *not* `projection` — different axes, no LOS superposition.
+
+With a Makie backend loaded, [`fluxmapplot`](@ref) renders it directly (diverging blue-in/red-out
+colormap for `:vr`):
+
+```julia
+using CairoMakie
+fig = fluxmapplot(fluxmap(gas; surface=:sphere, radius=30.0, shell_width=2.0, range_unit=:kpc))
+Makie.save("flux_skymap.png", fig)
+```
 
 ## Statistics: uncertainty and the radial profile
 
@@ -148,6 +188,6 @@ suite, in the same spirit as Mera's projection/covering-grid conservation oracle
 ## API
 
 The functions [`fluxbudget`](@ref), [`fluxprofile`](@ref), [`fluxtimeseries`](@ref),
-[`fluxshell`](@ref), [`fluxmap`](@ref) and the result types [`FluxBudgetType`](@ref) /
-[`FluxMapType`](@ref) are documented in the [API reference](api.md). See also
+[`fluxshell`](@ref), [`fluxmap`](@ref), [`fluxmapplot`](@ref) and the result types
+[`FluxBudgetType`](@ref) / [`FluxMapType`](@ref) are documented in the [API reference](api.md). See also
 [`shellregion`](@ref) (the shell selection underneath) and [Profiles & Phase Diagrams](15_multi_Profiles_Phase.md).

--- a/ext/MeraMakieExt.jl
+++ b/ext/MeraMakieExt.jl
@@ -114,4 +114,26 @@ function Mera._plot_quicklook(q::Mera.QuickLookResult; size=(1500, 460), colorma
     return fig
 end
 
+# ---- fluxmapplot: the inflow/outflow surface map -----------------------------------------
+function Mera._plot_fluxmap(fm::Mera.FluxMapType; size=(640, 460), colormap=nothing)
+    fig = Makie.Figure(; size=size)
+    xc = (fm.xedges[1:end-1] .+ fm.xedges[2:end]) ./ 2
+    yc = (fm.yedges[1:end-1] .+ fm.yedges[2:end]) ./ 2
+    ylab = fm.surface === :sphere ? "cos θ" : "z"
+    ax = Makie.Axis(fig[1, 1]; title="flux map [$(fm.surface), $(fm.quantity)]",
+                    xlabel="φ [deg]", ylabel=ylab)
+    if fm.quantity === :vr
+        a = sort!(filter(x -> isfinite(x) && x != 0, abs.(vec(fm.map))))   # robust symmetric range
+        m = isempty(a) ? 1.0 : a[clamp(round(Int, 0.98*length(a)), 1, length(a))]
+        cmap = colormap === nothing ? Makie.Reverse(:RdBu) : colormap     # low(inflow)=blue, high(outflow)=red
+        hm = Makie.heatmap!(ax, xc, yc, fm.map; colormap=cmap, colorrange=(-m, m))
+        Makie.Colorbar(fig[1, 2], hm; label="mean v⊥ [km/s]  (blue in / red out)")
+    else
+        cmap = colormap === nothing ? :viridis : colormap
+        hm = Makie.heatmap!(ax, xc, yc, fm.map; colormap=cmap)
+        Makie.Colorbar(fig[1, 2], hm; label="Ṁ per bin [$(fm.unit)]")
+    end
+    return fig
+end
+
 end # module

--- a/src/Mera.jl
+++ b/src/Mera.jl
@@ -169,6 +169,7 @@ export
     fluxprofile,
     fluxshell,
     fluxmap,
+    fluxmapplot,
     FluxBudgetType,
     FluxMapType,
     report,

--- a/src/functions/flux.jl
+++ b/src/functions/flux.jl
@@ -74,15 +74,33 @@ _sum_se(s, q, n) = n > 1 ? sqrt(max(0.0, n/(n-1) * (q - s*s/n))) : 0.0
 
 _funit(info, u) = u === :standard ? 1.0 : getunit(info, u)   # code→unit factor (1 for :standard)
 
-# one quantity's (in, out, net, err_*, unit) in physical units, from CGS carried-array + normal velocity.
-# err_* is the SAMPLING (shot-noise) standard error of the cell-sum — large when a few cells dominate.
-function _flux_quantity(vn_cms, carried_cgs, dr_cm, conv, unit_label)
+# one quantity's (in, out, net, err_*, ci_*, unit) in physical units, from CGS carried-array + normal
+# velocity. err_* is the SAMPLING (shot-noise) standard error of the cell-sum (large when a few cells
+# dominate); ci_* are percentile bootstrap confidence intervals (lo,hi) when nboot>0, else (NaN,NaN).
+function _flux_quantity(vn_cms, carried_cgs, dr_cm, conv, unit_label; nboot::Int=0, rng=nothing,
+                        ci_level::Float64=0.95)
     sin, sout, qin, qout, nin, nout = _flux_reduce(vn_cms, carried_cgs)
     k = conv / dr_cm
     fin = sin*k; fout = sout*k
     ein = _sum_se(sin, qin, nin)*abs(k); eout = _sum_se(sout, qout, nout)*abs(k)
-    return (in=fin, out=fout, net=fin + fout, err_in=ein, err_out=eout,
-            err_net=sqrt(ein^2 + eout^2), n_in=nin, n_out=nout, unit=unit_label)
+    ci_in = ci_out = ci_net = (NaN, NaN)
+    if nboot > 0
+        N = length(vn_cms); bin = Vector{Float64}(undef, nboot); bout = similar(bin); bnet = similar(bin)
+        @inbounds for b in 1:nboot
+            si = 0.0; so = 0.0
+            for _ in 1:N
+                j = rand(rng, 1:N); f = carried_cgs[j]*vn_cms[j]
+                isfinite(f) || continue
+                vn_cms[j] < 0 ? (si += f) : (so += f)
+            end
+            bin[b] = si*k; bout[b] = so*k; bnet[b] = (si + so)*k
+        end
+        α = (1 - ci_level)/2
+        _ci(v) = (sort!(v); (v[clamp(round(Int, α*nboot)+1, 1, nboot)], v[clamp(round(Int, (1-α)*nboot), 1, nboot)]))
+        ci_in = _ci(bin); ci_out = _ci(bout); ci_net = _ci(bnet)
+    end
+    return (in=fin, out=fout, net=fin + fout, err_in=ein, err_out=eout, err_net=sqrt(ein^2 + eout^2),
+            ci_in=ci_in, ci_out=ci_out, ci_net=ci_net, n_in=nin, n_out=nout, unit=unit_label)
 end
 
 """
@@ -112,18 +130,33 @@ fb.rates.mass.net        # net (in + out)
 """
 function fluxbudget(obj::HydroDataType; surface::Symbol=:sphere, radius::Real, shell_width::Real,
                     quantities::AbstractVector{Symbol}=[:mass], center=[:bc], range_unit::Symbol=:kpc,
-                    phases::Union{Nothing,NamedTuple}=nothing, verbose::Bool=true)
-    R = Float64(radius); dr = Float64(shell_width)
-    shell = _flux_shell(obj, surface, R, dr, center, range_unit)
-    info = obj.info; vn_sym = _FLUX_NORMAL[surface]
-    ncell = length(shell.data)
-    # the shell estimator assumes Δr ≳ the local cell size (so the shell is filled); a shell thinner
-    # than a cell grabs whole cells and over-counts. Record the cell size and warn if under-resolved.
-    csz = ncell > 0 ? median(getvar(shell, :cellsize, range_unit)) : 0.0
+                    phases::Union{Nothing,NamedTuple}=nothing, axis=nothing, height=nothing,
+                    bootstrap::Int=0, bootstrap_seed::Int=20240601, ci_level::Float64=0.95,
+                    verbose::Bool=true)
+    R = Float64(radius); dr = Float64(shell_width); info = obj.info
+    tilted = surface === :plane || (surface === :cylinder && axis !== nothing && axis !== :z)
+    surface in (:sphere, :cylinder, :plane) ||
+        throw(ArgumentError("surface must be :sphere, :cylinder or :plane (got :$surface)"))
+    surface === :plane && axis === nothing && throw(ArgumentError(":plane needs an `axis` (the plane normal)"))
+    rng = bootstrap > 0 ? MersenneTwister(bootstrap_seed) : nothing
+    if tilted                                                          # off-axis cylinder / plane
+        nhat = _flux_axis(obj, axis, center, range_unit)
+        # cylinder height defaults to 2·rout (matching the axis-aligned path); plane has no height
+        heff = surface === :plane ? nothing :
+               height === nothing ? 2*(R + dr/2) : Float64(height)
+        rates, comps, ncell, shell_mass, csz =
+            _flux_tilted(obj, surface, nhat, R, dr, heff, quantities, center, range_unit, phases;
+                         nboot=bootstrap, rng=rng, ci_level=ci_level)
+    else                                                              # axis-aligned sphere / cylinder
+        shell = _flux_shell(obj, surface, R, dr, center, range_unit)
+        ncell = length(shell.data)
+        csz = ncell > 0 ? median(getvar(shell, :cellsize, range_unit)) : 0.0
+        rates, comps, shell_mass = _flux_compute(shell, _FLUX_NORMAL[surface], dr, center, range_unit,
+                                                 quantities, phases; nboot=bootstrap, rng=rng, ci_level=ci_level)
+    end
     verbose && dr < csz && @warn "fluxbudget: shell_width Δr=$dr < cell size $(round(csz,sigdigits=3)) " *
         "$(range_unit) at R=$R — the shell is thinner than the AMR and the flux will be over-counted. " *
         "Use shell_width ≥ the local cell size (ideally a few cells)."
-    rates, comps, shell_mass = _flux_compute(shell, vn_sym, dr, center, range_unit, quantities, phases)
     fb = FluxBudgetType(surface, R, dr, csz, Float64.(_centervec(center, info, range_unit)), range_unit,
                         ncell, shell_mass, rates, comps, info)
     verbose && show(stdout, fb)
@@ -247,13 +280,28 @@ function fluxmap(obj::HydroDataType; surface::Symbol=:sphere, radius::Real, shel
     return fm
 end
 
+"""    fluxmapplot(fm::FluxMapType; kwargs...) -> Makie.Figure
+
+Render a [`fluxmap`](@ref) surface map as a heatmap — a diverging colormap centred at zero for
+`:vr` (blue inflow / red outflow), sequential for `:mdot`. Needs a Makie backend (`using CairoMakie`).
+
+```julia
+using CairoMakie
+fm = fluxmap(gas; surface=:sphere, radius=30.0, shell_width=2.0, range_unit=:kpc)
+fig = fluxmapplot(fm); Makie.save("flux_skymap.png", fig)
+```
+"""
+fluxmapplot(fm::FluxMapType; kwargs...) = _plot_fluxmap(fm; kwargs...)
+_plot_fluxmap(fm; kwargs...) =
+    error("fluxmapplot needs a Makie backend — load one first: `using CairoMakie` (or GLMakie).")
+
 # numeric centre (code units) for the record — [:bc] → box centre
 _centervec(center, info, range_unit) =
     (center == [:bc] || center == [:boxcenter]) ? [0.5, 0.5, 0.5] :
     [c === :bc ? 0.5 : Float64(c) for c in center]
 
 # compute the rate NamedTuple (+ per-phase components) over a selected shell
-function _flux_compute(shell, vn_sym, dr, center, range_unit, quantities, phases)
+function _flux_compute(shell, vn_sym, dr, center, range_unit, quantities, phases; nboot=0, rng=nothing, ci_level=0.95)
     info = shell.info
     dr_cm = (dr / _funit(info, range_unit)) * getunit(info, :cm)         # Δr in cm
     g_per_Msol = getunit(info, :g) / getunit(info, :Msol)
@@ -280,7 +328,7 @@ function _flux_compute(shell, vn_sym, dr, center, range_unit, quantities, phases
     end
     _rates(idx) = NamedTuple{Tuple(quantities)}(Tuple(begin
         carried, conv, ulab = carried_and_conv(q)
-        _flux_quantity(view(vn, idx), view(carried, idx), dr_cm, conv, ulab)
+        _flux_quantity(vn[idx], carried[idx], dr_cm, conv, ulab; nboot=nboot, rng=rng, ci_level=ci_level)
     end for q in quantities))
     allidx = eachindex(vn)
     rates = _rates(allidx)
@@ -290,6 +338,73 @@ function _flux_compute(shell, vn_sym, dr, center, range_unit, quantities, phases
             _rates(findall(collect(Bool, phases[p](shell)))) for p in keys(phases)))
     end
     return rates, comps, shell_mass
+end
+
+# =====================================================================================
+#  Off-axis / tilted surfaces — cylinder about an arbitrary axis (or the gas angular momentum),
+#  and a plane normal to that axis. Bypasses shellregion (which is axis-aligned): selects cells by
+#  dot-products with the axis unit vector n̂ and computes the surface-normal velocity directly.
+#  Cell-centre based (vs the axis-aligned path's cell-volume intersection) — standard for flux work.
+# =====================================================================================
+# resolve the axis unit vector: a 3-vector, :x/:y/:z, or :angmom/:L (net L = Σ m·h of the object)
+function _flux_axis(obj, axis, center, range_unit)
+    if axis === :angmom || axis === :L
+        L = [sum(getvar(obj, :lx; center=center, center_unit=range_unit)),
+             sum(getvar(obj, :ly; center=center, center_unit=range_unit)),
+             sum(getvar(obj, :lz; center=center, center_unit=range_unit))]
+        n = sqrt(sum(abs2, L)); n > 0 || throw(ArgumentError("angular-momentum vector L is zero")); return L ./ n
+    elseif axis isa AbstractVector
+        a = float.(collect(axis)); n = sqrt(sum(abs2, a))
+        (length(a) == 3 && n > 0) || throw(ArgumentError("axis must be a non-zero length-3 vector")); return a ./ n
+    elseif axis === :x; return [1.0, 0.0, 0.0]
+    elseif axis === :y; return [0.0, 1.0, 0.0]
+    elseif axis === :z; return [0.0, 0.0, 1.0]
+    else throw(ArgumentError("axis must be a 3-vector, :x/:y/:z or :angmom (got $axis)"))
+    end
+end
+
+# tilted cylinder wall (about n̂) or plane (normal n̂ at along-axis position R): returns the full
+# FluxBudgetType pieces (rates, comps, n_cells, shell_mass, cell_size).
+function _flux_tilted(obj, surface, nhat, R, dr, height, quantities, center, range_unit, phases;
+                      nboot=0, rng=nothing, ci_level=0.95)
+    info = obj.info
+    x = getvar(obj, :x, range_unit; center=center, center_unit=range_unit)
+    y = getvar(obj, :y, range_unit; center=center, center_unit=range_unit)
+    z = getvar(obj, :z, range_unit; center=center, center_unit=range_unit)
+    vx = getvar(obj, :vx, :cm_s); vy = getvar(obj, :vy, :cm_s); vz = getvar(obj, :vz, :cm_s)
+    zc = x .* nhat[1] .+ y .* nhat[2] .+ z .* nhat[3]                  # along-axis coordinate
+    if surface === :plane
+        mask = abs.(zc .- R) .<= dr/2
+        vn = vx .* nhat[1] .+ vy .* nhat[2] .+ vz .* nhat[3]          # normal = axis (cm/s)
+    else                                                              # tilted cylinder wall
+        px = x .- zc .* nhat[1]; py = y .- zc .* nhat[2]; pz = z .- zc .* nhat[3]   # perp vector
+        Rp = sqrt.(px.^2 .+ py.^2 .+ pz.^2)
+        mask = (Rp .>= R - dr/2) .& (Rp .<= R + dr/2)
+        height !== nothing && (mask = mask .& (abs.(zc) .<= height/2))
+        Rsafe = max.(Rp, eps())
+        vn = (vx .* px .+ vy .* py .+ vz .* pz) ./ Rsafe             # v · R̂_perp (cm/s)
+    end
+    idx = findall(mask)
+    dr_cm = (dr / _funit(info, range_unit)) * getunit(info, :cm)
+    g_per_Msol = getunit(info, :g)/getunit(info, :Msol); s_per_yr = getunit(info, :s)/getunit(info, :yr)
+    m_g = getvar(obj, :mass, :g)
+    haveZ = :metallicity in propertynames(getfield(obj, :data).columns)
+    Zarr = haveZ ? getvar(obj, :metallicity) : zeros(length(m_g))
+    Earr = (:energy in quantities) ? (getvar(obj, :ekin, :erg) .+ getvar(obj, :etherm, :erg)) : Float64[]
+    carried(q) = q === :mass ? (m_g, s_per_yr/g_per_Msol, :Msol_yr) :
+                 q === :metals ? (m_g .* Zarr, s_per_yr/g_per_Msol, :Msol_yr) :
+                 q === :momentum ? (m_g .* vn, s_per_yr/(g_per_Msol*1e5), :Msol_km_s_yr) :
+                 q === :energy ? (Earr, 1.0, :erg_s) :
+                 throw(ArgumentError("unknown flux quantity :$q"))
+    _rates(ix) = NamedTuple{Tuple(quantities)}(Tuple(begin
+        c, conv, ulab = carried(q)
+        _flux_quantity(vn[ix], c[ix], dr_cm, conv, ulab; nboot=nboot, rng=rng, ci_level=ci_level)
+    end for q in quantities))
+    rates = _rates(idx)
+    comps = phases === nothing ? nothing :
+        NamedTuple{keys(phases)}(Tuple(_rates(intersect(idx, findall(collect(Bool, phases[p](obj))))) for p in keys(phases)))
+    csz = isempty(idx) ? 0.0 : median(getvar(obj, :cellsize, range_unit)[idx])
+    return rates, comps, length(idx), sum(@view m_g[idx])/g_per_Msol, csz
 end
 
 # =====================================================================================
@@ -347,12 +462,13 @@ fp.radius, fp.net, fp.err_net      # net Ṁ(R) ± sampling error [Msol/yr]
 ```
 """
 function fluxprofile(obj::HydroDataType; surface::Symbol=:sphere, radii, shell_width::Real,
-                     quantity::Symbol=:mass, center=[:bc], range_unit::Symbol=:kpc, verbose::Bool=true)
+                     quantity::Symbol=:mass, center=[:bc], range_unit::Symbol=:kpc,
+                     axis=nothing, height=nothing, verbose::Bool=true)
     Rs = collect(Float64, radii)
     fin = Float64[]; fout = Float64[]; fnet = Float64[]; enet = Float64[]; nc = Int[]; unit = :_
     for R in Rs
         fb = fluxbudget(obj; surface=surface, radius=R, shell_width=shell_width, quantities=[quantity],
-                        center=center, range_unit=range_unit, verbose=false)
+                        center=center, range_unit=range_unit, axis=axis, height=height, verbose=false)
         r = fb.rates[quantity]; unit = r.unit
         push!(fin, r.in); push!(fout, r.out); push!(fnet, r.net); push!(enet, r.err_net); push!(nc, fb.n_cells)
     end

--- a/test/43_fluxbudget_tests.jl
+++ b/test/43_fluxbudget_tests.jl
@@ -49,6 +49,15 @@
         @test sin_ ≈ -ρ*v0*Vshell rtol=1e-12
     end
 
+    @testset "axis resolver _flux_axis (data-free)" begin
+        @test Mera._flux_axis(nothing, [0.0,0.0,2.0], [:bc], :kpc) ≈ [0.0,0.0,1.0]   # normalized
+        @test Mera._flux_axis(nothing, [3.0,4.0,0.0], [:bc], :kpc) ≈ [0.6,0.8,0.0]
+        @test Mera._flux_axis(nothing, :x, [:bc], :kpc) == [1.0,0.0,0.0]
+        @test Mera._flux_axis(nothing, :z, [:bc], :kpc) == [0.0,0.0,1.0]
+        @test_throws ArgumentError Mera._flux_axis(nothing, [1.0,0.0], [:bc], :kpc)   # not length 3
+        @test_throws ArgumentError Mera._flux_axis(nothing, :bogus, [:bc], :kpc)
+    end
+
     if !DATA_AVAILABLE
         @warn "Skipping data-backed fluxbudget tests - simulation data not available"
         @test_skip "Simulation data not available"
@@ -147,6 +156,58 @@
             fb = fluxbudget(gas; surface=:sphere, radius=10.0, shell_width=2.0, range_unit=:kpc, verbose=false)
             fp1 = fluxprofile(gas; surface=:sphere, radii=[10.0], shell_width=2.0, range_unit=:kpc, verbose=false)
             @test fp1.net[1] ≈ fb.rates.mass.net && fp1.err_net[1] ≈ fb.rates.mass.err_net
+        end
+
+        @testset "off-axis: tilted cylinder, plane, angular-momentum axis" begin
+            # tilted cylinder about +z (cell-centre selection) ≈ the axis-aligned cylinder on the
+            # dominant in/out magnitudes (the two selection conventions differ by ~10–15%)
+            fa = fluxbudget(gas; surface=:cylinder, radius=10.0, shell_width=3.0, range_unit=:kpc, verbose=false)
+            ft = fluxbudget(gas; surface=:cylinder, radius=10.0, shell_width=3.0, range_unit=:kpc,
+                            axis=[0.0,0.0,1.0], verbose=false)
+            @test isapprox(fa.rates.mass.out, ft.rates.mass.out; rtol=0.25)
+            @test isapprox(fa.rates.mass.in,  ft.rates.mass.in;  rtol=0.25)
+            # a plane normal to z above the midplane: a valid budget, net = in + out
+            fp = fluxbudget(gas; surface=:plane, radius=5.0, shell_width=2.0, range_unit=:kpc,
+                            axis=[0.0,0.0,1.0], verbose=false)
+            @test fp.surface === :plane && fp.n_cells > 0
+            @test fp.rates.mass.in <= 0 && fp.rates.mass.out >= 0
+            @test fp.rates.mass.net ≈ fp.rates.mass.in + fp.rates.mass.out
+            # angular-momentum-aligned cylinder runs and gives a sensible budget
+            fL = fluxbudget(gas; surface=:cylinder, radius=10.0, shell_width=2.0, range_unit=:kpc,
+                            axis=:angmom, verbose=false)
+            @test fL.n_cells > 0 && fL.rates.mass.net ≈ fL.rates.mass.in + fL.rates.mass.out
+            @test_throws ArgumentError fluxbudget(gas; surface=:plane, radius=5.0, shell_width=2.0)  # no axis
+            @test_throws ArgumentError fluxbudget(gas; surface=:torus, radius=5.0, shell_width=2.0)
+        end
+
+        @testset "bootstrap confidence intervals" begin
+            fb = fluxbudget(gas; surface=:sphere, radius=10.0, shell_width=2.0, range_unit=:kpc,
+                            bootstrap=400, verbose=false)
+            r = fb.rates.mass
+            @test r.ci_net[1] <= r.net <= r.ci_net[2]            # CI brackets the point estimate
+            @test r.ci_out[1] <= r.out <= r.ci_out[2]
+            @test r.ci_net[1] < r.ci_net[2]                      # a proper interval
+            # the 95% half-width is comparable to the analytic SE (~2σ)
+            @test (r.ci_net[2] - r.ci_net[1]) / 2 < 6 * r.err_net
+            # reproducible (seeded); no bootstrap → NaN CI
+            fb2 = fluxbudget(gas; surface=:sphere, radius=10.0, shell_width=2.0, range_unit=:kpc,
+                             bootstrap=400, verbose=false)
+            @test fb.rates.mass.ci_net == fb2.rates.mass.ci_net
+            @test all(isnan, fluxbudget(gas; surface=:sphere, radius=10.0, shell_width=2.0,
+                                        range_unit=:kpc, verbose=false).rates.mass.ci_net)
+        end
+
+        @testset "fluxmapplot (graceful without Makie)" begin
+            fm = fluxmap(gas; surface=:sphere, radius=10.0, shell_width=2.0, range_unit=:kpc, verbose=false)
+            if Base.find_package("CairoMakie") === nothing
+                @test_throws Exception fluxmapplot(fm)
+            else
+                @eval using CairoMakie
+                @test occursin("Figure", string(typeof(fluxmapplot(fm))))
+                fmd = fluxmap(gas; surface=:sphere, radius=10.0, shell_width=2.0, range_unit=:kpc,
+                              quantity=:mdot, verbose=false)
+                @test occursin("Figure", string(typeof(fluxmapplot(fmd))))
+            end
         end
 
         @testset "fluxmap: surface map closes to the budget" begin


### PR DESCRIPTION
The three remaining FluxBudget follow-ups (after #74/#75).

## Off-axis / L-aligned surfaces
`fluxbudget` (and `fluxprofile`) now take an `axis` — a 3-vector or `:angmom` (the gas net angular momentum `L = Σ m·h`) — for a **tilted cylinder**, plus a new **`:plane`** surface (normal to `axis`, at along-axis position `radius`) for flux crossing a plane (disk in/outflow). The tilted path bypasses the axis-aligned `shellregion` and selects by dot-products with the axis unit vector n̂, computing the surface-normal velocity directly. Cell-centre based (≈10–15 % vs the cell-volume axis-aligned path for thin shells — documented). Cylinder height defaults to `2·rout`, overridable with `height`. The axis-aligned path is untouched (zero regression).

```julia
fluxbudget(gas; surface=:cylinder, radius=15, shell_width=2, range_unit=:kpc, axis=:angmom)   # disk edge in spin frame
fluxbudget(gas; surface=:plane,    radius=5,  shell_width=2, range_unit=:kpc, axis=[0,0,1.])  # plane 5 kpc above disk
```

## Bootstrap confidence intervals
`bootstrap=N` attaches percentile CIs (`ci_in`/`ci_out`/`ci_net`) to each rate by resampling the shell cells with replacement — reproducible (`bootstrap_seed`), level via `ci_level` (default 0.95). Complements the analytic SE.

## fluxmapplot (Makie)
`fluxmapplot(fm)` renders a `fluxmap` surface map as a heatmap in the `MeraMakieExt` extension — diverging blue-in/red-out colormap (robust 98th-percentile range) for `:vr`, sequential for `:mdot`. Core ships a stub with a load hint.

## Tests / docs
`test/43` → **100** (data-free `_flux_axis` resolver; off-axis tilted-cylinder↔axis-aligned agreement, plane, `:angmom`, guards; bootstrap CI brackets + reproducibility; `fluxmapplot` graceful-without-Makie). Aqua 4/4, docs build clean locally.