### PR TITLE
list_fields: add builtin= to list built-in + custom derived fields

### DIFF
--- a/docs/src/derived_fields.md
+++ b/docs/src/derived_fields.md
@@ -122,10 +122,16 @@ Valid kinds: `:hydro`, `:gravity`, `:rt`, `:particle`, `:clump`.
 ## Managing registered fields
 
 ```julia
-list_fields(:hydro)          # names registered for hydro
-field_info(:vmag2)           # (; compute, depends_on, unit, description)
-delete_field(:vmag2)         # remove it (delete_field(name; datatypes=:all) by default)
+list_fields(:hydro)                 # names you added for hydro (custom only)
+list_fields(:hydro; builtin=true)   # built-in derived fields ∪ your custom ones, sorted
+field_info(:vmag2)                  # (; compute, depends_on, unit, description)
+delete_field(:vmag2)                # remove it (delete_field(name; datatypes=:all) by default)
 ```
+
+`list_fields(kind; builtin=true)` is the quickest way to discover what you can ask `getvar` for on a
+given data type — it returns the dependency-registry built-ins together with any fields you registered.
+It covers most but not every built-in quantity (a few specialised fields are computed directly in
+`getvar`); for the complete human-readable catalogue call `getvar()` with no arguments.
 
 !!! note "Registry scope"
     Registered fields live for the current Julia session (they are not persisted to disk).

--- a/src/functions/getvar/fields.jl
+++ b/src/functions/getvar/fields.jl
@@ -236,11 +236,33 @@ function delete_field(name::Symbol; datatypes=:all)
 end
 
 """
-    list_fields(kind::Symbol=:hydro) -> Vector{Symbol}
+    list_fields(kind::Symbol=:hydro; builtin::Bool=false) -> Vector{Symbol}
 
-The user-registered field names for a data-type `kind`.
+The registered derived-field names for a data-type `kind` (`:hydro`, `:gravity`, `:rt`,
+`:particle`, `:clump`), sorted.
+
+By default only the **user-added** fields (registered with [`add_field`](@ref)) are returned —
+this is the back-compatible behaviour. With `builtin=true` the result also includes the
+**built-in** derived quantities known to the dependency registry (`FIELD_DEPS[kind]`), so you get
+a single combined list of everything resolvable for that kind:
+
+```julia
+list_fields(:hydro)                 # only the fields you added
+list_fields(:hydro; builtin=true)   # built-in registry fields ∪ your custom fields
+```
+
+Note: `builtin=true` reflects the dependency registry, which covers most but not every built-in
+quantity (a few specialised fields, e.g. some RT-ionization variables, are computed directly in
+`getvar` without a registry entry). For the full human-readable catalogue call `getvar()` with no
+arguments.
 """
-list_fields(kind::Symbol=:hydro) = haskey(USER_FIELDS, kind) ? sort!(collect(keys(USER_FIELDS[kind]))) : Symbol[]
+function list_fields(kind::Symbol=:hydro; builtin::Bool=false)
+    names = haskey(USER_FIELDS, kind) ? collect(keys(USER_FIELDS[kind])) : Symbol[]
+    if builtin && haskey(FIELD_DEPS, kind)
+        union!(names, keys(FIELD_DEPS[kind]))
+    end
+    return sort!(names)
+end
 
 """
     field_info(name::Symbol; kind::Symbol=:hydro)

--- a/test/37_derived_fields_tests.jl
+++ b/test/37_derived_fields_tests.jl
@@ -45,6 +45,23 @@
         delete_field(:halfrho_f); delete_unit(:per2)
     end
 
+    @testset "list_fields: custom-only default vs builtin=true (data-free)" begin
+        @test list_fields(:hydro) == Symbol[]                       # no custom fields registered yet
+        bi = list_fields(:hydro; builtin=true)
+        @test issorted(bi)
+        @test all(in(bi), [:T, :ekin, :mach, :ϕ, :jeanslength])     # built-ins present
+        # adding a custom field shows in BOTH the default and the builtin listing; built-ins still there
+        add_field(:vmag2, (o,d)->d[:vx].^2 .+ d[:vy].^2 .+ d[:vz].^2; depends_on=[:vx,:vy,:vz])
+        @test list_fields(:hydro) == [:vmag2]                       # default = custom only
+        bi2 = list_fields(:hydro; builtin=true)
+        @test :vmag2 in bi2 && :T in bi2                            # union of custom + built-in
+        @test length(bi2) == length(bi) + 1
+        delete_field(:vmag2)
+        @test list_fields(:hydro; builtin=true) == bi               # back to just built-ins
+        # other kinds resolve their own registry
+        @test :escape_speed in list_fields(:gravity; builtin=true)
+    end
+
     if !DATA_AVAILABLE
         @warn "Skipping data-backed derived-field tests - simulation data not available"
         @test_skip "Simulation data not available"


### PR DESCRIPTION
Follow-up to the getvar/derived-fields panel: there was no single call to discover all derived fields available for a data type — `list_fields` returned only user-added fields, and the built-in catalogue was only a hand-maintained `getvar()` text printout.

## Change
`list_fields(kind; builtin=false)`:
- **default unchanged** — returns only the fields you registered with `add_field` (back-compatible).
- **`builtin=true`** — returns the dependency-registry built-ins (`FIELD_DEPS[kind]`) **∪** your custom fields, sorted.

```julia
list_fields(:hydro)                 # custom only
list_fields(:hydro; builtin=true)   # 66 hydro built-ins + your custom fields, sorted
list_fields(:gravity; builtin=true) # :a_magnitude, :escape_speed, :ϕ, …
```

Documented the caveat that the registry covers most but not every built-in (a few specialised fields, e.g. some RT-ionization variables, are computed directly in `getvar`); `getvar()` with no args remains the complete human-readable catalogue.

## Tests / docs
- New data-free testset in `test/37`: custom-only default, `builtin=true` union (built-ins present, custom merged in, sorted, count = built-ins + 1), per-kind resolution.
- `derived_fields.md` "Managing registered fields" updated.

Focused suite green; docs build clean.