### PR TITLE
Covering-grid panel remediation: type guard + cleanup + tests/docs

### DIFF
--- a/docs/src/covering_grid.md
+++ b/docs/src/covering_grid.md
@@ -8,6 +8,13 @@ version (a fixed-resolution buffer through a plane).
 Use it to feed analyses that need a regular grid: power spectra, FFTs, structure functions, volume
 rendering / VTK export, machine-learning inputs, or simple `array`-style indexing.
 
+!!! note "Works on AMR cell data only"
+    `covering_grid` and `slice` operate on the **AMR cell** datasets — hydro ([`gethydro`](@ref)),
+    gravity ([`getgravity`](@ref)), and radiative transfer ([`getrt`](@ref)) — which carry cell
+    indices and refinement levels. They are **not** defined for particles ([`getparticles`](@ref),
+    which are point masses, not cells) or clumps; passing one raises a clear `MethodError`. To grid
+    particles, deposit them with [`projection`](@ref) instead.
+
 !!! warning "Size it first — a uniform grid can be far larger than the AMR data"
     AMR stores cells only where the simulation refined; a covering grid fills **every** cell at the
     target level. Resampling a sparsely-refined region to its finest level can blow up the cell count
@@ -63,7 +70,10 @@ sl[:rho]                       # a 2-D array (single-cell-thick, non-integrated)
 ```
 
 `slice_pos` is in `slice_unit` (`:standard` ⇒ a fraction of the box). The slice equals the
-corresponding layer of the full covering grid, but only that layer is built.
+corresponding layer of the full covering grid, but only that layer is built. `slice_axis` may be
+`:x`, `:y`, or `:z`; `grid[var]` is then a 2-D array. Note that `result.extent` keeps all six
+bounds `[x0,x1,y0,y1,z0,z1]` (the collapsed axis spans one cell), so you always know where the slice
+sits in 3-D.
 
 ![A mid-plane `slice` of the gas number density resampled to a uniform level-8 grid: the spiral
 structure and dense core are reproduced, with coarse de-refined regions shown as the larger

--- a/src/functions/covering_grid.jl
+++ b/src/functions/covering_grid.jl
@@ -4,6 +4,7 @@
 #  A "covering grid" (yt term) / fixed-resolution buffer (FRB) turns the sparse AMR leaf
 #  cells into a dense, uniform Nx×Ny×Nz array at a chosen level — every output cell sampled,
 #  not integrated (unlike `projection`). `slice` is the 2-D single-layer FRB.
+#  AMR cell data only (hydro/gravity/RT, which carry :cx/:cy/:cz + :level); not particles/clumps.
 #
 #  Resampling is volume-conservative:
 #    * a leaf coarser than the target level (ℓ ≤ L) is **replicated** to fill the (2^{L-ℓ})³
@@ -33,7 +34,7 @@ struct CoveringGridResult
     pos_unit::Symbol
     ranges::Vector{Float64}        # normalized [0,1] box actually covered
     slice_axis::Union{Nothing,Symbol}
-    info
+    info::InfoType
 end
 Base.getindex(c::CoveringGridResult, v::Symbol) = c.grid[v]
 Base.keys(c::CoveringGridResult) = keys(c.grid)
@@ -135,9 +136,10 @@ function _covering_core(obj, vars::Vector{Symbol}, units::Vector{Symbol}, L::Int
     nv = length(vars)
     peak = prod(dims) * sizeof(Float64) * (nv + 1)
     if peak > max_bytes
-        est = covering_grid_memory(obj, vars; lmax=L, verbose=false)   # dims via full box differ; recompute below
-        error("covering_grid would need ~$(_human_bytes(peak)) (peak) for dims $(dims) × $(nv) var(s), " *
-              "above max_bytes=$(_human_bytes(max_bytes)). Reduce lmax, narrow the range, or raise max_bytes.")
+        ncells = prod(dims); amr = length(obj.data)
+        error("covering_grid would need ~$(_human_bytes(peak)) (peak) for dims $(dims) = $(ncells) cells × $(nv) var(s)" *
+              " — a ×$(round(ncells/amr, sigdigits=4)) blow-up over the $(amr) AMR cells — above max_bytes=" *
+              "$(_human_bytes(max_bytes)). Reduce lmax, narrow the range, or raise max_bytes.")
     end
     cxs = select(obj.data, :cx); cys = select(obj.data, :cy); czs = select(obj.data, :cz)
     lvls = in(:level, propertynames(obj.data.columns)) ? select(obj.data, :level) : fill(obj.lmax, length(cxs))
@@ -164,15 +166,22 @@ end
 
 _axis_dim(ax::Symbol) = ax === :x ? 1 : ax === :y ? 2 : 3
 
+# covering_grid/slice operate on AMR CELL data only (these carry :cx/:cy/:cz cell indices and :level).
+# Particles (point positions :x/:y/:z, no cell indices) and clumps (no :lmax / no cells) are excluded so
+# such calls fail with a clear MethodError at the call site instead of a cryptic column/field error deep
+# inside the core (mirrors how `projection` dispatches on the data type).
+const _CGCellData = Union{HydroDataType, GravDataType, RtDataType}
+
 """
     covering_grid(obj, var, [unit]; lmax=obj.lmax, center=[0.,0.,0.],
                   xrange=[missing,missing], yrange=[missing,missing], zrange=[missing,missing],
                   range_unit=:standard, max_bytes=4e9, pos_unit=:standard, verbose=true) -> CoveringGridResult
 
-Resample the AMR data onto a **uniform Nx×Ny×Nz grid** at refinement level `lmax` over the (optional)
-sub-box — every output cell sampled (not integrated). `var` may be a `Symbol` or a vector; `unit`
-likewise (defaults to code units). Coarse leaves are replicated, fine leaves volume-averaged; output
-cells outside the data are `NaN`.
+Resample **AMR cell data** (`HydroDataType`, `GravDataType`, or `RtDataType`) onto a **uniform
+Nx×Ny×Nz grid** at refinement level `lmax` over the (optional) sub-box — every output cell sampled
+(not integrated). `var` may be a `Symbol` or a vector; `unit` likewise (defaults to code units).
+Coarse leaves are replicated, fine leaves volume-averaged; output cells outside the data are `NaN`.
+Particles and clumps are not AMR cells and raise a `MethodError` (use [`projection`](@ref) for particles).
 
 A uniform grid is dense and can be far larger than the AMR data — call [`covering_grid_memory`](@ref)
 first; this errors rather than allocate past `max_bytes`.
@@ -184,10 +193,10 @@ cg  = covering_grid(gas, [:rho, :T], [:nH, :K]; lmax=8) # then build
 cg[:rho]                                                # the 3-D array
 ```
 """
-covering_grid(obj, var::Symbol, unit::Symbol=:standard; kwargs...) = covering_grid(obj, [var], [unit]; kwargs...)
-covering_grid(obj, vars::AbstractVector{Symbol}; kwargs...) =
+covering_grid(obj::_CGCellData, var::Symbol, unit::Symbol=:standard; kwargs...) = covering_grid(obj, [var], [unit]; kwargs...)
+covering_grid(obj::_CGCellData, vars::AbstractVector{Symbol}; kwargs...) =
     covering_grid(obj, vars, fill(:standard, length(vars)); kwargs...)
-function covering_grid(obj, vars::AbstractVector{Symbol}, units::AbstractVector{Symbol};
+function covering_grid(obj::_CGCellData, vars::AbstractVector{Symbol}, units::AbstractVector{Symbol};
                        lmax::Int=obj.lmax, center=[0.,0.,0.], xrange=[missing,missing],
                        yrange=[missing,missing], zrange=[missing,missing], range_unit::Symbol=:standard,
                        max_bytes::Real=4e9, pos_unit::Symbol=:standard, verbose::Bool=true)
@@ -212,9 +221,9 @@ sl = slice(gas, :rho, :nH; slice_axis=:z, slice_pos=0.5)   # mid-plane n_H map
 sl[:rho]                                                    # 2-D array
 ```
 """
