### PR TITLE
Projection correctness fixes + docs (parttypes, off-axis clip, LOS-cube qrange)

### DIFF
--- a/docs/src/06_hydro_Projection.md
+++ b/docs/src/06_hydro_Projection.md
@@ -54,6 +54,37 @@ MERA.jl provides powerful projection capabilities for analyzing hydrodynamical s
 - **Weighting Schemes**: Mass-weighted, volume-weighted, or custom weighting
 - **Coordinate Systems**: Native Cartesian or derived cylindrical/spherical coordinates
 
+### Intensive vs. extensive quantities — what a projection *means*
+
+A line-of-sight projection reduces a 3-D field to a 2-D map, and **how** the cells along each
+sightline are combined depends on whether the quantity is *intensive* or *extensive*:
+
+| Quantity kind | Examples | How it is projected | Result per pixel |
+|---|---|---|---|
+| **Extensive** (adds up) | `:sd` (surface density), `:mass` | **summed** along the sightline, divided by the pixel area | a column / surface density — the total is conserved |
+| **Intensive** (a local value) | `:T`, `:vx`, `:rho`, `:cs`, `:p`, … | **weight-averaged** along the sightline (`weighting=:mass` by default, or `:volume`) | a representative value, *not* a sum |
+
+In other words: a mass-weighted projection of an intensive field answers *"what value would a
+mass-tracer see, averaged down this column?"*, while a surface-density projection answers
+*"how much is there per unit area?"*. Choosing the wrong combination is the most common projection
+mistake — e.g. mass-weighting a temperature map biases it toward dense gas, whereas volume-weighting
+(`weighting=:volume`) gives the volume-filling temperature.
+
+```julia
+projection(gas, :T)                      # mass-weighted T (default) — tracks dense gas
+projection(gas, :T,  weighting=:volume)  # volume-weighted T — volume-filling value
+projection(gas, :sd, :Msol_pc2)          # extensive: summed mass per pixel area (column)
+```
+
+!!! note "`mode=:standard` vs `mode=:sum`"
+    The default `mode=:standard` produces the **physically normalized** map described above
+    (extensive ⇒ per-area column; intensive ⇒ weight-average). `mode=:sum` instead returns the
+    **raw per-pixel weighted sum** with no area/normalization division — useful when you want to
+    accumulate a conserved total yourself (e.g. summing energy or a custom budget across pixels) and
+    will apply your own normalization. For standard surface-density and weighted-average maps, keep
+    `mode=:standard`. (Particle projections support `weighting=:mass`/`:volume`; `mode` applies to
+    the hydro/gravity grid path.)
+
 ## Environment Setup and Data Loading
 
 ### Package Configuration

