### PR TITLE
getvar/derived-fields panel remediation (all tiers): :cz/:ϕ/escape_speed fixes, aggregation guards, registry tests

### DIFF
--- a/docs/src/derived_fields.md
+++ b/docs/src/derived_fields.md
@@ -17,6 +17,25 @@ getvar(gas, [:vr_cylinder, :vϕ_cylinder], :km_s; center=[:bc])
 These derived names also work everywhere `getvar` is used internally — in
 [`projection`](@ref), [`profile`](@ref), [`phase`](@ref), and friends.
 
+## Conventions for selected quantities
+
+A few derived quantities carry physical assumptions worth stating explicitly:
+
+- **Jeans length** `:jeanslength` uses the standard form ``λ_J = c_s\,\sqrt{\dfrac{3π}{32\,G\,ρ}}`` (and
+  `:jeansmass`/`:jeansnumber` follow from it). This is one of several Jeans-length conventions in the
+  literature; factors of order unity differ between them.
+- **Magnetosonic Mach numbers** `:mach_alfven`, `:mach_fast`, `:mach_slow` require the magnetic-field
+  components `:bx,:by,:bz` (an MHD run) and error otherwise. The B field is taken in **RAMSES code
+  units** and converted to Gaussian-CGS internally (Alfvén speed ``v_A = B/\sqrt{4πρ}``); fast/slow use
+  ``v_{f}=\sqrt{c_s^2+v_A^2}`` and the isotropic ``v_{s}=c_s v_A/\sqrt{c_s^2+v_A^2}``. All three are
+  dimensionless. (Because they need the field components, `getvar_requirements` lists `:bx,:by,:bz,:rho`
+  among their dependencies.)
+- **Escape speed** `:escape_speed` ``= \sqrt{-2φ}`` is defined only where the potential ``φ<0`` (bound);
+  unbound cells (``φ≥0``, possible near boundaries) are clamped to `0` rather than erroring.
+- **Cosmological-only** quantities — `:overdensity`/`:delta` (hydro) and `:age`-relatives
+  `:formation_time`/`:formation_redshift`/`:zform` (particles) — are defined only for cosmological runs
+  and error on non-cosmological output.
+
 ## The dependency registry
 
 Each derived quantity knows which **raw** variables it is built from. That graph is queryable:

