### PR TITLE
fluxbudget: correctness set — :metals/:energy guards, cosmological warning, conversion-factor tests

### DIFF
--- a/docs/src/fluxbudget.md
+++ b/docs/src/fluxbudget.md
@@ -30,6 +30,18 @@ Units per quantity: **mass** and **metals** in `Msol/yr`, **momentum** in `Msol�
 mass/metals/energy `in ≤ 0` and `out ≥ 0`; for **momentum** the carried quantity already contains `v⊥`
 (radial momentum), so both `in` and `out` are ≥ 0 — the ram-pressure flux from in- and out-moving gas.
 
+!!! note "`:metals` needs a `:metallicity` column"
+    The `:metals` flux multiplies cell mass by the gas metallicity, read from a column literally named
+    `:metallicity`. Mera does **not** auto-treat a passive scalar (e.g. `:var6`) as metallicity, so on a
+    run without that column `:metals` raises a clear error rather than silently returning zero — alias
+    your metal scalar to `:metallicity` before the call if needed. Likewise `:energy` needs the thermal
+    energy (pressure `:p`) and errors clearly on an isothermal/pressureless output.
+
+!!! warning "Cosmological runs: no Hubble flow"
+    `v⊥` is the **peculiar** gas velocity; the Hubble flow `H(a)·r` is not added. At large radius the
+    Hubble term can dominate and even flip the inflow/outflow sign, so the in/out split near turnaround
+    is unreliable on cosmological/zoom runs (a `@warn` fires). The non-cosmological case is unaffected.
+
 Use `surface=:cylinder` for the flux through a cylindrical wall (e.g. the edge of a disk):
 
 ```julia

--- a/src/functions/flux.jl
+++ b/src/functions/flux.jl
@@ -134,6 +134,10 @@ function fluxbudget(obj::HydroDataType; surface::Symbol=:sphere, radius::Real, s
                     bootstrap::Int=0, bootstrap_seed::Int=20240601, ci_level::Float64=0.95,
                     verbose::Bool=true)
     R = Float64(radius); dr = Float64(shell_width); info = obj.info
+    # the surface-normal velocity is the raw (peculiar) gas velocity; on a cosmological run it omits the
+    # Hubble flow H(a)·r, which at large radius can dominate v⊥ and even flip the inflow/outflow sign.
+    verbose && iscosmological(info) && @warn "fluxbudget: cosmological run — v⊥ is the peculiar " *
+        "velocity only; the Hubble flow H(a)·r is NOT included, so in/out near turnaround may be wrong."
     tilted = surface === :plane || (surface === :cylinder && axis !== nothing && axis !== :z)
     surface in (:sphere, :cylinder, :plane) ||
         throw(ArgumentError("surface must be :sphere, :cylinder or :plane (got :$surface)"))
@@ -326,9 +330,25 @@ _centervec(center, info, range_unit) =
     (center == [:bc] || center == [:boxcenter]) ? [0.5, 0.5, 0.5] :
     [c === :bc ? 0.5 : Float64(c) for c in center]
 
+# validate that the requested quantities are computable on this output — fail loudly rather than
+# silently returning zero (metals) or throwing a cryptic IndexedTables error deep in getvar (energy).
+function _flux_validate_quantities(cols, quantities)
+    if :metals in quantities && !(:metallicity in cols)
+        throw(ArgumentError("flux :metals needs a :metallicity column, which this output does not have " *
+            "(Mera does not auto-rename passive scalars, so a metal scalar stored as e.g. :var6 is NOT " *
+            "treated as metallicity). Alias your metal field to :metallicity before calling, or drop " *
+            ":metals from `quantities`. (Returning zero silently would be a wrong answer.)"))
+    end
+    if :energy in quantities && !(:p in cols)
+        throw(ArgumentError("flux :energy needs the thermal energy from pressure (:p), absent on this " *
+            "isothermal/pressureless output. Drop :energy from `quantities`, or use a run with pressure."))
+    end
+end
+
 # compute the rate NamedTuple (+ per-phase components) over a selected shell
 function _flux_compute(shell, vn_sym, dr, center, range_unit, quantities, phases; nboot=0, rng=nothing, ci_level=0.95)
     info = shell.info
