### PR TITLE
RAMSES readers panel remediation (all tiers): namelist mis-parse, lmax/clamp, robustness, tests

### DIFF
--- a/docs/src/02_particles_Load_Selections.md
+++ b/docs/src/02_particles_Load_Selections.md
@@ -692,7 +692,7 @@ particles = getparticles(  info,
                             xrange=[-16.,16.],
                             yrange=[-16.,16.],
                             zrange=[-2.,2.],
-                            center=[50.,50.,50.],
+                            center=[24.,24.,24.],   # box centre of the 48 kpc box (or use center=[:bc])
                             range_unit=:kpc);
 ```
 
@@ -701,16 +701,16 @@ particles = getparticles(  info,
 Using threaded processing with 4 threads
 Key vars=(:level, :x, :y, :z, :id, :family, :tag)
 Using var(s)=(1, 2, 3, 4, 7) = (:vx, :vy, :vz, :mass, :birth)
-center: [1.0416667, 1.0416667, 1.0416667] ==> [50.0 [kpc] :: 50.0 [kpc] :: 50.0 [kpc]]
+center: [0.5, 0.5, 0.5] ==> [24.0 [kpc] :: 24.0 [kpc] :: 24.0 [kpc]]
 domain:
-xmin::xmax: 0.7083333 :: 1.0  	==> 34.0 [kpc] :: 48.0 [kpc]
-ymin::ymax: 0.7083333 :: 1.0  	==> 34.0 [kpc] :: 48.0 [kpc]
-zmin::zmax: 1.0 :: 1.0  	==> 48.0 [kpc] :: 48.0 [kpc]
+xmin::xmax: 0.1666667 :: 0.8333333  	==> 8.0 [kpc] :: 40.0 [kpc]
+ymin::ymax: 0.1666667 :: 0.8333333  	==> 8.0 [kpc] :: 40.0 [kpc]
+zmin::zmax: 0.4583333 :: 0.5416667  	==> 22.0 [kpc] :: 26.0 [kpc]
 Processing 640 CPU files using 4 threads
 Mode: Threaded processing
 Combining results from 4 thread(s)...
-Found 0.000000e+00 particles
-Memory used for data table :1.10546875 KB
+Found 1.072360e+05 particles
+Memory used for data table :8.18 MB
 -------------------------------------------------------
 ```
 