--- a/src/functions/projection/projection.jl
+++ b/src/functions/projection/projection.jl
@@ -646,10 +646,24 @@ function los_cube(dataobject; quantity=:vlos, los=nothing, theta=nothing, phi=no
 
     qmin, qmax = qrange === nothing ? (isempty(qv) ? (0.0, 1.0) : extrema(qv)) : (float(qrange[1]), float(qrange[2]))
     dq = (qmax - qmin) / nbins
-    # guard a zero-spread quantity (single cell / constant field / qrange=[a,a]): route all samples
-    # to channel 1 instead of dividing by dq=0 (→ floor(NaN) InexactError).
-    chan = dq > 0 ? clamp.(floor.(Int, (qv .- qmin) ./ dq) .+ 1, 1, nbins) :
-                    ones(Int, length(qv))                            # NGP along the quantity axis
+    # bin index along the quantity axis. With an AUTO range (qrange===nothing) every sample lies in
+    # [qmin,qmax] by construction, so clamping only re-seats the single sample exactly at qmax. With
+    # an EXPLICIT qrange, samples outside [qmin,qmax] must be DROPPED (index 0 / >nbins, never selected
+    # by the k-loop below), NOT clamped onto the edge channels — clamping silently piles the wings of
+    # the distribution onto the first/last bin and corrupts the spectrum and any moment taken from it.
+    # A zero-spread quantity (single cell / constant field / qrange=[a,a]) routes all samples to
+    # channel 1 instead of dividing by dq=0 (→ floor(NaN) InexactError).
+    ndropped = 0
+    if dq > 0
+        chan = floor.(Int, (qv .- qmin) ./ dq) .+ 1
+        if qrange === nothing
+            chan = clamp.(chan, 1, nbins)
+        else
+            ndropped = count(c -> c < 1 || c > nbins, chan)
+        end
+    else
+        chan = ones(Int, length(qv))                            # NGP along the quantity axis
+    end
 
     cube = zeros(Float64, nx, ny, nbins)
     for k in 1:nbins
@@ -663,7 +677,12 @@ function los_cube(dataobject; quantity=:vlos, los=nothing, theta=nothing, phi=no
     end
     if verbose
         println("LOS cube  (quantity=", quantity, ", los=", round.(cam_w, digits=4), ")")
-        println("  $(nx)×$(ny) sky pixels × $(nbins) bins of $(quantity) ∈ [$(round(qmin,digits=3)),$(round(qmax,digits=3))] $q_unit"); println()
+        println("  $(nx)×$(ny) sky pixels × $(nbins) bins of $(quantity) ∈ [$(round(qmin,digits=3)),$(round(qmax,digits=3))] $q_unit")
+        if ndropped > 0
+            pct = round(100 * ndropped / length(chan), digits=1)
+            println("  note: $(ndropped) sample(s) ($(pct)%) outside qrange were dropped (not clamped onto the edge bins)")
+        end
+        println()
     end
     return LosCubeType(cube, collect(range(x0,x1,length=nx+1)), collect(range(y0,y1,length=ny+1)),
                        collect(range(qmin,qmax,length=nbins+1)), quantity, q_unit, weight,
@@ -747,6 +766,15 @@ end
 
 Moment-0/1/2 maps of a LOS cube `c`: the column `Σ` (summed weight, e.g. column mass), the
 weight-weighted **mean** of the binned quantity, and its **dispersion** — each a 2D array.
+
+!!! note "Discretization bias of the dispersion"
+    The moments are computed from the cube's **bin centres**, so the dispersion is biased high by
+    roughly the *Sheppard correction* σ²_true ≈ σ²_measured − Δ²/12, where Δ = bin width
+    (`step(c.bins)`). The bias is negligible once a feature spans several bins (Δ ≪ σ); it only
+    matters for under-resolved, near-delta distributions. To reduce it, build the cube with more
+    `nbins` or a tighter `qrange`. For an **unbinned** (bias-free) dispersion of a vector's LOS
+    component, use [`los_component`](@ref)`(...; dispersion=true)`, which accumulates the moments
+    from the continuous per-cell samples directly.
 """
 function los_moments(c::LosCubeType)
     cube = c.cube; nx, ny, nb = size(cube)

--- a/src/functions/projection/projection_particles.jl
+++ b/src/functions/projection/projection_particles.jl
@@ -21,6 +21,29 @@
 #     return select( filter( p-> spt( parttypes, p.id), data, select=(:id, var)), var )
 # end
 
+# Convert `parttypes` (e.g. [:stars], [:dm]) into a boolean particle selection that is folded into the
+# tested `mask=` path of projection (histogram weights are multiplied by the :mask column, zeroing
+# excluded particles — works for both the axis-aligned and the off-axis routines). Family-aware:
+# RAMSES new format uses :family with 1=DM, 2=star; legacy outputs fall back to :birth (≠0 ⇒ star,
+# ==0 ⇒ DM). Returns `nothing` for [:all] or [:stars,:dm] (no filtering). Errors loudly on an
+# unsupported request rather than silently projecting all particles.
+function _parttype_select(dataobject::PartDataType, parttypes::Array{Symbol,1})
+    (isempty(parttypes) || in(:all, parttypes)) && return nothing
+    want_star = in(:stars, parttypes); want_dm = in(:dm, parttypes)
+    (want_star || want_dm) || throw(ArgumentError("projection parttypes=$(parttypes) unsupported; use [:all], [:stars], or [:dm]."))
+    (want_star && want_dm) && return nothing
+    cols = colnames(dataobject.data)
+    if in(:family, cols)
+        fam = select(dataobject.data, :family)
+        return want_star ? (fam .== 2) : (fam .== 1)
+    elseif in(:birth, cols)
+        b = select(dataobject.data, :birth)
+        return want_star ? (b .!= 0) : (b .== 0)
+    else
+        throw(ArgumentError("projection parttypes=$(parttypes) needs a :family or :birth column to separate stars from DM; this dataset has neither."))
+    end
+end
+
 
 
 """
@@ -549,6 +572,7 @@ function create_projection(   dataobject::PartDataType, vars::Array{Symbol,1};
         end
     end
     # ========================================================
+    weighting in (:mass, :volume) || throw(ArgumentError("projection (particles): unsupported weighting=$(weighting); use :mass (default) or :volume."))
     if weighting == :mass
         use_sd_map = Mera.checkformaps(selected_vars, ranglecheck)
         # only add :sd if there are also other variables than in ranglecheck
@@ -569,6 +593,21 @@ function create_projection(   dataobject::PartDataType, vars::Array{Symbol,1};
 
     # Off-axis branch (arbitrary line of sight). The axis-aligned histogram path below
     # is left unchanged; it runs whenever no off-axis specifier is given.
+
+    # parttypes (stars/dm) → boolean selection, combined with any user mask and routed through the
+    # tested :mask machinery (axis-aligned) or the `sel` clip (off-axis). Previously `parttypes` was
+    # accepted but never read, so projection(part, :sd, parttypes=[:stars]) silently returned the
+    # all-particle map. Done here (before the off-axis dispatch) so both paths honour it.
+    ptsel = _parttype_select(dataobject, parttypes)
+    if ptsel !== nothing
+        if length(mask) > 1
+            length(mask) == length(ptsel) || error("[Mera] ", now(), " : array-mask length: $(length(mask)) does not match with data-table length: $(length(ptsel))")
+            mask = collect(Bool, mask) .& ptsel
+        else
+            mask = ptsel
+        end
+    end
+
     if is_offaxis(los=los, theta=theta, phi=phi, inclination=inclination, azimuth=azimuth, position_angle=position_angle, direction=direction)
         return projection_offaxis_particles(dataobject, selected_vars, units, res, weighting,
                                             ranges, data_centerm, range_unit, mask,
@@ -860,28 +899,12 @@ function create_projection(   dataobject::PartDataType, vars::Array{Symbol,1};
                         maps_unit[Symbol( string(i_var)  )] = unit_name
                         maps_mode[Symbol( string(i_var)  )] = :volume_weighted
                     end
-                elseif mode == :sum
-                    if length(mask) == 1
-                        h = fit(Histogram, (select(filtered_data, var_a) ,
-                                            select(filtered_data, var_b) ),
-                                            weights( getvar(dataobject, i_var, filtered_db=filtered_data, center=data_centerm, direction=direction, ref_time=ref_time)  ),
-                                            closed=closed,
-                                            (newrange1, newrange2) )
-                    else
-                        h = fit(Histogram, (select(filtered_data, var_a) ,
-                                            select(filtered_data, var_b) ),
-                                            weights( getvar(dataobject, i_var, filtered_db=filtered_data, center=data_centerm, direction=direction, ref_time=ref_time) .* select(filtered_data, :mask)  ),
-                                            closed=closed,
-                                            (newrange1, newrange2) )
-                    end
-                    selected_unit, unit_name= getunit(dataobject, i_var, selected_vars, units, uname=true)
-                    if selected_unit != 1.
-                        maps[Symbol(i_var)] = h.weights .* selected_unit
-                    else
-                        maps[Symbol(i_var)] = h.weights
-                    end
-                    maps_unit[Symbol( string(i_var)  )] = unit_name
-                    maps_mode[Symbol( string(i_var)  )] = :sum
+                else
+                    # particle projection only supports weighting=:mass or :volume. The former code
+                    # had an `elseif mode == :sum` branch here, but particle projection has no `mode`
+                    # kwarg, so `mode` was undefined: any other weighting threw UndefVarError(:mode),
+                    # which the surrounding try/catch swallowed into a silent NaN map. Fail clearly.
+                    throw(ArgumentError("projection (particles): unsupported weighting=$(weighting); use :mass (default) or :volume."))
                 end
             catch e
                 push!(failed_projection_vars, i_var)
@@ -1087,27 +1110,28 @@ function projection_offaxis_particles(dataobject, selected_vars, units, res, wei
         length(mask) == npart || error("[Mera]: mask length $(length(mask)) ≠ particle count $npart")
         sel = collect(Bool.(mask))
     end
-    full_z = (ranges[5] == 0.0 && ranges[6] == 1.0)
-    if !full_z
-        halfdepth = (ranges[6] - ranges[5]) * boxlen / 2
-        sel = sel .& (abs.(z_cam) .<= halfdepth)
-    end
+    # subregion clip on WORLD coords (px,py,pz about the sub-box-centre pivot), NOT the rotated camera
+    # coords: clipping a rotated coord (x_cam/y_cam/z_cam) against an axis-aligned half-extent drops
+    # in-box corner particles and silently loses mass (the same bug fixed on the hydro path). Skip an
+    # axis whose requested range already covers the loaded data (dataobject.ranges) — no extra crop.
+    dr = dataobject.ranges; tol = 1e-10
+    full_x = ranges[1] <= dr[1] + tol && ranges[2] >= dr[2] - tol
+    full_y = ranges[3] <= dr[3] + tol && ranges[4] >= dr[4] - tol
+    full_z = ranges[5] <= dr[5] + tol && ranges[6] >= dr[6] - tol
+    full_x || (sel = sel .& (abs.(px) .<= (ranges[2]-ranges[1]) * boxlen / 2))
+    full_y || (sel = sel .& (abs.(py) .<= (ranges[4]-ranges[3]) * boxlen / 2))
+    full_z || (sel = sel .& (abs.(pz) .<= (ranges[6]-ranges[5]) * boxlen / 2))
 
     pixsize = boxlen / res
-    full_xy = (ranges[1] == 0.0 && ranges[2] == 1.0 && ranges[3] == 0.0 && ranges[4] == 1.0)
-    if full_xy && any(sel)
+    # camera-plane extent always auto-fits the rotated footprint of the KEPT particles (+1 px pad),
+    # so every selected particle lands on the grid and the total is conserved (matches the hydro path).
+    if any(sel)
         pad = pixsize
         x0 = minimum(@view x_cam[sel]) - pad; x1 = maximum(@view x_cam[sel]) + pad
         y0 = minimum(@view y_cam[sel]) - pad; y1 = maximum(@view y_cam[sel]) + pad
-    elseif full_xy
-        # nothing selected: emit an empty map spanning the box instead of crashing
+    else
         half = boxlen / 2
         x0, x1, y0, y1 = -half, half, -half, half
-    else
-        hx = (ranges[2]-ranges[1]) * boxlen / 2
-        hy = (ranges[4]-ranges[3]) * boxlen / 2
-        x0, x1, y0, y1 = -hx, hx, -hy, hy
-        sel = sel .& (x_cam .>= x0) .& (x_cam .<= x1) .& (y_cam .>= y0) .& (y_cam .<= y1)
     end
     nx = max(1, round(Int, (x1 - x0) / pixsize))
     ny = max(1, round(Int, (y1 - y0) / pixsize))

--- a/test/06_projections.jl
+++ b/test/06_projections.jl
@@ -2254,4 +2254,78 @@ end
         end
     end
 
+    # ========================================================================
+    # Particle projection: parttypes selection + off-axis subregion clip
+    # ========================================================================
+    # Regression coverage for three silent-wrong-answer bugs fixed together:
+    #   (1) `parttypes` was accepted but never read -> projection(part, :sd,
+    #       parttypes=[:stars]) returned the byte-identical all-particle map.
+    #   (2) the off-axis particle clip cropped on ROTATED camera coords against
+    #       axis-aligned half-extents -> a tilted subregion silently lost mass.
+    #   (3) an unsupported `weighting` fell into a dead `mode==:sum` branch that
+    #       referenced an undefined `mode` and was swallowed into a NaN map.
+    @testset "Particle parttypes & off-axis subregion" begin
+        ds_p = DATASETS[:spiral_ugrid]
+        if !isdir(ds_p.path) || !ds_p.has_particles
+            @test_skip "spiral_ugrid particles not available"
+        else
+            part = getparticles(getinfo(ds_p.output, ds_p.path, verbose=false),
+                                 verbose=false, show_progress=false)
+            cols = propertynames(part.data.columns)
+            bl   = part.boxlen
+
+            @testset "parttypes splits stars vs DM (axis-aligned)" begin
+                m_all  = projection(part, :sd, verbose=false, show_progress=false)
+                m_star = projection(part, :sd, parttypes=[:stars], verbose=false, show_progress=false)
+                m_dm   = projection(part, :sd, parttypes=[:dm],    verbose=false, show_progress=false)
+                tall, tstar, tdm = sum(m_all.maps[:sd]), sum(m_star.maps[:sd]), sum(m_dm.maps[:sd])
+                # stars + DM partition the whole population (mass conserved)…
+                @test isapprox(tstar + tdm, tall; rtol=1e-6)
+                # …and each subset is a STRICT subset (the old bug returned the all map)
+                @test !isapprox(tstar, tall; rtol=1e-3)
+                @test !isapprox(tdm,   tall; rtol=1e-3)
+                @test tstar > 0 && tdm > 0
+                # cross-check the split totals against the raw particle masses. The :sd grid drops a
+                # few particles exactly on the box edge slightly differently per subset, so this
+                # agreement is at the histogram-discretization level (~1e-3), not bit-exact — that is
+                # still far tighter than the old bug, which gave tstar/tall == 1.
+                mass = getvar(part, :mass)
+                if :family in cols
+                    fam = part.data.columns.family
+                    @test isapprox(tstar / tall, sum(mass[fam .== 2]) / sum(mass); rtol=2e-3)
+                end
+                # [:stars,:dm] together == all (no filtering)
+                m_both = projection(part, :sd, parttypes=[:stars,:dm], verbose=false, show_progress=false)
+                @test isapprox(sum(m_both.maps[:sd]), tall; rtol=1e-10)
+            end
+
+            @testset "parttypes also honoured off-axis" begin
+                los = [0.0, 0.3, 0.95]
+                oa_all  = projection(part, :sd, los=los, verbose=false, show_progress=false)
+                oa_star = projection(part, :sd, los=los, parttypes=[:stars], verbose=false, show_progress=false)
+                oa_dm   = projection(part, :sd, los=los, parttypes=[:dm],    verbose=false, show_progress=false)
+                @test !isapprox(sum(oa_star.maps[:sd]), sum(oa_all.maps[:sd]); rtol=1e-3)
+                @test isapprox(sum(oa_star.maps[:sd]) + sum(oa_dm.maps[:sd]),
+                               sum(oa_all.maps[:sd]); rtol=1e-6)
+            end
+
+            @testset "off-axis subregion conserves mass (world-space clip)" begin
+                mass = getvar(part, :mass); x = getvar(part, :x); y = getvar(part, :y)
+                # tilted line of sight + a sub-box in x,y: every particle inside the WORLD box
+                # must land on the map (the old rotated-coord clip dropped corner particles).
+                incube = (x .>= 0.3bl) .& (x .<= 0.7bl) .& (y .>= 0.3bl) .& (y .<= 0.7bl)
+                m_enc  = sum(mass[incube])
+                oa = projection(part, :sd, los=[0.2, 0.0, 0.98],
+                                xrange=[0.3, 0.7], yrange=[0.3, 0.7],
+                                verbose=false, show_progress=false)
+                @test isapprox(sum(oa.maps[:sd]) * oa.pixsize^2, m_enc; rtol=1e-6)
+            end
+
+            @testset "unsupported weighting errors clearly (no silent NaN)" begin
+                @test_throws ArgumentError projection(part, :sd, weighting=:bogus,
+                                                      verbose=false, show_progress=false)
+            end
+        end
+    end
+
 end

--- a/test/36_offaxis_features_tests.jl
+++ b/test/36_offaxis_features_tests.jl
@@ -28,6 +28,26 @@ end
         @test I2 ≈ I                                                    # mask=all equals full
     end
 
+    @testset "LOS cube: explicit qrange drops out-of-range samples (no edge pile-up)" begin
+        # Regression: an explicit qrange used to CLAMP out-of-range samples onto the first/last
+        # channel, piling the wings of the distribution onto the edge bins and corrupting the
+        # spectrum. They must be DROPPED instead. A narrow qrange must therefore hold STRICTLY less
+        # total than the auto-range cube, and the edge channels must not balloon.
+        win = (direction=:edgeon, center=[:bc], xrange=[-15,15], yrange=[-15,15], range_unit=:kpc,
+               pxsize=[1.0,:kpc], nv=60, v_unit=:km_s)
+        full   = velocity_cube(gas; win..., verbose=false)                       # auto range
+        vmax   = maximum(abs.(extrema(full.bins)))
+        narrow = velocity_cube(gas; win..., vrange=[-vmax/3, vmax/3], verbose=false)
+        @test sum(narrow.cube) < sum(full.cube)                                   # wings genuinely dropped
+        # edge channels of the narrow cube must not collect the dropped wings:
+        Σnar  = dropdims(sum(narrow.cube, dims=(1,2)), dims=(1,2))                # per-channel total
+        @test Σnar[1]   <= maximum(Σnar)                                          # first bin not a spike
+        @test Σnar[end] <= maximum(Σnar)                                          # last  bin not a spike
+        # a generous qrange that brackets all data keeps everything (== auto range total)
+        wide = velocity_cube(gas; win..., vrange=[-vmax*2, vmax*2], verbose=false)
+        @test isapprox(sum(wide.cube), sum(full.cube); rtol=1e-9)
+    end
+
     @testset "cubes/los_component support hole-free :overlap binning" begin
         # the footprint deposit (:overlap) works in cubes too: conserves the total AND fills the
         # cell footprints (no centre-deposit holes), unlike the default :cic.


### PR DESCRIPTION
Remediation of the projection expert-panel findings #1–#5 (correctness + docs).

## Correctness (silent-wrong-answer fixes)
1. **`parttypes` was accepted but never read.** `projection(part, :sd, parttypes=[:stars])` returned the byte-identical all-particle map. Now converted to a boolean particle selection (family-aware: 1=DM, 2=star; legacy `:birth` fallback) and routed through the proven `mask=` machinery, so both the axis-aligned and off-axis paths honour it. Errors loudly on an unsupported request instead of projecting everything.
2. **Off-axis particle subregion clip.** The off-axis path clipped on *rotated* camera coords against axis-aligned half-extents, so a tilted `xrange`/`yrange` subregion silently dropped corner particles (mass loss). Now clips on **world** coords (px,py,pz) with a covers-loaded-data test, mirroring the hydro fix; the camera extent auto-fits the kept footprint. Verified mass-conserving to machine precision on a tilted LOS.
3. **Dead `mode==:sum` branch.** Particle projection has no `mode` kwarg, so an unsupported `weighting` fell into `elseif mode == :sum`, threw `UndefVarError(:mode)`, and the surrounding try/catch swallowed it into a NaN map. Replaced with an up-front clear `ArgumentError` on bad `weighting`.
4. **LOS-cube `qrange` clamping.** An explicit `qrange` used to `clamp` out-of-range samples onto the first/last channel, piling the distribution's wings onto the edge bins. Now out-of-range samples are **dropped** (auto-range still clamps the single qmax-edge sample), with a verbose note of how many were dropped.

## Docs
5. `los_moments` docstring: note on the **Sheppard** discretization bias of the binned dispersion (σ²≈σ²_meas − Δ²/12) and the unbiased `los_component(...; dispersion=true)` route.
6. `06_hydro_Projection.md`: an **intensive vs. extensive** concept table and a `mode=:standard` vs `mode=:sum` note.

## Tests
- `test/06_projections.jl`: new "Particle parttypes & off-axis subregion" testset — stars/DM partition the population and are strict subsets; parttypes honoured off-axis; tilted off-axis subregion conserves mass; unsupported weighting throws.
- `test/36_offaxis_features_tests.jl`: new LOS-cube qrange-drop testset — a narrow `qrange` holds strictly less total than auto-range with no edge pile-up; a wide range keeps everything.

Focused suites (`06`, `36`) green; docs build clean.