+    _flux_validate_quantities(propertynames(getfield(shell, :data).columns), quantities)
     dr_cm = (dr / _funit(info, range_unit)) * getunit(info, :cm)         # Δr in cm
     g_per_Msol = getunit(info, :g) / getunit(info, :Msol)
     s_per_yr = getunit(info, :s) / getunit(info, :yr)
@@ -430,6 +450,7 @@ function _flux_tilted(obj, surface, nhat, R, dr, height, quantities, center, ran
     idx = findall(mask)
     dr_cm = (dr / _funit(info, range_unit)) * getunit(info, :cm)
     g_per_Msol = getunit(info, :g)/getunit(info, :Msol); s_per_yr = getunit(info, :s)/getunit(info, :yr)
+    _flux_validate_quantities(propertynames(getfield(obj, :data).columns), quantities)
     m_g = getvar(obj, :mass, :g)
     haveZ = :metallicity in propertynames(getfield(obj, :data).columns)
     Zarr = haveZ ? getvar(obj, :metallicity) : zeros(length(m_g))

--- a/test/43_fluxbudget_tests.jl
+++ b/test/43_fluxbudget_tests.jl
@@ -49,6 +49,29 @@
         @test sin_ ≈ -ρ*v0*Vshell rtol=1e-12
     end
 
+    @testset "per-quantity conversion factors (magnitude oracle, data-free)" begin
+        # Lock the four carried/conv relationships against silent magnitude errors (e.g. a dropped
+        # cm/s→km/s factor) — the existing public test only checks signs/units. Build a uniform outflow
+        # shell with known per-cell mass, velocity, energy and metallicity, run each through
+        # _flux_quantity with the SAME conv expressions flux.jl uses, and assert physical magnitudes.
+        syr = 3.156e7; gMsol = 1.989e33                     # s/yr, g/Msol (ratio tests below are unit-free)
+        N = 400; v0_cms = 2.5e7; v0_kms = v0_cms/1e5        # 250 km/s outflow
+        dr_cm = 3.086e21                                    # 1 kpc shell width
+        m_g = fill(1.0e38/N, N); vn = fill(v0_cms, N); Z = 0.02; E = fill(7.0e50/N, N)  # erg per cell
+        conv_mass = syr/gMsol; conv_mom = syr/(gMsol*1e5); conv_met = syr/gMsol
+        mass = Mera._flux_quantity(vn, m_g,        dr_cm, conv_mass, :Msol_yr)
+        mom  = Mera._flux_quantity(vn, m_g .* vn,  dr_cm, conv_mom,  :Msol_km_s_yr)
+        met  = Mera._flux_quantity(vn, m_g .* Z,   dr_cm, conv_met,  :Msol_yr)
+        en   = Mera._flux_quantity(vn, E,          dr_cm, 1.0,       :erg_s)
+        # momentum/mass ratio = v⊥ in km/s (NOT cm/s) → catches a missing or extra 1e5 factor
+        @test isapprox(mom.out / mass.out, v0_kms; rtol=1e-12)
+        # metals/mass ratio = the metallicity (carried = m·Z, same conv as mass)
+        @test isapprox(met.out / mass.out, Z; rtol=1e-12)
+        # energy: conv = 1, so out = Σ(E·v⊥)/Δ exactly, and the unit is erg/s
+        @test isapprox(en.out, sum(E) * v0_cms / dr_cm; rtol=1e-12) && en.unit === :erg_s
+        @test mass.unit === :Msol_yr && mom.unit === :Msol_km_s_yr && met.unit === :Msol_yr
+    end
+
     @testset "axis resolver _flux_axis (data-free)" begin
         @test Mera._flux_axis(nothing, [0.0,0.0,2.0], [:bc], :kpc) ≈ [0.0,0.0,1.0]   # normalized
         @test Mera._flux_axis(nothing, [3.0,4.0,0.0], [:bc], :kpc) ≈ [0.6,0.8,0.0]
@@ -80,6 +103,26 @@
             # momentum: carried already ∝ v⊥ ⇒ both contributions ≥ 0 (ram-pressure flux)
             @test fb.rates.momentum.in >= 0 && fb.rates.momentum.out >= 0
             @test fb.rates.momentum.unit === :Msol_km_s_yr
+            # momentum/mass magnitude sanity through the REAL carried_and_conv path: the outflow
+            # ratio is a characteristic v⊥ and must land in a physical km/s range (a dropped 1e5
+            # factor would put it at ~1e5–1e8). Guards the public conversion, not just the kernel.
+            if fb.rates.mass.out > 0
+                @test 1.0 < fb.rates.momentum.out / fb.rates.mass.out < 1.0e4   # km/s, not cm/s
+            end
+        end
+
+        @testset "metals guard: fail loudly, not silently zero" begin
+            # spiral_clumps stores a passive scalar :var6 but NO :metallicity column, so :metals would
+            # silently return 0 — now it must throw a clear error instead.
+            @test !(:metallicity in gas.info.variable_list)
+            @test_throws ArgumentError fluxbudget(gas; surface=:sphere, radius=10.0, shell_width=2.0,
+                                                  range_unit=:kpc, quantities=[:metals], verbose=false)
+            # the same guard fires on the off-axis (tilted) path
+            @test_throws ArgumentError fluxbudget(gas; surface=:cylinder, radius=10.0, shell_width=2.0,
+                                                  range_unit=:kpc, axis=[1.0,1.0,1.0], quantities=[:metals], verbose=false)
+            # :mass/:momentum/:energy still work on this output (have rho/v/p)
+            @test fluxbudget(gas; surface=:sphere, radius=10.0, shell_width=2.0, range_unit=:kpc,
+                             quantities=[:mass, :energy], verbose=false) isa FluxBudgetType
         end
 
         @testset "end-to-end physics: Msol/yr matches an independent calculation" begin


### PR DESCRIPTION
Addresses the FluxBudget expert-panel evaluation (7.6/10). The chosen correctness set — closing the silent-wrong-answer risks the panel verified.

## Silent-wrong fixes
- **`:metals` no longer silently returns zero.** `haveZ` checked for a `:metallicity` column, but Mera stores metal scalars as `:var6` (descriptor renaming disabled), so real metal runs got `metals = 0`. Now a clear `ArgumentError` (both axis-aligned and tilted paths) tells the user to alias their scalar. (panel #1, #3)
- **`:energy` on pressureless/isothermal runs** now errors clearly instead of a cryptic IndexedTables failure deep in getvar (`:p` absent). (panel #6 guard)
- Shared `_flux_validate_quantities` helper used by both paths.

## Cosmological warning (panel #4)
- `fluxbudget` `@warn`s on cosmological runs that `v⊥` is the **peculiar** velocity only (no Hubble flow `H(a)·r`), which can flip the in/out sign near turnaround. Non-cosmological runs unaffected.

## Tests (panel #2, #3)
- **Magnitude oracle (data-free):** pins the four carried/conv relationships — `momentum/mass = v⊥ in km/s` (catches a dropped/extra 1e5), `metals/mass = Z`, `energy = Σ(E·v⊥)/Δr` (conv=1). The old suite checked mass magnitude + only signs/units for the rest, so a wrong scale factor would have passed.
- **AMR:** momentum/mass outflow ratio asserted in a physical km/s range (guards the real `carried_and_conv`), plus the metals guard on sphere + tilted paths.

## Docs
- Notes on `:metals` needing `:metallicity` / `:energy` needing `:p`, and the cosmological no-Hubble-flow caveat.

Verified: flux tests 113/113 (incl. new oracle + guards); cosmological `@warn` confirmed on yt_cosmo; docs build clean.

Deferred (panel, lower priority): off-axis tilted-vs-axis-aligned selection reconciliation, PdV/enthalpy energy term, SE/bootstrap exchangeability caveat + RNG determinism, viz percentile/label tuning + conversion dedup.