-slice(obj, var::Symbol, unit::Symbol=:standard; kwargs...) = slice(obj, [var], [unit]; kwargs...)
-slice(obj, vars::AbstractVector{Symbol}; kwargs...) = slice(obj, vars, fill(:standard, length(vars)); kwargs...)
-function slice(obj, vars::AbstractVector{Symbol}, units::AbstractVector{Symbol};
+slice(obj::_CGCellData, var::Symbol, unit::Symbol=:standard; kwargs...) = slice(obj, [var], [unit]; kwargs...)
+slice(obj::_CGCellData, vars::AbstractVector{Symbol}; kwargs...) = slice(obj, vars, fill(:standard, length(vars)); kwargs...)
+function slice(obj::_CGCellData, vars::AbstractVector{Symbol}, units::AbstractVector{Symbol};
                slice_axis::Symbol=:z, slice_pos::Real=0.5, slice_unit::Symbol=:standard,
                lmax::Int=obj.lmax, center=[0.,0.,0.], xrange=[missing,missing], yrange=[missing,missing],
                zrange=[missing,missing], range_unit::Symbol=:standard, max_bytes::Real=4e9,

--- a/test/41_covering_grid_tests.jl
+++ b/test/41_covering_grid_tests.jl
@@ -123,5 +123,64 @@
                                        zrange=[0.49,0.51], verbose=false)
             @test 0 < prod(est.dims) < 4096^3     # vastly smaller than the full-box level-12 grid (4096³)
         end
+
+        @testset "sub-box grid == the matching sub-array of the full grid (offset/g0 math)" begin
+            # A sub-box covering grid must equal the full-box grid restricted to the same global index
+            # window: output cell (kx) at global index (kx+g0x) sees the same AMR leaves regardless of the
+            # requested box. This empirically validates _grid_dims' g0 offset and the kernel's g0 subtraction
+            # for sub-boxes (the most subtle path, untested before).
+            L = gas.lmax - 1
+            xr = [0.25, 0.5]; yr = [0.5, 1.0]; zr = [0.0, 0.5]
+            full = covering_grid(gas, :rho; lmax=L, verbose=false)
+            sub  = covering_grid(gas, :rho; lmax=L, xrange=xr, yrange=yr, zrange=zr, verbose=false)
+            g0, dims = Mera._grid_dims([xr[1],xr[2], yr[1],yr[2], zr[1],zr[2]], L)
+            @test size(sub[:rho]) == dims
+            fx = (g0[1]+1):(g0[1]+dims[1]); fy = (g0[2]+1):(g0[2]+dims[2]); fz = (g0[3]+1):(g0[3]+dims[3])
+            @test isequal(sub[:rho], full[:rho][fx, fy, fz])     # isequal: NaNs compare equal
+        end
+
+        @testset "gravity data is supported (same AMR-cell path)" begin
+            grav = getgravity(info, verbose=false, show_progress=false)
+            cgg = covering_grid(grav, :epot; lmax=grav.lmax, verbose=false)
+            @test size(cgg[:epot]) == ntuple(_ -> 2^grav.lmax, 3)
+            cx = Int.(getvar(grav, :cx)); cy = Int.(getvar(grav, :cy)); cz = Int.(getvar(grav, :cz))
+            lev = getvar(grav, :level); ep = getvar(grav, :epot)
+            kfin = findfirst(==(grav.lmax), lev)
+            @test cgg[:epot][cx[kfin], cy[kfin], cz[kfin]] ≈ ep[kfin]   # finest leaf maps one-to-one
+        end
+
+        @testset "slice along :x and :y (dropdims / _axis_dim collapse)" begin
+            cg = covering_grid(gas, :rho, :nH; lmax=gas.lmax, verbose=false)
+            k = floor(Int, 0.5 * 2^gas.lmax) + 1
+            for ax in (:x, :y)
+                sl = slice(gas, :rho, :nH; slice_axis=ax, slice_pos=0.5, lmax=gas.lmax, verbose=false)
+                @test sl.slice_axis === ax
+                @test ndims(sl[:rho]) == 2 && length(sl.dims) == 2
+                expected = ax === :x ? cg[:rho][k, :, :] : cg[:rho][:, k, :]
+                @test isequal(sl[:rho], expected)
+            end
+        end
+
+        @testset "pos_unit scales extent/cellsize but not the data" begin
+            # the 1-code-length = 1-kpc test sims would mask a scaling bug, so compare :kpc vs :standard
+            # explicitly and assert the kpc factor is applied.
+            cgs = covering_grid(gas, :rho; lmax=6, verbose=false)                  # code units
+            cgk = covering_grid(gas, :rho; lmax=6, pos_unit=:kpc, verbose=false)   # physical kpc
+            s = gas.scale.kpc
+            @test cgk.pos_unit == :kpc
+            @test cgk.cellsize ≈ cgs.cellsize * s
+            @test cgk.extent   ≈ cgs.extent .* s
+            @test isequal(cgk[:rho], cgs[:rho])                                    # values unaffected
+        end
+
+        @testset "non-AMR data rejected with a clear MethodError" begin
+            if dc.has_clumps
+                cl = getclumps(info, verbose=false)
+                @test_throws MethodError covering_grid(cl, :mass, verbose=false)
+                @test_throws MethodError slice(cl, :mass, verbose=false)
+            else
+                @test_skip "no clump data in fixture"
+            end
+        end
     end
 end


### PR DESCRIPTION
Remediation of the covering_grid/slice expert-panel findings (panel score 8.0/10; 1 confirmed HIGH, the rest minor). All three tiers.

## Tier 1 — confirmed HIGH (input-type safety)
`covering_grid`/`slice` took an untyped `obj`, so calling them on a `PartDataType` threw a cryptic "column :cx not found" deep in the core, and on a `ClumpDataType` a `FieldError` while evaluating the default `lmax=obj.lmax`. Now all overloads dispatch on `Union{HydroDataType,GravDataType,RtDataType}` (a new `_CGCellData` alias) — non-AMR-cell data fails with a clear `MethodError` at the call site, matching how `projection` dispatches. Verified: particles/clumps → `MethodError`; hydro & gravity work.

## Tier 2 — robustness / cleanup
- Deleted the dead `est = covering_grid_memory(...)` call in `_covering_core` (its result was never read; the "recompute below" comment was stale).
- The `max_bytes` error now reports the **blow-up factor** and **AMR cell count** (computed only on the error path) so the user knows whether to lower `lmax` or narrow the range.
- Typed `CoveringGridResult.info::InfoType` (was bare).

## Tier 3 — tests + docs
New tests in `test/41_covering_grid_tests.jl` (13 added, 56 total green):
- **sub-box grid == matching sub-array of the full grid** — empirically validates the `_grid_dims` `g0` offset and the kernel's offset subtraction (the subtle sub-box path; settles the panel's rejected "_grid_dims volume-loss" debate).
- **gravity data** supported (same AMR-cell path, finest-leaf round-trip).
- **slice `:x` and `:y`** axes (exercises `dropdims`/`_axis_dim`).
- **`pos_unit` scaling** — `:kpc` vs `:standard` extent/cellsize (uses a non-`:standard` unit to dodge the 1-code-length=1-kpc masking).
- **non-AMR data rejected** with `MethodError`.

Docs (`docs/src/covering_grid.md` + docstrings): a "Works on AMR cell data only" note naming hydro/gravity/RT and excluding particles/clumps (→ use `projection` for particles), and a note that `extent` stays 6-element for slices.

Verified: package loads, focused suite green, docs build clean.