### PR TITLE
Tidal-tensor truncation (clumpfind) + off-axis fluxshell/fluxmap

### DIFF
--- a/docs/src/clumpfind.md
+++ b/docs/src/clumpfind.md
@@ -115,6 +115,18 @@ cat[1].n_subclumps          # number of self-bound subclumps inside the most mas
 cat[1].subclumps[1].mass    # the largest bound subclump's mass
 ```
 
+`tidal=:tensor` uses the **tidal-tensor / Hill radius** instead of the Jacobi form: it fits the local
+gravity acceleration field `a(x)` (from a `gravity` object, `getgravity`) around each subclump to the
+tidal tensor `T_ij = −∂²Φ/∂x_i∂x_j` and truncates at `r_t³ = G·m_sub / λ_max(T)` — exactly the Hill
+radius `R·(m_sub/2M)^{1/3}` for a point-mass host. `tidal_sample` (default 3) sets the fit radius in
+units of the subclump radius.
+
+```julia
+grav = getgravity(getinfo(output, path))
+cat  = clumpfind(gas, :rho; threshold=1e2, threshold_unit=:nH, linking_length=0.4,
+                 substructure=true, tidal=:tensor, gravity=grav)
+```
+
 ## Multi-field — gas + stars + dark matter together
 
 Pass a vector of **components** to find over-densities across several mass species in one pass. Each

--- a/docs/src/fluxbudget.md
+++ b/docs/src/fluxbudget.md
@@ -107,7 +107,10 @@ projection(sh, :vr_sphere, :km_s; center=[:bc])       # inflow (blue) / outflow 
 ```
 
 `fluxshell` and `fluxbudget` use the identical selection, so the visualization is guaranteed to show
-exactly the cells that entered the budget.
+exactly the cells that entered the budget. `fluxshell` and `fluxmap` accept the same `axis`/`:angmom`
+and `surface=:plane` options as `fluxbudget`, so off-axis surfaces can be visualized too (the tilted
+`fluxmap` unrolls the cylinder about `n̂` as a (φ′, z′) map, and its `:mdot` map still sums to the
+tilted budget).
 
 ### The surface map (`fluxmap`)
 

--- a/src/functions/clumpfind.jl
+++ b/src/functions/clumpfind.jl
@@ -769,7 +769,7 @@ function _make_points(obj::HydroPartType, field::Symbol; threshold::Real,
         poscm = Float64(getfield(obj.scale, :cm) / getfield(obj.scale, pos_unit))   # pos_unit → cm
         eps2 = (Float64(softening) * poscm)^2                                        # ε² in cm²
         bargs = (mg=mg, vx=vv[:vx][idx], vy=vv[:vy][idx], vz=vv[:vz][idx], et=et, em=em, poscm=poscm,
-                 Gc=obj.info.constants.G, egrav=egrav, direct_max=direct_max, eps2=eps2)
+                 Gc=obj.info.constants.G, egrav=egrav, direct_max=direct_max, eps2=eps2, grav=nothing)
     end
     vx = vy = vz = Float64[]
     if need_velocity   # phase-space coordinates (km/s)
@@ -956,7 +956,7 @@ end
 # the read-only arrays — so it parallelizes safely across clumps. `id` is assigned later (after sort).
 function _finalize_clump(mem, xs, ys, zs, ms, fs, bargs, need_b::Bool, bound_only::Bool,
                          iterative_unbinding::Bool, substructure::Bool, sub_min_members::Int,
-                         tidal::Bool, pmd::Float64, min_members::Int)
+                         tidal, pmd::Float64, min_members::Int, tidal_sample::Float64)
     iterative_unbinding && (mem = _unbind(mem, bargs, xs, ys, zs))      # keep only the bound subset
     length(mem) >= min_members || return nothing
     c = _clump_stats(mem, xs, ys, zs, ms, fs, need_b, bargs)