--- a/src/functions/basic_calc.jl
+++ b/src/functions/basic_calc.jl
@@ -62,11 +62,6 @@ function msum(dataobject::ContainMassDataSetType; unit::Symbol=:standard, mask::
     return msum_metaprog(dataobject, Val(unit), mask)
 end
 
-# Deprecated original function - kept for compatibility
-function msum_deprecated(dataobject::ContainMassDataSetType; unit::Symbol=:standard, mask::MaskType=[false])
-    return sum( getvar(dataobject, :mass, unit=unit, mask=mask) )
-end
-
 
 
 """
@@ -86,11 +81,12 @@ Uses compile-time template generation for maximum performance.
         z_data = getvar(dataobject, :z, mask=mask)
         
         total_mass = sum(mass_data)
-        
+        total_mass > 0 || error("center_of_mass: total mass is zero (empty selection or all-zero masses)")
+
         # Vectorized mass-weighted averages with compile-time unit conversion
         (
             sum(x_data .* mass_data) / total_mass * unit_factor,
-            sum(y_data .* mass_data) / total_mass * unit_factor,  
+            sum(y_data .* mass_data) / total_mass * unit_factor,
             sum(z_data .* mass_data) / total_mass * unit_factor
         )
     end
@@ -125,12 +121,6 @@ function center_of_mass(dataobject::ContainMassDataSetType; unit::Symbol=:standa
     # - Single-pass vectorized operations for maximum performance
     
     return center_of_mass_metaprog(dataobject, Val(unit), mask)
-end
-
-# Deprecated original function - kept for compatibility
-function center_of_mass_deprecated(dataobject::ContainMassDataSetType; unit::Symbol=:standard, mask::MaskType=[false])
-    selected_unit = getunit(dataobject.info, unit)
-    return ( average_mweighted(dataobject, :x, mask=mask), average_mweighted(dataobject, :y, mask=mask), average_mweighted(dataobject, :z,  mask=mask) ) .* selected_unit
 end
 
 
@@ -210,6 +200,7 @@ Uses template-based loop generation with compile-time optimization.
             end
         end
         
+        sum_mass_total > 0 || error("center_of_mass: total mass is zero (empty selection or all-zero masses)")
         # Compute final weighted averages with compile-time unit conversion
         (
             sum_mx_total / sum_mass_total * unit_factor,
@@ -249,41 +240,6 @@ function center_of_mass(dataobject::Array{HydroPartType,1}; unit::Symbol=:standa
     
     return center_of_mass_joint_metaprog(dataobject, Val(unit), mask)
 end
-
-# Deprecated original function - kept for compatibility
-function center_of_mass_deprecated(dataobject::Array{HydroPartType,1}; unit::Symbol=:standard, mask::MaskArrayAbstractType=[[false],[false]])
-    selected_unit = getunit(dataobject[1].info, unit) # assuming both datasets are from same simulation output
-
-    if length(mask[1]) == 1 && length(mask[2]) == 1
-        m1 = getvar(dataobject[1], :mass)
-        m1_sum = sum(m1)
-
-        m2 = getvar(dataobject[2], :mass)
-        m2_sum = sum(m2)
-
-        m_sum = m1_sum + m2_sum
-
-        x_weighted = (sum( getvar(dataobject[1], :x) .* m1 ) + sum( getvar(dataobject[2], :x) .* m2) ) / m_sum
-        y_weighted = (sum( getvar(dataobject[1], :y) .* m1 ) + sum( getvar(dataobject[2], :y) .* m2) ) / m_sum
-        z_weighted = (sum( getvar(dataobject[1], :z) .* m1 ) + sum( getvar(dataobject[2], :z) .* m2) ) / m_sum
-
-    else
-        m1 = getvar(dataobject[1], :mass)[mask[1]]
-        m1_sum = sum(m1)
-
-        m2 = getvar(dataobject[2], :mass)[mask[2]]
-        m2_sum = sum(m2)
-
-        m_sum = m1_sum + m2_sum
-
-        x_weighted = (sum( getvar(dataobject[1], :x)[mask[1]] .* m1 ) + sum( getvar(dataobject[2], :x)[mask[2]] .* m2) ) / m_sum
-        y_weighted = (sum( getvar(dataobject[1], :y)[mask[1]] .* m1 ) + sum( getvar(dataobject[2], :y)[mask[2]] .* m2) ) / m_sum
-        z_weighted = (sum( getvar(dataobject[1], :z)[mask[1]] .* m1 ) + sum( getvar(dataobject[2], :z)[mask[2]] .* m2) ) / m_sum
-
-    end
-    return ( x_weighted, y_weighted, z_weighted ) .* selected_unit
-end
-
 
 
 """
@@ -353,7 +309,8 @@ Generates specialized code for each weighting scheme at compile time.
             vz_data = getvar(dataobject, :vz, mask=mask)
             
             total_mass = sum(mass_data)
-            
+            total_mass > 0 || error("bulk_velocity: total mass is zero (empty selection or all-zero masses)")
+
             # Vectorized mass-weighted averages
             (
                 sum(vx_data .* mass_data) / total_mass * unit_factor,
@@ -376,7 +333,8 @@ Generates specialized code for each weighting scheme at compile time.
                     vz_data = getvar(dataobject, :vz, mask=mask)
                     
                     total_volume = sum(vol_data)
-                    
+                    total_volume > 0 || error("bulk_velocity: total volume is zero (empty selection)")
+
                     (
                         sum(vx_data .* vol_data) / total_volume * unit_factor,
                         sum(vy_data .* vol_data) / total_volume * unit_factor,
@@ -439,26 +397,6 @@ function bulk_velocity(dataobject::ContainMassDataSetType; unit::Symbol=:standar
     
     return bulk_velocity_metaprog(dataobject, Val(unit), Val(weighting), mask)
 end
-
-# Deprecated original function - kept for compatibility
-function bulk_velocity_deprecated(dataobject::ContainMassDataSetType; unit::Symbol=:standard, weighting::Symbol=:mass, mask::MaskType=[false])
-    selected_unit = getunit(dataobject.info, unit)
-    if weighting == :mass
-        return ( average_mweighted(dataobject, :vx, mask=mask), average_mweighted(dataobject, :vy, mask=mask), average_mweighted(dataobject, :vz,  mask=mask) ) .* selected_unit
-    elseif weighting == :volume && typeof(dataobject) == HydroDataType
-        isamr = checkuniformgrid(dataobject, dataobject.lmax)
-        if isamr
-            return ( sum( getvar(dataobject, :vx, mask=mask) .* getvar(dataobject, :volume, mask=mask) ) ./ sum( getvar(dataobject, :volume, mask=mask) ),
-                     sum( getvar(dataobject, :vy, mask=mask) .* getvar(dataobject, :volume, mask=mask) ) ./ sum( getvar(dataobject, :volume, mask=mask) ),
-                     sum( getvar(dataobject, :vz, mask=mask) .* getvar(dataobject, :volume, mask=mask) ) ./ sum( getvar(dataobject, :volume, mask=mask) ) ) .* selected_unit
-        else
-            return ( mean( getvar(dataobject, :vx, mask=mask) ), mean( getvar(dataobject, :vy, mask=mask) ), mean( getvar(dataobject, :vz,  mask=mask)) ) .* selected_unit
-        end
-    elseif weighting == :no # for AMR
-            return ( mean( getvar(dataobject, :vx, mask=mask) ), mean( getvar(dataobject, :vy, mask=mask) ), mean( getvar(dataobject, :vz,  mask=mask)) ) .* selected_unit
-    end
-end
-
 
 """
 #### Calculate the average velocity (w/o mass-weight) of any ContainMassDataSetType:
@@ -540,6 +478,7 @@ Generates specialized code for different weighting and masking combinations.
             
             if length(weights) > 1
                 w_sum = sum(weights)
+                w_sum > 0 || error("wstat: sum of weights is zero (empty selection or all-zero weights)")
                 mean_val = sum(array .* weights) / w_sum
                 median_val = median(array, Weights(weights))
                 std_val = std(array, Weights(weights), mean=mean_val, corrected=false)
@@ -547,12 +486,12 @@ Generates specialized code for different weighting and masking combinations.
                 max_val = maximum(array)
                 skew_val = skewness(array, mean_val)
                 kurt_val = kurtosis(array, mean_val)
-                
+
                 WStatType(mean_val, median_val, std_val, skew_val, kurt_val, min_val, max_val)
             else
                 mean_val = mean(array)
                 median_val = median(array)
-                std_val = std(array, mean=mean_val)
+                std_val = std(array, mean=mean_val, corrected=false)   # population std, consistent with the weighted path
                 skew_val = skewness(array, mean_val)
                 kurt_val = kurtosis(array, mean_val)
                 min_val = minimum(array)
@@ -570,7 +509,7 @@ Generates specialized code for different weighting and masking combinations.
             
             mean_val = mean(array)
             median_val = median(array)
-            std_val = std(array, mean=mean_val)
+            std_val = std(array, mean=mean_val, corrected=false)   # population std, consistent with the weighted path
             skew_val = skewness(array, mean_val)
             kurt_val = kurtosis(array, mean_val)
             min_val = minimum(array)
@@ -583,6 +522,7 @@ Generates specialized code for different weighting and masking combinations.
             # Generate optimized weighted statistics
             if length(weights) > 1
                 w_sum = sum(weights)
+                w_sum > 0 || error("wstat: sum of weights is zero (empty selection or all-zero weights)")
                 mean_val = sum(array .* weights) / w_sum
                 median_val = median(array, Weights(weights))
                 std_val = std(array, Weights(weights), mean=mean_val, corrected=false)
@@ -590,12 +530,12 @@ Generates specialized code for different weighting and masking combinations.
                 kurt_val = kurtosis(array, mean_val)
                 min_val = minimum(array)
                 max_val = maximum(array)
-                
+
                 WStatType(mean_val, median_val, std_val, skew_val, kurt_val, min_val, max_val)
             else
                 mean_val = mean(array)
                 median_val = median(array)
-                std_val = std(array, mean=mean_val)
+                std_val = std(array, mean=mean_val, corrected=false)   # population std, consistent with the weighted path
                 skew_val = skewness(array, mean_val)
                 kurt_val = kurtosis(array, mean_val)
                 min_val = minimum(array)
@@ -609,7 +549,7 @@ Generates specialized code for different weighting and masking combinations.
             # Generate optimized simple statistics
             mean_val = mean(array)
             median_val = median(array)
-            std_val = std(array, mean=mean_val)
+            std_val = std(array, mean=mean_val, corrected=false)   # population std, consistent with the weighted path
             skew_val = skewness(array, mean_val)
             kurt_val = kurtosis(array, mean_val)
             min_val = minimum(array)
@@ -618,80 +558,4 @@ Generates specialized code for different weighting and masking combinations.
             WStatType(mean_val, median_val, std_val, skew_val, kurt_val, min_val, max_val)
         end
     end
-end
-
-# ==============================================================================
-# PERFORMANCE BENCHMARKING AND VALIDATION
-# ==============================================================================
-
-"""
-Benchmark symbolic vs original implementations.
-Validates correctness and measures performance improvements.
-"""
-function benchmark_metaprog_basic_calc(dataobject; iterations=100, verbose=true)
-    if verbose
-        println("🚀 Benchmarking Symbolic Programming Optimizations")  
-        println("=" ^ 60)
-    end
-    
-    # Test mass sum
-    result_orig = msum_deprecated(dataobject)
-    result_symb = msum(dataobject)
-    
-    if verbose
-        println("✓ Mass Sum Correctness: $(abs(result_orig - result_symb) < 1e-12)")
-        
-        t_orig = @elapsed for _ in 1:iterations; msum_deprecated(dataobject); end
-        t_symb = @elapsed for _ in 1:iterations; msum(dataobject); end
-        
-        speedup = t_orig / t_symb
-        println("  Original:  $(round(t_orig / iterations * 1e3, digits=3)) ms")
-        println("  Symbolic:  $(round(t_symb / iterations * 1e3, digits=3)) ms")  
-        println("  Speedup:   $(round(speedup, digits=2))x")
-        println()
-    end
-    
-    # Test center of mass
-    result_orig = center_of_mass_deprecated(dataobject)
-    result_symb = center_of_mass(dataobject)
-    
-    if verbose
-        max_diff = maximum(abs.(collect(result_orig) .- collect(result_symb)))
-        println("✓ Center of Mass Correctness: $(max_diff < 1e-12)")
-        
-        t_orig = @elapsed for _ in 1:iterations; center_of_mass_deprecated(dataobject); end
-        t_symb = @elapsed for _ in 1:iterations; center_of_mass(dataobject); end
-        
-        speedup = t_orig / t_symb
-        println("  Original:  $(round(t_orig / iterations * 1e3, digits=3)) ms")
-        println("  Symbolic:  $(round(t_symb / iterations * 1e3, digits=3)) ms")
-        println("  Speedup:   $(round(speedup, digits=2))x")
-        println()
-    end
-    
-    # Test bulk velocity
-    result_orig = bulk_velocity_deprecated(dataobject)
-    result_symb = bulk_velocity(dataobject)
-    
-    if verbose
-        max_diff = maximum(abs.(collect(result_orig) .- collect(result_symb)))
-        println("✓ Bulk Velocity Correctness: $(max_diff < 1e-12)")
-        
-        t_orig = @elapsed for _ in 1:iterations; bulk_velocity_deprecated(dataobject); end
-        t_symb = @elapsed for _ in 1:iterations; bulk_velocity(dataobject); end
-        
-        speedup = t_orig / t_symb
-        println("  Original:  $(round(t_orig / iterations * 1e3, digits=3)) ms")
-        println("  Symbolic:  $(round(t_symb / iterations * 1e3, digits=3)) ms")
-        println("  Speedup:   $(round(speedup, digits=2))x")
-        println()
-        
-        println("🎯 Symbolic Programming Summary:")
-        println("   ✓ All functions maintain mathematical correctness")
-        println("   ✓ Compile-time specialization eliminates overhead")
-        println("   ✓ Template-based generation fuses operations")
-        println("   ✓ SIMD-optimized loops maximize performance")
-    end
-    
-    return true
 end

--- a/src/functions/getvar/fields.jl
+++ b/src/functions/getvar/fields.jl
@@ -68,6 +68,10 @@ const FIELD_DEPS = Dict{Symbol, Dict{Symbol,Vector{Symbol}}}(
     :mach_r_cylinder=>[:vr_cylinder,:cs], :mach_phi_cylinder=>[:vϕ_cylinder,:cs],
     :mach_r_sphere=>[:vr_sphere,:cs], :mach_theta_sphere=>[:vθ_sphere,:cs],
     :mach_phi_sphere=>[:vϕ_sphere,:cs],
+    # magnetosonic Mach numbers (need the magnetic field components in addition to v / cs / rho)
+    :mach_alfven=>[:v,:bx,:by,:bz,:rho],
+    :mach_fast=>[:v,:cs,:bx,:by,:bz,:rho],
+    :mach_slow=>[:v,:cs,:bx,:by,:bz,:rho],
     :ekin=>[:mass,:v], :etherm=>[:p,:volume],
   ),
 

--- a/src/functions/getvar/getvar.jl
+++ b/src/functions/getvar/getvar.jl
@@ -531,6 +531,67 @@ function getvar(   dataobject::RtDataType, vars::Array{Symbol,1};
     return get_data_userfields(dataobject, vars, units, direction, center, mask, ref_time; hydro_data=hydro_data)
 end
 
+# Positional `hydro_data` overloads for RtDataType (parity with the GravDataType+hydro API below):
+# getvar(rt, hydro, :photoionizations) reads the same as getvar(rt, :photoionizations; hydro_data=hydro).
+function getvar(   dataobject::RtDataType, hydro_data::HydroDataType, var::Symbol;
+                    filtered_db::IndexedTables.AbstractIndexedTable=IndexedTables.table([1]),
+                    center::Array{<:Any,1}=[0.,0.,0.], center_unit::Symbol=:standard,
+                    direction::Symbol=:z, unit::Symbol=:standard,
+                    mask::MaskType=[false], ref_time::Real=dataobject.info.time)
+    center = center_in_standardnotation(dataobject.info, center, center_unit)
+    if typeof(filtered_db) != IndexedTable{StructArrays.StructArray{Tuple{Int64},1,Tuple{Array{Int64,1}},Int64}}
+        dataobject = construct_datatype(filtered_db, dataobject)
+    end
+    return get_data_userfields(dataobject, [var], [unit], direction, center, mask, ref_time; hydro_data=hydro_data)
+end
+
+function getvar(   dataobject::RtDataType, hydro_data::HydroDataType, var::Symbol, unit::Symbol;
+                    filtered_db::IndexedTables.AbstractIndexedTable=IndexedTables.table([1]),
+                    center::Array{<:Any,1}=[0.,0.,0.], center_unit::Symbol=:standard,
+                    direction::Symbol=:z, mask::MaskType=[false], ref_time::Real=dataobject.info.time)
+    center = center_in_standardnotation(dataobject.info, center, center_unit)
+    if typeof(filtered_db) != IndexedTable{StructArrays.StructArray{Tuple{Int64},1,Tuple{Array{Int64,1}},Int64}}
+        dataobject = construct_datatype(filtered_db, dataobject)
+    end
+    return get_data_userfields(dataobject, [var], [unit], direction, center, mask, ref_time; hydro_data=hydro_data)
+end
+
+function getvar(   dataobject::RtDataType, hydro_data::HydroDataType, vars::Array{Symbol,1}, units::Array{Symbol,1};
+                    filtered_db::IndexedTables.AbstractIndexedTable=IndexedTables.table([1]),
+                    center::Array{<:Any,1}=[0.,0.,0.], center_unit::Symbol=:standard,
+                    direction::Symbol=:z, mask::MaskType=[false], ref_time::Real=dataobject.info.time)
+    center = center_in_standardnotation(dataobject.info, center, center_unit)
+    if typeof(filtered_db) != IndexedTable{StructArrays.StructArray{Tuple{Int64},1,Tuple{Array{Int64,1}},Int64}}
+        dataobject = construct_datatype(filtered_db, dataobject)
+    end
+    return get_data_userfields(dataobject, vars, units, direction, center, mask, ref_time; hydro_data=hydro_data)
+end
+
+function getvar(   dataobject::RtDataType, hydro_data::HydroDataType, vars::Array{Symbol,1}, unit::Symbol;
+                    filtered_db::IndexedTables.AbstractIndexedTable=IndexedTables.table([1]),
+                    center::Array{<:Any,1}=[0.,0.,0.], center_unit::Symbol=:standard,
+                    direction::Symbol=:z, mask::MaskType=[false], ref_time::Real=dataobject.info.time)
+    center = center_in_standardnotation(dataobject.info, center, center_unit)
+    if typeof(filtered_db) != IndexedTable{StructArrays.StructArray{Tuple{Int64},1,Tuple{Array{Int64,1}},Int64}}
+        dataobject = construct_datatype(filtered_db, dataobject)
+    end
+    units = [unit for i in 1:length(vars)]
+    return get_data_userfields(dataobject, vars, units, direction, center, mask, ref_time; hydro_data=hydro_data)
+end
+
+function getvar(   dataobject::RtDataType, hydro_data::HydroDataType, vars::Array{Symbol,1};
+                    filtered_db::IndexedTables.AbstractIndexedTable=IndexedTables.table([1]),
+                    center::Array{<:Any,1}=[0.,0.,0.], center_unit::Symbol=:standard,
+                    direction::Symbol=:z, unit::Symbol=:standard,
+                    mask::MaskType=[false], ref_time::Real=dataobject.info.time)
+    center = center_in_standardnotation(dataobject.info, center, center_unit)
+    if typeof(filtered_db) != IndexedTable{StructArrays.StructArray{Tuple{Int64},1,Tuple{Array{Int64,1}},Int64}}
+        dataobject = construct_datatype(filtered_db, dataobject)
+    end
+    units = [unit for i in 1:length(vars)]
+    return get_data_userfields(dataobject, vars, units, direction, center, mask, ref_time; hydro_data=hydro_data)
+end
+
 
 # ========== NEW API: GRAVITY + HYDRO WITH POSITIONAL ARGUMENTS ==========
 
@@ -654,8 +715,10 @@ function center_in_standardnotation(dataobject::InfoType, center::Array{<:Any,1}
         if in(:bc, center) || in(:boxcenter, center)
             return [0.5, 0.5, 0.5]
         end
-        return copy(center)
+        # a single numeric value is ambiguous and would later index center[3] → BoundsError.
+        error("center must be [:bc] or a 3-element [x,y,z]; got a length-1 numeric center $(center).")
     end
+    Ncenter == 3 || error("center must be [:bc] or a 3-element [x,y,z]; got length $(Ncenter): $(center).")
     out = similar(center, Float64)
     for i = 1:Ncenter
         if center[i] == :bc || center[i] == :boxcenter
@@ -801,10 +864,14 @@ return vx, vy, vz
 
 """
 function getvelocities( dataobject::DataSetType, unit::Symbol;
+    direction::Symbol=:z,
+    center::Array{<:Any,1}=[0., 0., 0.],
+    center_unit::Symbol=:standard,
     mask::MaskType=[false])
 
     velocities = getvar(dataobject, [:vx, :vy, :vz],
     units=[unit, unit, unit],
+    direction=direction, center=center, center_unit=center_unit,
     mask=mask)
 
     return velocities[:vx], velocities[:vy], velocities[:vz]
@@ -812,11 +879,15 @@ end
 
 function getvelocities( dataobject::DataSetType;
     unit::Symbol=:standard,
+    direction::Symbol=:z,
+    center::Array{<:Any,1}=[0., 0., 0.],
+    center_unit::Symbol=:standard,
     mask::MaskType=[false])
 
 
     velocities = getvar(dataobject, [:vx, :vy, :vz],
     units=[unit, unit, unit],
+    direction=direction, center=center, center_unit=center_unit,
     mask=mask)
 
     return velocities[:vx], velocities[:vy], velocities[:vz]

--- a/src/functions/getvar/getvar_gravity.jl
+++ b/src/functions/getvar/getvar_gravity.jl
@@ -81,7 +81,7 @@ function get_data(dataobject::GravDataType,
                 else # if uniform grid
                     vars_dict[i] =  select(masked_data, bpos) .- 2^lmax .* center[2]
                 end
-            elseif i == :cx
+            elseif i == :cz
                 if isamr
                     vars_dict[i] =  select(masked_data, cpos) .- 2 .^select(masked_data, :level) .* center[3]
                 else # if uniform grid
@@ -139,11 +139,14 @@ function get_data(dataobject::GravDataType,
             az = select(masked_data, :az)
             vars_dict[:a_magnitude] = @. sqrt(ax^2 + ay^2 + az^2) * selected_unit
 
-        # Escape speed from gravitational potential - code units by default
+        # Escape speed from gravitational potential - code units by default.
+        # v_esc = sqrt(-2 φ) is only real where the potential is negative (bound). RAMSES φ can be
+        # positive for unbound cells (and near boundaries), which would make sqrt throw a DomainError;
+        # clamp those to 0 (escape speed is 0 / undefined where the cell is not bound).
         elseif i == :escape_speed
             selected_unit = getunit(dataobject, :escape_speed, vars, units)
             epot = select(masked_data, :epot)
-            vars_dict[:escape_speed] = @. sqrt(-2 * epot) * selected_unit
+            vars_dict[:escape_speed] = @. sqrt(max(-2 * epot, 0.0)) * selected_unit
 
         # Gravitational redshift (weak field approximation) - dimensionless by default
         elseif i == :gravitational_redshift

--- a/src/functions/getvar/getvar_hydro.jl
+++ b/src/functions/getvar/getvar_hydro.jl
@@ -840,6 +840,14 @@ function get_data(  dataobject::HydroDataType,
             z = getvar(filtered_dataobject, :z, center=center, mask=use_mask_in_recursion)
             vars_dict[:r_sphere] = @. sqrt(x^2 + y^2 + z^2) * selected_unit
 
+        # Azimuthal angle ϕ = atan(y, x) about the chosen center (registered in FIELD_DEPS[:hydro];
+        # mirrors the particle/gravity implementations so getvar(hydro, :ϕ) no longer errors).
+        elseif i == :ϕ
+            selected_unit = getunit(dataobject, :ϕ, vars, units)
+            x = getvar(filtered_dataobject, :x, center=center, mask=use_mask_in_recursion)
+            y = getvar(filtered_dataobject, :y, center=center, mask=use_mask_in_recursion)
+            vars_dict[:ϕ] = @. atan(y, x) * selected_unit
+
         end
 
     end

--- a/test/37_derived_fields_tests.jl
+++ b/test/37_derived_fields_tests.jl
@@ -101,5 +101,56 @@
             # a velocity projection (mass-weighted ⇒ needs :rho too) still works one-call
             @test haskey(project(info, :vz, :km_s; direction=:z, res=64, verbose=false).maps, :vz)
         end
+
+        @testset "every registered FIELD_DEPS field has a working compute branch" begin
+            # Guards against registry↔implementation drift: a field listed in FIELD_DEPS but missing a
+            # get_data branch (the :ϕ bug) or whose deps are under-reported (the magnetic-Mach bug)
+            # would surface here. Each registered field must compute on real data EXCEPT those that
+            # legitimately need data this fixture lacks (cosmology / magnetic field) — listed explicitly
+            # so a genuinely-unimplemented new field cannot hide behind the skip-set.
+            grav = getgravity(info, verbose=false, show_progress=false)
+            part = getparticles(info, verbose=false, show_progress=false)
+            skip = Dict(
+                :hydro    => Set([:delta, :overdensity,                       # cosmological only
+                                  :mach_alfven, :mach_fast, :mach_slow]),     # need magnetic field
+                :gravity  => Set{Symbol}(),
+                :particle => Set([:formation_redshift, :formation_time, :zform]),  # cosmological only
+            )
+            for (kind, obj) in [(:hydro, gas), (:gravity, grav), (:particle, part)]
+                for k in keys(Mera.FIELD_DEPS[kind])
+                    k in skip[kind] && continue
+                    v = getvar(obj, k, center=[:bc])
+                    @test v isa AbstractArray
+                end
+            end
+        end
+
+        @testset "coordinate transforms, :ϕ, and aggregation helpers" begin
+            x = getvar(gas, :x, center=[:bc]); y = getvar(gas, :y, center=[:bc])
+            # :ϕ (B1 regression) = atan(y,x) ∈ [-π,π]
+            phi = getvar(gas, :ϕ, center=[:bc])
+            @test phi ≈ atan.(y, x)
+            @test all(-π .<= phi .<= π)
+            @test getvar(gas, :r_cylinder, center=[:bc]) ≈ sqrt.(x.^2 .+ y.^2)
+            # aggregation helpers: finite results + the C1 zero-weight guards
+            com = center_of_mass(gas); @test length(com) == 3 && all(isfinite, com)
+            bv  = bulk_velocity(gas);  @test length(bv) == 3 && all(isfinite, bv)
+            ws  = wstat(getvar(gas, :rho), weight=getvar(gas, :mass))
+            @test isfinite(ws.mean) && ws.std >= 0
+            empt = falses(length(gas.data))
+            @test_throws ErrorException center_of_mass(gas, mask=empt)        # was silent NaN
+            @test_throws ErrorException wstat(getvar(gas, :rho), weight=zeros(length(gas.data)))
+        end
+
+        @testset "gravity :cz honors a non-default center (A1 regression)" begin
+            grav = getgravity(info, verbose=false, show_progress=false)
+            cx = getvar(grav, :cx, center=[0.3,0.4,0.7])
+            cz = getvar(grav, :cz, center=[0.3,0.4,0.7])
+            @test !(cx ≈ cz)                                  # distinct branches (was a duplicate :cx)
+            cz_bc = getvar(grav, :cz, center=[:bc])
+            cz_0  = getvar(grav, :cz, center=[0.,0.,0.])
+            @test !(cz_bc ≈ cz_0)                             # the center is actually applied now
+            @test all((cz_0 .- cz_bc) .≈ (cz_0[1] - cz_bc[1]))   # uniform constant center offset
+        end
     end
 end


### PR DESCRIPTION
Remediation of the getvar/derived-fields expert-panel findings (panel 6.5/10 — physics formulas sound, but several shipping correctness defects in this subsystem that feeds nearly every analysis). All three tiers.

## Tier 1 — must-fix correctness
- **gravity `:cz` was unreachable** (`getvar_gravity.jl`): a duplicate `elseif i == :cx` shadowed the `:cz` branch, so `:cz` fell through to the generic path **without center subtraction** — wrong z-coordinates / centering on uniform grids. (CRITICAL, verified)
- **hydro `:ϕ` registered but unimplemented** (`getvar_hydro.jl` / `fields.jl:56`): `getvar(hydro, :ϕ)` errored. Implemented `atan(y,x)` mirroring the particle/gravity branches. (CRITICAL, verified)
- **unguarded division in aggregations** (`basic_calc.jl`): `center_of_mass`/`bulk_velocity`/`wstat` divided by total mass/volume/weight with no guard, emitting silent `NaN`/`Inf` on an empty or zero-weight selection. Now error clearly. (HIGH)
- **`escape_speed` crashed** (`getvar_gravity.jl`): `sqrt(-2φ)` threw a `DomainError` for unbound cells (`φ>0`); now `sqrt(max(-2φ,0))`. (found while building the consistency test)

## Tier 2 — robustness / usability
- **magnetic Mach numbers registered** in `FIELD_DEPS[:hydro]` (`:mach_alfven/fast/slow`) so `getvar_requirements` (and the auto-read path) fetch `:bx,:by,:bz,:rho`; previously implemented but unregistered → failed via auto-read.
- **center API**: `center_in_standardnotation` now rejects a length-1 numeric / non-3 center (was a later `BoundsError`); `getvelocities` gains `center`/`direction` for parity with `getpositions`.
- **RtDataType positional `hydro_data` overloads** added (parity with the GravDataType+hydro API).
- **`wstat`** unweighted std now uses `corrected=false`, consistent with the weighted path (population std).

## Tier 3 — tests / docs / cleanup
- **Registry↔implementation consistency test** (`test/37`): asserts *every* registered `FIELD_DEPS` field computes on real hydro/gravity/particle data (explicit skip-set for cosmological/magnetic-only fields). This catches exactly the `:ϕ`/magnetic-Mach class of drift, plus coordinate/`:ϕ`/aggregation tests and a gravity `:cz` regression. (+128 assertions, 152 total)
- **Docs** (`derived_fields.md`): conventions for the magnetosonic Mach numbers (B-field unit convention), escape-speed sign, the Jeans-length variant, and the cosmological-only quantities.
- **Dead code**: removed ~140 lines from `basic_calc.jl` (the `*_deprecated` functions and their only caller `benchmark_metaprog_basic_calc`, all unexported/unused).

## Verification
- Package loads/precompiles; `test/37` + `04` + `13` + `22` green; docs build clean.
- All four confirmed defects independently reproduced before fixing and re-verified after.