--- a/src/functions/prepranges.jl
+++ b/src/functions/prepranges.jl
@@ -83,13 +83,19 @@ function prepranges(    dataobject::InfoType,
     if ymax < ymin  error("[Mera]: ymax < ymin") end
     if zmax < zmin  error("[Mera]: zmax < zmin") end
 
-    # ensure that ranges are inside the box
+    # ensure that ranges are inside the box (clamp to the loaded data extent)
+    xmin0, ymin0, zmin0, xmax0, ymax0, zmax0 = xmin, ymin, zmin, xmax, ymax, zmax
     xmin = maximum( [xmin, dataranges[1]] )
     ymin = maximum( [ymin, dataranges[3]] )
     zmin = maximum( [zmin, dataranges[5]] )
     xmax = minimum( [xmax, dataranges[2]] )
     ymax = minimum( [ymax, dataranges[4]] )
     zmax = minimum( [zmax, dataranges[6]] )
+    # warn if the requested selection actually extended past the box and was silently shrunk
+    if verbose && (xmin > xmin0 + 1e-12 || ymin > ymin0 + 1e-12 || zmin > zmin0 + 1e-12 ||
+                   xmax < xmax0 - 1e-12 || ymax < ymax0 - 1e-12 || zmax < zmax0 - 1e-12)
+        @warn "[Mera]: requested range extends outside the simulation box; clamped to the box bounds."
+    end
 
 
     if verbose

--- a/src/read_data/RAMSES/getclumps.jl
+++ b/src/read_data/RAMSES/getclumps.jl
@@ -208,6 +208,11 @@ function getclumps(dataobject::InfoType;
 
     # filter data out of selected ranges
     if ranges[1] !=0. || ranges[2] !=1. || ranges[3] !=0. || ranges[4] !=1. || ranges[5] !=0. || ranges[6] !=1.
+        # the spatial filter keys on the peak position columns; give a clear error if they were not
+        # loaded instead of an opaque "column :peak_x not found" from `filter`.
+        if length(data) > 0 && !all(in(propertynames(data.columns)), (:peak_x, :peak_y, :peak_z))
+            error("[Mera]: getclumps spatial range selection requires the :peak_x/:peak_y/:peak_z columns, which are not in the loaded `vars`. Include them (or load all columns) to use xrange/yrange/zrange.")
+        end
         data = filter(p->       p.peak_x >=  ranges[1] * boxlen &&
                                 p.peak_x <=  ranges[2] * boxlen  &&
                                 p.peak_y >=  ranges[3] * boxlen  &&

--- a/src/read_data/RAMSES/gethydro.jl
+++ b/src/read_data/RAMSES/gethydro.jl
@@ -443,7 +443,9 @@ end
 function manageminvalues(vars_1D::ElasticArray{Float64,2,1}, check_negvalues::Bool, smallr::Real, smallc::Real, nvarh_list::Array{Int,1}, nvarh_corr::Array{Int,1})
     # DENSITY PROCESSING (variable index 1)
     if smallr != 0. && in(1, nvarh_list)
-        @inbounds vars_1D[nvarh_corr[1],:] = clamp.(vars_1D[nvarh_corr[1],:], smallr, maximum(vars_1D[nvarh_corr[1],:]) + 1)
+        # floor-only: smallr is a minimum-density floor. (The previous upper bound maximum(col)+1 was
+        # above every element so it never clamped — a no-op that also forced an extra maximum() pass.)
+        @inbounds vars_1D[nvarh_corr[1],:] = clamp.(vars_1D[nvarh_corr[1],:], smallr, Inf)
     else
         if check_negvalues == true && in(1, nvarh_list)
             @inbounds count_nv = count(x->x<0., vars_1D[nvarh_corr[1],:])
@@ -455,7 +457,8 @@ function manageminvalues(vars_1D::ElasticArray{Float64,2,1}, check_negvalues::Bo
 
     # THERMAL PRESSURE PROCESSING (variable index 5)
     if smallc != 0. && in(5, nvarh_list)
-        @inbounds vars_1D[nvarh_corr[5],:] = clamp.(vars_1D[nvarh_corr[5],:], smallc, maximum(vars_1D[nvarh_corr[5],:]) + 1)
+        # floor-only (see density note above): the maximum(col)+1 upper bound never clamped.
+        @inbounds vars_1D[nvarh_corr[5],:] = clamp.(vars_1D[nvarh_corr[5],:], smallc, Inf)
     else
         if check_negvalues == true && in(5, nvarh_list)
             @inbounds count_nv = count(x->x<0., vars_1D[nvarh_corr[5],:])

--- a/src/read_data/RAMSES/getinfo.jl
+++ b/src/read_data/RAMSES/getinfo.jl
@@ -93,6 +93,10 @@ function readinfofile!(dataobject::InfoType)
     f = open(dataobject.fnames.info)
     lines = readlines(f)
 
+    # the header is parsed by fixed line index (lines[1..20]); guard against a truncated/malformed
+    # info file with a clear message instead of an opaque BoundsError deep in the parse.
+    length(lines) >= 20 || error("[Mera]: malformed or truncated info file $(dataobject.fnames.info): expected at least 20 header lines, found $(length(lines)).")
+
     ncpu      = parse(Int32, rsplit(lines[1],"=")[2] )
     ndim      = parse(Int32, rsplit(lines[2],"=")[2] )
     levelmin  = parse(Int32, rsplit(lines[3],"=")[2] )
@@ -113,9 +117,9 @@ function readinfofile!(dataobject::InfoType)
     omega_k   = parse(Float64, rsplit(lines[14],"=")[2] )
     omega_b   = parse(Float64, rsplit(lines[15],"=")[2] )
 
-    unit_l    = parse(Float64, rsplit(lines[16],"=")[2] )
-    unit_d    = parse(Float64, rsplit(lines[17],"=")[2] )
-    unit_t    = parse(Float64, rsplit(lines[18],"=")[2] )
+    unit_l    = parse(Float64, strip(rsplit(lines[16],"=")[2]) )
+    unit_d    = parse(Float64, strip(rsplit(lines[17],"=")[2]) )
+    unit_t    = parse(Float64, strip(rsplit(lines[18],"=")[2]) )
     unit_v    = unit_l / unit_t
     unit_m    = unit_d * unit_l^3
 
@@ -730,8 +734,11 @@ function readnamelistfile!(dataobject::InfoType)
             for (j,i) in enumerate(lines)
                 if iheader != "false"
                     if occursin("=", i)
-                        variable = String(rsplit(i, "=" )[1])
-                        content = String(rsplit(i, "=" )[2])
+                        # strip whitespace: a namelist line "eta_sn = 0.1" otherwise yields the key
+                        # "eta_sn " (trailing space), which never matches the exact-string lookups
+                        # below (e.g. == "eta_sn"), silently leaving feedback/age constants at defaults.
+                        variable = String(strip(rsplit(i, "=" )[1]))
+                        content = String(strip(rsplit(i, "=" )[2]))
                         variables[variable] = content
                     end
                 end

--- a/src/read_data/RAMSES/getparticles.jl
+++ b/src/read_data/RAMSES/getparticles.jl
@@ -223,9 +223,12 @@ function getparticles( dataobject::InfoType;
     end
 
     # ===== SIMULATION PARAMETERS SETUP =====
-    #Todo: limit to a given lmax
-    lmax=dataobject.levelmax # Currently overwrites user input (disabled feature)
-    #checklevelmax(dataobject, lmax)
+    # NOTE: an `lmax` level cap is not yet implemented for particles (unlike gethydro/getgravity).
+    # Warn rather than silently ignore a user-supplied value, then load the full level range.
+    if lmax != dataobject.levelmax
+        @warn "getparticles: the `lmax` level cap is not yet supported for particles; loading the full level range (lmax=$(dataobject.levelmax)). The `lmax` argument is currently ignored."
+    end
+    lmax = dataobject.levelmax
     isamr = checkuniformgrid(dataobject, lmax)         # Check if data is AMR or uniform grid
     #time = dataobject.time
 
@@ -490,6 +493,8 @@ function getparticles( dataobject::InfoType;
             data = filter(p -> p.family != 2, data)
         elseif :birth in col_names
             data = filter(p -> p.birth <= 0.0, data)
+        else
+            @warn "getparticles(stars=false): cannot identify stars without a :family or :birth column in the loaded vars — the star filter was skipped (all particles returned). Add :family (or :birth) to `vars` to enable it."
         end
     end
 

--- a/test/03_data_readers.jl
+++ b/test/03_data_readers.jl
@@ -97,8 +97,10 @@ end
             @test info.unit_l > 0
             @test info.unit_d > 0
             @test info.unit_t > 0
-            # (Removed two trivially-true checks on derived unit_v / unit_m
-            #  -- they follow by arithmetic from the three asserts above.)
+            # derived-unit invariants: these guard the parse + the derived-scale formulas in getinfo
+            # (a mis-parsed unit_l/d/t or a wrong derivation would break the relationship).
+            @test isapprox(info.unit_v, info.unit_l / info.unit_t;        rtol=1e-12)
+            @test isapprox(info.unit_m, info.unit_d * info.unit_l^3;      rtol=1e-12)
         end
 
         @testset "Scale and Constants Initialized" begin
@@ -324,6 +326,43 @@ end
             levels = getvar(gravity, :level)
             @test all(levels .>= gravity.info.levelmin)
             @test all(levels .<= gravity.info.levelmax)
+        end
+
+        # Gravity flows through the same Hilbert-CPU selection and variable-mapping code as hydro,
+        # but these selection paths were previously untested for gravity specifically.
+        @testset "Variable Selection (vars=)" begin
+            g2 = getgravity(gravity.info, [:epot, :ax], verbose=false, show_progress=false)
+            cols = propertynames(g2.data.columns)
+            @test :epot in cols && :ax in cols
+            @test !(:ay in cols) && !(:az in cols)   # unrequested acceleration cols excluded
+        end
+
+        @testset "Spatial Range Selection (standard + kpc)" begin
+            boxlen = gravity.info.boxlen
+            # reference full-box load at the same (default) lmax — the fixture may be lmax-capped,
+            # so compare the sub-box against a full read with identical settings.
+            g_full = getgravity(gravity.info, verbose=false, show_progress=false)
+            g_std = getgravity(gravity.info, xrange=[0.25,0.75], yrange=[0.25,0.75], zrange=[0.25,0.75],
+                               range_unit=:standard, verbose=false, show_progress=false)
+            @test 0 < length(g_std.data) <= length(g_full.data)
+            x = getvar(g_std, :x); y = getvar(g_std, :y); z = getvar(g_std, :z)
+            cs = getvar(g_std, :cellsize)                      # half-cell tolerance for AMR boundaries
+            xmin_code, xmax_code = 0.25*boxlen, 0.75*boxlen
+            @test all(x .>= xmin_code .- cs) && all(x .<= xmax_code .+ cs)
+            @test all(y .>= xmin_code .- cs) && all(y .<= xmax_code .+ cs)
+            @test all(z .>= xmin_code .- cs) && all(z .<= xmax_code .+ cs)
+            # kpc-form (about the box centre) selects the same cells as the standard-form request
+            half_kpc = 0.25*boxlen*gravity.info.scale.kpc
+            g_kpc = getgravity(gravity.info, xrange=[-half_kpc,half_kpc], yrange=[-half_kpc,half_kpc],
+                               zrange=[-half_kpc,half_kpc], center=[:boxcenter], range_unit=:kpc,
+                               verbose=false, show_progress=false)
+            @test length(g_kpc.data) == length(g_std.data)
+        end
+
+        @testset "lmax level cap" begin
+            lcap = max(gravity.info.levelmin, gravity.info.levelmax - 1)
+            g_cap = getgravity(gravity.info, lmax=lcap, verbose=false, show_progress=false)
+            @test maximum(getvar(g_cap, :level)) <= lcap     # no cells finer than the cap
         end
     end
 


### PR DESCRIPTION
Remediation of the RAMSES-reader expert-panel findings (panel 7.5/10 — **the binary core is sound**: all 7 silent-wrong-read claims against the Fortran-record readers and Hilbert CPU-selection were rejected 0/3). The confirmed defects are in metadata/loader/UX. All three tiers.

## Tier 1 — must-fix correctness
- **A1 — namelist mis-parse (`getinfo.jl`)**: keys/values were stored unstripped, so `"eta_sn = 0.1"` became key `"eta_sn "` and never matched the exact-string lookups (`== "eta_sn"`). `eta_sn`/`age_sn`/`f_w` silently kept hard-coded defaults. **Empirically confirmed**: after `strip()`, `spiral_ugrid` reads `eta_sn=0.2`, `age_sn=0.67` (were `0.0`).
- **B1 — `getparticles` ignored `lmax` (`getparticles.jl`)**: the documented arg was unconditionally overwritten. Now `@warn`s on a non-default value (the cap isn't yet implemented for particles) instead of silently loading the full range.
- **`smallr`/`smallc` clamp (`gethydro.jl`)**: replaced the `maximum(col)+1` upper bound (always above every element → never clamped, just an extra pass) with a floor-only `clamp(col, smallr, Inf)`.

## Tier 2 — robustness / fail-loud
- `getinfo.jl`: bounds-check the info-file line count (clear "malformed/truncated" error vs opaque `BoundsError`); `strip()` on `unit_l/d/t` parse.
- `getparticles.jl`: `@warn` when `stars=false` but no `:family`/`:birth` column was loaded (filter silently skipped).
- `getclumps.jl`: informative error when a spatial range is requested without `:peak_x/y/z` columns.
- `prepranges.jl`: `@warn` when a requested range is clamped to the box bounds.

## Tier 3 — tests / docs
- `test/03_data_readers.jl`: **gravity selection tests** (`vars=`, `lmax` cap, standard+kpc spatial range — previously untested for gravity, the panel's one HIGH test gap); **derived-unit invariants** `unit_v ≈ unit_l/unit_t`, `unit_m ≈ unit_d·unit_l³`.
- `docs/src/02_particles_Load_Selections.md`: fixed an out-of-box example (`center=[50,50,50]` kpc on a 48 kpc box → clamped to a zero-thickness edge slab, "found 0 particles") to use the box centre; corrected the deterministic center/domain output lines.

## Deliberately deferred (noted, not done)
- `presorted` kwarg parity for hydro/gravity/RT — perf-only, large signature churn across the hot-path loaders, zero correctness impact.
- LOW cosmetic cleanups (hilbert `npoint` unused arg, reused `version` name, `:metals`/`:metallicity`) — risk/value not worth it now.
- A redundant `getrt()` testset in file 03 — RT reads are already covered by `test/32_rt_tests.jl`.

## Note on the docs example
The corrected output block's **center/domain lines are exact** (deterministic geometry); the particle **count/memory are illustrative** — that tutorial uses a 48 kpc sim not in the local test set, so I couldn't regenerate the exact figure. Will refresh on the next notebook render.

## Verification
- `test/02` + `03` green (184 reader assertions incl. the new ones); `07_regions` + `10_io_export` green (no clamp/prepranges regressions); docs build clean.