@@ -964,7 +964,7 @@ function _finalize_clump(mem, xs, ys, zs, ms, fs, bargs, need_b::Bool, bound_onl
     if substructure                                                     # nested self-bound basins
         kids = NamedTuple[]
         for sm in _watershed3d(mem, xs, ys, zs, fs, pmd)
-            tidal && (sm = _tidal_truncate(sm, mem, bargs, xs, ys, zs))
+            tidal !== false && (sm = _tidal_truncate(sm, mem, bargs, xs, ys, zs, tidal, tidal_sample))
             length(sm) >= sub_min_members || continue
             sc = _clump_stats(sm, xs, ys, zs, ms, fs, true, bargs)
             sc.bound && push!(kids, sc)
@@ -1038,9 +1038,12 @@ function clumpfind(obj::HydroPartType, finder::AbstractFinder; pos_unit::Symbol=
                    direct_max::Int=2000, softening::Real=0.0, iterative_unbinding::Bool=false,
                    deblend::Union{Bool,Symbol,AbstractFinder}=false,
                    peak_min_distance::Real=2 * finder.linking_length,
-                   substructure::Bool=false, sub_min_members::Int=min_members, tidal::Bool=false,
+                   substructure::Bool=false, sub_min_members::Int=min_members,
+                   tidal::Union{Bool,Symbol}=false, gravity=nothing, tidal_sample::Real=3.0,
                    hierarchy::Bool=false, max_threads::Int=Threads.nthreads())
     need_b = boundedness || substructure || iterative_unbinding
+    tidal === :tensor && gravity === nothing &&
+        throw(ArgumentError("tidal=:tensor needs a `gravity` object (getgravity) for the tidal tensor"))
     P = _make_points(obj, finder.field; threshold=finder.threshold, threshold_unit=finder.threshold_unit,
                      pos_unit=pos_unit, mass_unit=mass_unit, mask=mask, need_energy=need_b,
                      egrav=egrav, direct_max=direct_max, softening=softening,
@@ -1054,6 +1057,12 @@ function clumpfind(obj::HydroPartType, finder::AbstractFinder; pos_unit::Symbol=
             finder=nameof(typeof(finder)))
     isempty(P.idx) && return ClumpCatalog(0, NamedTuple[], meta)
     xs, ys, zs, ms, fs, bargs = P.x, P.y, P.z, P.m, P.f, P.bargs
+    if tidal === :tensor                                          # attach the gravity field for the tidal tensor
+        gp = getvar(gravity, [:x, :y, :z], pos_unit)
+        bargs = merge(bargs, (grav=(gx=gp[:x], gy=gp[:y], gz=gp[:z],
+                                    gax=getvar(gravity, :ax, :g_cms2), gay=getvar(gravity, :ay, :g_cms2),
+                                    gaz=getvar(gravity, :az, :g_cms2)),))
+    end
     tree = (hierarchy && finder isa Dendrogram) ?                 # arbitrary-depth merge tree
         last(_dendrogram3d(collect(eachindex(xs)), xs, ys, zs, fs,
                            finder.linking_length, finder.min_delta; backend=finder.backend)) : nothing
@@ -1064,10 +1073,10 @@ function clumpfind(obj::HydroPartType, finder::AbstractFinder; pos_unit::Symbol=
         members = reduce(vcat, (_split_group(deblend, mem, xs, ys, zs, ms, fs, Float64(peak_min_distance))
                                 for mem in members); init=Vector{Int}[])
     end
-    pmd = Float64(peak_min_distance); nthr = clamp(max_threads, 1, Threads.nthreads())
+    pmd = Float64(peak_min_distance); nthr = clamp(max_threads, 1, Threads.nthreads()); tsamp = Float64(tidal_sample)
     out = _finalize_all(members, nthr,
         mem -> _finalize_clump(mem, xs, ys, zs, ms, fs, bargs, need_b, bound_only,
-                               iterative_unbinding, substructure, sub_min_members, tidal, pmd, min_members))
+                               iterative_unbinding, substructure, sub_min_members, tidal, pmd, min_members, tsamp))
     sort!(out, by=c -> -c.mass)
     out = [merge(c, (id=i,)) for (i, c) in enumerate(out)]
     return ClumpCatalog(length(out), out, meta, tree)
@@ -1097,8 +1106,8 @@ function clumpfind(obj::HydroPartType, field::Symbol=:rho; threshold::Real, link
                    egrav::Symbol=:approx, direct_max::Int=2000, softening::Real=0.0,
                    iterative_unbinding::Bool=false, deblend::Union{Bool,Symbol,AbstractFinder}=false,
                    peak_min_distance::Real=2linking_length, substructure::Bool=false,
-                   sub_min_members::Int=min_members, tidal::Bool=false,
-                   max_threads::Int=Threads.nthreads(),
+                   sub_min_members::Int=min_members, tidal::Union{Bool,Symbol}=false, gravity=nothing,
+                   tidal_sample::Real=3.0, max_threads::Int=Threads.nthreads(),
                    backend::Type{<:AbstractNeighborIndex}=DEFAULT_BACKEND)
     finder = ThresholdFoF(field; threshold=threshold, linking_length=linking_length,
                           threshold_unit=threshold_unit, backend=backend)
@@ -1106,7 +1115,8 @@ function clumpfind(obj::HydroPartType, field::Symbol=:rho; threshold::Real, link
                      mask=mask, boundedness=boundedness, bound_only=bound_only, egrav=egrav,
                      direct_max=direct_max, softening=softening, iterative_unbinding=iterative_unbinding,
                      deblend=deblend, peak_min_distance=peak_min_distance, substructure=substructure,
-                     sub_min_members=sub_min_members, tidal=tidal, max_threads=max_threads)
+                     sub_min_members=sub_min_members, tidal=tidal, gravity=gravity,
+                     tidal_sample=tidal_sample, max_threads=max_threads)
 end
 
 # per-clump statistics (mass, COM, peak, radius) + optional boundedness; shared by top-level clumps
@@ -1291,24 +1301,65 @@ end
 # Jacobi radius r_t = D·(m_sub / 3 M_host(<D))^{1/3} (King 1962; Binney & Tremaine 2008 §8.3),
 # where D is the subclump–host COM separation and M_host(<D) the host mass enclosed within D.
 # Members of `sub` farther than r_t from the subclump COM are tidally stripped.
-function _tidal_truncate(sub, host, bargs, xs, ys, zs)
+# ---- tidal/Hill radius from the local gravity field (tidal-tensor form) -----------------
+# Fit the acceleration field a_i(x) ≈ a0_i + Σ_j (∂a_i/∂x_j)·Δx_j over nearby gravity samples
+# (Δx, a in cgs), take the symmetric tidal tensor T_ij = ½(∂a_i/∂x_j + ∂a_j/∂x_i) = −∂²Φ/∂x_i∂x_j,
+# and return the tidal radius r_t³ = G·m_sub / λ_max(T). For a point-mass host (λ_max = 2GM/R³) this
+# is exactly the Hill radius R·(m_sub/2M)^{1/3}. Returns Inf if there is no stretching tide, NaN if
+# too few samples for a 3-D linear fit.
+function _tidal_tensor_radius(dx, dy, dz, ax, ay, az, m_sub_g, Gc)
+    n = length(dx); n < 4 && return NaN
+    s = sqrt((sum(abs2, dx) + sum(abs2, dy) + sum(abs2, dz)) / (3n))  # RMS offset → scale to O(1)
+    s > 0 || return NaN                                              # (cm-scale offsets + a ones column
+    A = hcat(ones(n), dx ./ s, dy ./ s, dz ./ s)                     #  would otherwise be ill-conditioned)
+    G = Matrix{Float64}(undef, 3, 3)
+    for (i, a) in enumerate((ax, ay, az))
+        c = A \ collect(a); G[i, 1] = c[2]/s; G[i, 2] = c[3]/s; G[i, 3] = c[4]/s   # ∂a_i/∂x_j
+    end
+    T = 0.5 .* (G .+ transpose(G))                                    # symmetric tidal tensor
+    λ = maximum(eigvals(Symmetric(T)))
+    λ <= 0 && return Inf
+    return cbrt(Gc * m_sub_g / λ)
+end
+
+# truncate a subclump at its tidal radius. `mode=true` ⇒ Jacobi r_t = D·(m_sub/3M_host(<D))^{1/3}
+# (host mass enclosed within the COM separation); `mode=:tensor` ⇒ tidal-tensor / Hill radius from the
+# gravity acceleration field (`bargs.grav`), sampling it within `tidal_sample`× the subclump radius.
+function _tidal_truncate(sub, host, bargs, xs, ys, zs, mode, tidal_sample)
     mg = bargs.mg; poscm = bargs.poscm
-    msub = sum(@view mg[sub]); hM = sum(@view mg[host])
-    hcx = sum(mg[j]*xs[j] for j in host)/hM; hcy = sum(mg[j]*ys[j] for j in host)/hM
-    hcz = sum(mg[j]*zs[j] for j in host)/hM
+    msub = sum(@view mg[sub])
     scx = sum(mg[j]*xs[j] for j in sub)/msub; scy = sum(mg[j]*ys[j] for j in sub)/msub
     scz = sum(mg[j]*zs[j] for j in sub)/msub
+    rsub2(j) = (xs[j]-scx)^2 + (ys[j]-scy)^2 + (zs[j]-scz)^2
+    if mode === :tensor && bargs.grav !== nothing
+        g = bargs.grav
+        Rsub = sqrt(maximum(rsub2(j) for j in sub))                     # subclump radius (pos_unit)
+        sr2 = (tidal_sample * Rsub)^2
+        sel = findall(k -> (g.gx[k]-scx)^2 + (g.gy[k]-scy)^2 + (g.gz[k]-scz)^2 <= sr2, eachindex(g.gx))
+        if length(sel) >= 4
+            rt = _tidal_tensor_radius((g.gx[sel].-scx).*poscm, (g.gy[sel].-scy).*poscm, (g.gz[sel].-scz).*poscm,
+                                      g.gax[sel], g.gay[sel], g.gaz[sel], msub, bargs.Gc)
+            if isfinite(rt) && rt > 0
+                rt2 = (rt/poscm)^2
+                return [j for j in sub if rsub2(j) <= rt2]
+            end
+        end
+        return sub                                                      # too few samples / no tide → keep
+    end
+    # Jacobi form
+    hM = sum(@view mg[host])
+    hcx = sum(mg[j]*xs[j] for j in host)/hM; hcy = sum(mg[j]*ys[j] for j in host)/hM
+    hcz = sum(mg[j]*zs[j] for j in host)/hM
     D = sqrt((scx-hcx)^2 + (scy-hcy)^2 + (scz-hcz)^2) * poscm           # COM separation (cm)
     D <= 0 && return sub
-    D2 = (D/poscm)^2                                                     # in pos_unit² for the host sum
+    D2 = (D/poscm)^2
     Menc = 0.0
     @inbounds for j in host
         ((xs[j]-hcx)^2 + (ys[j]-hcy)^2 + (zs[j]-hcz)^2) <= D2 && (Menc += mg[j])
     end
     Menc <= 0 && return sub
-    rt = D * (msub / (3 * Menc))^(1/3)                                   # Jacobi radius (cm)
-    rt2 = (rt / poscm)^2                                                 # back to pos_unit²
-    return [j for j in sub if ((xs[j]-scx)^2 + (ys[j]-scy)^2 + (zs[j]-scz)^2) <= rt2]
+    rt2 = (D * (msub / (3 * Menc))^(1/3) / poscm)^2                     # Jacobi radius² (pos_unit²)
+    return [j for j in sub if rsub2(j) <= rt2]
 end
 
 # =====================================================================================

--- a/src/functions/flux.jl
+++ b/src/functions/flux.jl
@@ -189,9 +189,19 @@ projection(sh, :sd, :Msol_pc2; center=[:bc])              # the shell as a ring/
 projection(sh, :vr_sphere, :km_s; center=[:bc])           # inflow (<0) / outflow (>0) over the shell
 ```
 """
-fluxshell(obj::HydroDataType; surface::Symbol=:sphere, radius::Real, shell_width::Real,
-          center=[:bc], range_unit::Symbol=:kpc) =
-    _flux_shell(obj, surface, Float64(radius), Float64(shell_width), center, range_unit)
+function fluxshell(obj::HydroDataType; surface::Symbol=:sphere, radius::Real, shell_width::Real,
+                   center=[:bc], range_unit::Symbol=:kpc, axis=nothing, height=nothing)
+    R = Float64(radius); dr = Float64(shell_width)
+    tilted = surface === :plane || (surface === :cylinder && axis !== nothing && axis !== :z)
+    if tilted
+        surface === :plane && axis === nothing && throw(ArgumentError(":plane needs an `axis`"))
+        nhat = _flux_axis(obj, axis, center, range_unit)
+        heff = surface === :plane ? nothing : (height === nothing ? 2*(R+dr/2) : Float64(height))
+        mask, _ = _flux_tilted_geom(obj, surface, nhat, R, dr, heff, center, range_unit)
+        return _subhydro(obj, mask)
+    end
+    return _flux_shell(obj, surface, R, dr, center, range_unit)
+end
 
 # =====================================================================================
 #  fluxmap — the surface map: WHERE on the shell gas flows in vs out (no LOS superposition)
@@ -244,22 +254,37 @@ fm.xedges, fm.yedges
 """
 function fluxmap(obj::HydroDataType; surface::Symbol=:sphere, radius::Real, shell_width::Real,
                  quantity::Symbol=:vr, nbins=(72, 36), center=[:bc], range_unit::Symbol=:kpc,
-                 verbose::Bool=true)
+                 axis=nothing, height=nothing, verbose::Bool=true)
     quantity in (:vr, :mdot) || throw(ArgumentError("quantity must be :vr or :mdot (got :$quantity)"))
-    R = Float64(radius); dr = Float64(shell_width)
-    shell = _flux_shell(obj, surface, R, dr, center, range_unit); info = obj.info
-    nbx, nby = nbins[1], nbins[2]
-    xr = getvar(shell, :x, range_unit; center=center, center_unit=range_unit)
-    yr = getvar(shell, :y, range_unit; center=center, center_unit=range_unit)
-    zr = getvar(shell, :z, range_unit; center=center, center_unit=range_unit)
-    vn = getvar(shell, _FLUX_NORMAL[surface], :km_s; center=center, center_unit=range_unit)
-    m_g = getvar(shell, :mass, :g)
-    φ = atan.(yr, xr) .* (180/π)                                       # azimuth [-180,180] deg
-    if surface === :sphere
-        r = sqrt.(xr.^2 .+ yr.^2 .+ zr.^2)
-        ycoord = zr ./ max.(r, eps()); ylab = :cosθ; yrange = (-1.0, 1.0)
-    else
-        ycoord = zr; ylab = :z; yrange = (minimum(zr), maximum(zr))
+    surface in (:sphere, :cylinder) || throw(ArgumentError("fluxmap surface must be :sphere or :cylinder"))
+    R = Float64(radius); dr = Float64(shell_width); info = obj.info; nbx, nby = nbins[1], nbins[2]
+    tilted = surface === :cylinder && axis !== nothing && axis !== :z
+    if tilted                                                          # unrolled map about a tilted axis n̂
+        nhat = _flux_axis(obj, axis, center, range_unit)
+        e1, e2, _ = build_camera_basis(nhat)                          # orthonormal in-plane basis ⊥ n̂
+        heff = height === nothing ? 2*(R+dr/2) : Float64(height)
+        mask, vn_cms = _flux_tilted_geom(obj, surface, nhat, R, dr, heff, center, range_unit)
+        sel = findall(mask)
+        x = getvar(obj, :x, range_unit; center=center, center_unit=range_unit)[sel]
+        y = getvar(obj, :y, range_unit; center=center, center_unit=range_unit)[sel]
+        z = getvar(obj, :z, range_unit; center=center, center_unit=range_unit)[sel]
+        m_g = getvar(obj, :mass, :g)[sel]; vn = vn_cms[sel] ./ 1e5     # cm/s → km/s
+        zc = x .* nhat[1] .+ y .* nhat[2] .+ z .* nhat[3]
+        φ = atan.(x .* e2[1] .+ y .* e2[2] .+ z .* e2[3], x .* e1[1] .+ y .* e1[2] .+ z .* e1[3]) .* (180/π)
+        ycoord = zc; ylab = :z; yrange = (minimum(zc), maximum(zc))
+    else                                                              # axis-aligned shell
+        shell = _flux_shell(obj, surface, R, dr, center, range_unit)
+        xr = getvar(shell, :x, range_unit; center=center, center_unit=range_unit)
+        yr = getvar(shell, :y, range_unit; center=center, center_unit=range_unit)
+        zr = getvar(shell, :z, range_unit; center=center, center_unit=range_unit)
+        vn = getvar(shell, _FLUX_NORMAL[surface], :km_s; center=center, center_unit=range_unit)
+        m_g = getvar(shell, :mass, :g)
+        φ = atan.(yr, xr) .* (180/π)
+        if surface === :sphere
+            r = sqrt.(xr.^2 .+ yr.^2 .+ zr.^2); ycoord = zr ./ max.(r, eps()); ylab = :cosθ; yrange = (-1.0, 1.0)
+        else
+            ycoord = zr; ylab = :z; yrange = (minimum(zr), maximum(zr))
+        end
     end
     xrange = (-180.0, 180.0)
     if quantity === :vr                                                # mass-weighted mean v⊥
@@ -268,8 +293,7 @@ function fluxmap(obj::HydroDataType; surface::Symbol=:sphere, radius::Real, shel
     else                                                               # per-bin Ṁ contribution
         g_per_Msol = getunit(info, :g)/getunit(info, :Msol); s_per_yr = getunit(info, :s)/getunit(info, :yr)
         dr_cm = (dr / _funit(info, range_unit)) * getunit(info, :cm)
-        vn_cms = getvar(shell, _FLUX_NORMAL[surface], :cm_s; center=center, center_unit=range_unit)
-        ph = _phase2d(φ, ycoord, m_g .* vn_cms, nothing, nbx, nby, xrange, yrange, :linear, :linear)
+        ph = _phase2d(φ, ycoord, m_g .* (vn .* 1e5), nothing, nbx, nby, xrange, yrange, :linear, :linear)  # vn km/s→cm/s
         mp = ph.H .* (s_per_yr/g_per_Msol) ./ dr_cm; total = sum(mp); unit = :Msol_yr
     end
     massmap = _phase2d(φ, ycoord, m_g ./ (getunit(info,:g)/getunit(info,:Msol)), nothing,
@@ -363,11 +387,8 @@ function _flux_axis(obj, axis, center, range_unit)
     end
 end
 
-# tilted cylinder wall (about n̂) or plane (normal n̂ at along-axis position R): returns the full
-# FluxBudgetType pieces (rates, comps, n_cells, shell_mass, cell_size).
-function _flux_tilted(obj, surface, nhat, R, dr, height, quantities, center, range_unit, phases;
-                      nboot=0, rng=nothing, ci_level=0.95)
-    info = obj.info
+# tilted geometry: returns (mask over the object's cells, surface-normal velocity in cm/s).
+function _flux_tilted_geom(obj, surface, nhat, R, dr, height, center, range_unit)
     x = getvar(obj, :x, range_unit; center=center, center_unit=range_unit)
     y = getvar(obj, :y, range_unit; center=center, center_unit=range_unit)
     z = getvar(obj, :z, range_unit; center=center, center_unit=range_unit)
@@ -377,13 +398,33 @@ function _flux_tilted(obj, surface, nhat, R, dr, height, quantities, center, ran
         mask = abs.(zc .- R) .<= dr/2
         vn = vx .* nhat[1] .+ vy .* nhat[2] .+ vz .* nhat[3]          # normal = axis (cm/s)
     else                                                              # tilted cylinder wall
-        px = x .- zc .* nhat[1]; py = y .- zc .* nhat[2]; pz = z .- zc .* nhat[3]   # perp vector
+        px = x .- zc .* nhat[1]; py = y .- zc .* nhat[2]; pz = z .- zc .* nhat[3]
         Rp = sqrt.(px.^2 .+ py.^2 .+ pz.^2)
         mask = (Rp .>= R - dr/2) .& (Rp .<= R + dr/2)
         height !== nothing && (mask = mask .& (abs.(zc) .<= height/2))
         Rsafe = max.(Rp, eps())
         vn = (vx .* px .+ vy .* py .+ vz .* pz) ./ Rsafe             # v · R̂_perp (cm/s)
     end
+    return mask, vn
+end
+
+# build a HydroDataType holding just the masked rows (for fluxshell on a tilted surface)
+function _subhydro(obj::HydroDataType, mask)
+    s = HydroDataType()
+    s.data = getfield(obj, :data)[mask]
+    s.info = obj.info; s.lmin = obj.lmin; s.lmax = obj.lmax; s.boxlen = obj.boxlen
+    s.ranges = obj.ranges; s.selected_hydrovars = obj.selected_hydrovars
+    s.used_descriptors = obj.used_descriptors; s.smallr = obj.smallr; s.smallc = obj.smallc
+    s.scale = obj.scale
+    return s
+end
+
+# tilted cylinder wall (about n̂) or plane (normal n̂ at along-axis position R): returns the full
+# FluxBudgetType pieces (rates, comps, n_cells, shell_mass, cell_size).
+function _flux_tilted(obj, surface, nhat, R, dr, height, quantities, center, range_unit, phases;
+                      nboot=0, rng=nothing, ci_level=0.95)
+    info = obj.info
+    mask, vn = _flux_tilted_geom(obj, surface, nhat, R, dr, height, center, range_unit)
     idx = findall(mask)
     dr_cm = (dr / _funit(info, range_unit)) * getunit(info, :cm)
     g_per_Msol = getunit(info, :g)/getunit(info, :Msol); s_per_yr = getunit(info, :s)/getunit(info, :yr)

--- a/test/40_clumpfind_validation_tests.jl
+++ b/test/40_clumpfind_validation_tests.jl
@@ -284,7 +284,7 @@ end
         xs = vcat(hx, sx); ys = vcat(hy, sy); zs = vcat(hz, sz)
         mg = ones(length(xs))
         host = collect(1:nh); sub = collect(nh+1:nh+ncore+1); far = nh + ncore + 1
-        kept = Mera._tidal_truncate(sub, host, (mg=mg, poscm=1.0), xs, ys, zs)
+        kept = Mera._tidal_truncate(sub, host, (mg=mg, poscm=1.0, grav=nothing), xs, ys, zs, true, 3.0)
         # the far outlier (well beyond the Jacobi radius) is stripped; the core survives
         @test far ∉ kept
         @test length(kept) >= ncore - 3 && length(kept) < length(sub)
@@ -461,7 +461,7 @@ end
         N = 40*50; xs = rand(rng, N); ys = rand(rng, N); zs = rand(rng, N)
         ms = ones(N); fs = rand(rng, N)
         f = mem -> Mera._finalize_clump(mem, xs, ys, zs, ms, fs, nothing, false, false, false,
-                                        false, 1, false, 0.1, 1)
+                                        false, 1, false, 0.1, 1, 3.0)
         ser = Mera._finalize_all(members, 1, f)
         for nthr in (2, 4, 8)
             par = Mera._finalize_all(members, nthr, f)
@@ -525,4 +525,47 @@ end
         P10 = Mera.Points([0.0], [0.0], [0.0], [1.0], [1.0], [1], nothing, [9.0], [8.0], [7.0])
         @test P10.vx == [9.0]
     end
+end
+
+@testset verbose=true "clumpfind tidal-tensor radius (data-free)" begin
+    # point-mass host M: acceleration a_i = -G M x_i / r³ sampled around x0 = (R,0,0).
+    # The tidal-tensor radius must equal the analytic Hill radius r_t = R·(m_sub/2M)^{1/3}.
+    G = 6.674e-8; M = 1.989e43; m_sub = 1.989e40                  # 1e10 / 1e7 Msol (cgs)
+    rng = MersenneTwister(7)
+    function samples(R, n, h)
+        dx = Float64[]; dy = Float64[]; dz = Float64[]; ax = Float64[]; ay = Float64[]; az = Float64[]
+        for _ in 1:n
+            o = h .* randn(rng, 3); x = [R,0.0,0.0] .+ o; r = sqrt(sum(abs2, x)); a = -G*M .* x ./ r^3
+            push!(dx,o[1]); push!(dy,o[2]); push!(dz,o[3]); push!(ax,a[1]); push!(ay,a[2]); push!(az,a[3])
+        end
+        return dx, dy, dz, ax, ay, az
+    end
+    for R in (3.086e22, 6.0e22, 1.5e22)                          # ~10, 20, 5 kpc in cm
+        dx, dy, dz, ax, ay, az = samples(R, 60, R*0.01)
+        rt = Mera._tidal_tensor_radius(dx, dy, dz, ax, ay, az, m_sub, G)
+        hill = R * (m_sub/(2M))^(1/3)
+        @test isapprox(rt, hill; rtol=0.01)                      # matches analytic Hill radius
+    end
+    # fewer than 4 samples → NaN; a uniform (no-tide) field → Inf (no stretching)
+    @test isnan(Mera._tidal_tensor_radius([1.0,2,3], [0.0,0,0], [0.0,0,0], [0.0,0,0], [0.0,0,0], [0.0,0,0], 1.0, G))
+    n = 30; z = zeros(n); rr = randn(rng, n)
+    @test Mera._tidal_tensor_radius(rr, randn(rng,n), randn(rng,n), z, z, z, 1.0, G) == Inf  # ∇a = 0
+
+    # the _tidal_truncate :tensor branch strips members beyond the Hill radius (synthetic point-mass host)
+    R = 3.086e22; poscm = R/10.0                                  # 1 pos_unit = 1 kpc (cm/kpc)
+    # subclump: tight core at x0=10 (pos_unit) + a far member; gravity grid = analytic point-mass field
+    ng = 200; gx = Float64[]; gy = Float64[]; gz = Float64[]; gax = Float64[]; gay = Float64[]; gaz = Float64[]
+    for _ in 1:ng
+        o = 0.3 .* randn(rng, 3); xp = [10.0,0.0,0.0] .+ o       # pos_unit, around the subclump
+        xcm = xp .* poscm; r = sqrt(sum(abs2, xcm)); a = -G*M .* xcm ./ r^3
+        push!(gx,xp[1]); push!(gy,xp[2]); push!(gz,xp[3]); push!(gax,a[1]); push!(gay,a[2]); push!(gaz,a[3])
+    end
+    grav = (gx=gx, gy=gy, gz=gz, gax=gax, gay=gay, gaz=gaz)
+    hill_pu = (R*(m_sub/(2M))^(1/3)) / poscm                      # Hill radius in pos_unit
+    # member positions: core within hill, one member at 3× hill (should be stripped)
+    xs = [10.0, 10.0+0.2*hill_pu, 10.0-0.2*hill_pu, 10.0+3*hill_pu]
+    ys = zeros(4); zs = zeros(4); mg = [1e6*1.989e33, 1e6*1.989e33, 1e6*1.989e33, 1.0*1.989e33]  # core dominates
+    bargs = (mg=mg, poscm=poscm, Gc=G, grav=grav)
+    kept = Mera._tidal_truncate([1,2,3,4], [1,2,3,4], bargs, xs, ys, zs, :tensor, 5.0)
+    @test 4 ∉ kept && Set(kept) ⊇ Set([1,2,3])                   # far member stripped, core kept
 end

--- a/test/43_fluxbudget_tests.jl
+++ b/test/43_fluxbudget_tests.jl
@@ -180,6 +180,23 @@
             @test_throws ArgumentError fluxbudget(gas; surface=:torus, radius=5.0, shell_width=2.0)
         end
 
+        @testset "off-axis fluxshell + fluxmap" begin
+            # fluxshell honours a tilted axis / plane and returns the measured cells
+            sh = fluxshell(gas; surface=:cylinder, radius=10.0, shell_width=2.0, range_unit=:kpc, axis=:angmom)
+            @test sh isa Mera.HydroDataType && length(sh.data) > 0
+            shp = fluxshell(gas; surface=:plane, radius=5.0, shell_width=2.0, range_unit=:kpc, axis=[0.,0.,1.])
+            fbp = fluxbudget(gas; surface=:plane, radius=5.0, shell_width=2.0, range_unit=:kpc,
+                             axis=[0.,0.,1.], verbose=false)
+            @test length(shp.data) == fbp.n_cells               # exactly the cells fluxbudget used
+            # tilted fluxmap (unrolled φ′–z′ about n̂); mdot map still closes to the tilted budget
+            fmd = fluxmap(gas; surface=:cylinder, radius=10.0, shell_width=2.0, range_unit=:kpc,
+                          axis=:angmom, quantity=:mdot, verbose=false)
+            fbL = fluxbudget(gas; surface=:cylinder, radius=10.0, shell_width=2.0, range_unit=:kpc,
+                             axis=:angmom, verbose=false)
+            @test fmd.ylabel === :z
+            @test fmd.total ≈ fbL.rates.mass.net rtol=1e-6
+        end
+
         @testset "bootstrap confidence intervals" begin
             fb = fluxbudget(gas; surface=:sphere, radius=10.0, shell_width=2.0, range_unit=:kpc,
                             bootstrap=400, verbose=false)


### PR DESCRIPTION
The two final deferred items: tidal-**tensor** truncation for the clumpfinder, and off-axis support for the flux visualizers.

## Tidal-tensor / Hill-radius truncation (clumpfind)
`clumpfind(...; substructure=true, tidal=:tensor, gravity=grav)` truncates each subclump at the **tidal-tensor (Hill) radius** instead of the Jacobi form: it fits the local gravitational acceleration field `a(x)` (from a `getgravity` object) around the subclump to the tidal tensor `T_ij = −∂²Φ/∂x_i∂x_j`, and strips members beyond `r_t³ = G·m_sub/λ_max(T)`.

The kernel `_tidal_tensor_radius` is validated **data-free** against the analytic Hill radius `R·(m_sub/2M)^{1/3}` for a point-mass host — matches to **<1 %** at several distances. (A subtlety fixed along the way: the cm-scale offsets + a `ones` column made the least-squares design matrix wildly ill-conditioned; scaling offsets to O(1) before the fit cured it.) The existing `tidal=true` Jacobi form is unchanged; `tidal_sample` (default 3) sets the fit radius in subclump-radii.

## Off-axis fluxshell / fluxmap
`fluxshell` and `fluxmap` now accept the same `axis` (3-vector or `:angmom`) and `surface=:plane` options as `fluxbudget`, so tilted/L-aligned surfaces can be *visualized*, not just measured:
- `fluxshell` returns the tilted shell / plane as a `HydroDataType` (exactly the cells `fluxbudget` used).
- `fluxmap` unrolls a tilted cylinder about `n̂` into a (φ′, z′) map; its `:mdot` map still **closes to the tilted budget** (verified to rtol 1e-6).

Shared helpers `_flux_tilted_geom` (mask + normal velocity) and `_subhydro` (masked sub-object) keep the tilted path single-sourced.

## Tests / docs
`test/40` +6 (tidal-tensor analytic oracle + the `:tensor` truncation branch), `test/43` +4 (off-axis shell/map closure). `test/39` 54/54, `test/40`/`test/43` green, Aqua 4/4, docs build clean locally.