### PR TITLE
profile/phase panel remediation (all tiers): binning guards + consistency + tests

### DIFF
--- a/src/functions/profile.jl
+++ b/src/functions/profile.jl
@@ -20,6 +20,9 @@ end
 # build edges from a fixed step Δ over [lo,hi], keeping `hi` exact (the final bin may be short).
 function _edges_by_step(lo::Float64, hi::Float64, Δ::Float64)
     Δ > 0 || throw(ArgumentError("binsize must be > 0 (got $Δ)"))
+    # require a strictly increasing range: a reversed range (lo>hi) used to return a DECREASING edge
+    # vector ([lo,hi]) that silently mis-binned every point; lo==hi gives a degenerate zero-width bin.
+    lo < hi || throw(ArgumentError("binning range requires lo < hi (got lo=$lo, hi=$hi)"))
     e = collect(lo:Δ:hi)
     (isempty(e) || (hi - e[end]) > 1e-9 * max(abs(hi), abs(lo), 1.0)) && push!(e, hi)
     length(e) < 2 ? [lo, hi] : e
@@ -29,10 +32,20 @@ end
 # every bin holds ~the same number of points). `binsize` (opt-in) sets a fixed bin WIDTH instead of a
 # count: in xunit for linear, a dex (log10) step for :log, and disallowed for :equal.
 function _bin_edges(v, rng, scale::Symbol, n::Int; binsize=nothing)
-    lo, hi = rng === nothing ? extrema(v) : (Float64(rng[1]), Float64(rng[2]))
+    # range from the data extrema (auto) or an explicit user range. Non-finite (NaN/Inf) values must
+    # not reach extrema/quantile/range: extrema throws on NaN, and Inf produces non-finite edges that
+    # corrupt bin assignment. Drop them once here (auto), and reject a non-finite explicit range.
+    if rng === nothing
+        vfin = filter(isfinite, v)
+        isempty(vfin) && throw(ArgumentError("binning: no finite values to bin"))
+        lo, hi = extrema(vfin)
+    else
+        lo, hi = Float64(rng[1]), Float64(rng[2])
+        (isfinite(lo) && isfinite(hi)) || throw(ArgumentError("binning range must be finite (got lo=$lo, hi=$hi)"))
+    end
     if scale === :log
         if lo <= 0                                   # clamp low edge to the smallest positive value
-            pos = filter(>(0), v)
+            pos = filter(x -> isfinite(x) && x > 0, v)
             isempty(pos) && throw(ArgumentError("log scale requires positive values, but none are positive"))
             lo = minimum(pos)
             @warn "scale=:log: non-positive values are dropped (they have no log bin)" maxlog=1
@@ -44,7 +57,7 @@ function _bin_edges(v, rng, scale::Symbol, n::Int; binsize=nothing)
     elseif scale === :equal
         binsize === nothing ||
             throw(ArgumentError("binsize is incompatible with scale=:equal (quantile bins have no fixed width); use nbins"))
-        vv = rng === nothing ? collect(float.(v)) : [Float64(x) for x in v if lo <= x <= hi]
+        vv = rng === nothing ? collect(float.(filter(isfinite, v))) : [Float64(x) for x in v if isfinite(x) && lo <= x <= hi]
         isempty(vv) && throw(ArgumentError("equal-count binning (scale=:equal): no data in range"))
         e = collect(quantile(vv, range(0.0, 1.0, length=n+1)))   # equal-population (quantile) edges
         adj = false                                              # ties → nudge to keep edges strictly increasing
@@ -55,6 +68,9 @@ function _bin_edges(v, rng, scale::Symbol, n::Int; binsize=nothing)
         return e
     end
     scale in (:linear,) || throw(ArgumentError("scale must be :linear, :log or :equal (got :$scale)"))
+    # strictly-increasing range (the :log branch guards its own at line 41); a reversed/degenerate
+    # linear range would otherwise build collapsed or decreasing edges and silently mis-bin.
+    hi > lo || throw(ArgumentError("binning range requires lo < hi (got lo=$lo, hi=$hi)"))
     binsize === nothing && return collect(range(lo, hi, length=n+1))
     return _edges_by_step(lo, hi, Float64(binsize))             # binsize = width in xunit
 end
@@ -66,9 +82,11 @@ function _resolve_binsize(bs, info, axunit::Symbol, scale::Symbol)
     bs === nothing && return nothing
     if (bs isa Tuple || bs isa AbstractVector) && length(bs) == 2 && !(bs[2] isa Real)
         scale === :log && throw(ArgumentError("a :log binsize is a dimensionless dex step — pass a scalar, not a (value,:unit) tuple"))
+        Float64(bs[1]) > 0 || throw(ArgumentError("binsize must be > 0 (got $(bs[1]))"))
         gu(u) = u === :standard ? 1.0 : getunit(info, u)
         return Float64(bs[1]) * gu(axunit) / gu(Symbol(bs[2]))
     end
+    Float64(bs) > 0 || throw(ArgumentError("binsize must be > 0 (got $bs)"))
     return Float64(bs)
 end
 
@@ -274,10 +292,12 @@ function _reduce_one(members, nb::Int, y, w, sumw, sumw2, qs, statistic;
                 med_ci[b,1],  med_ci[b,2], mse  = _bootstrap_ci(yv, wv, wmed,  med[b], nboot, ci_level, ci_method, rng)
                 med_se[b] = mse
             end
+            # custom statistic is weight-aware → only meaningful for a positive total weight, so keep
+            # it inside the sw>0 guard (consistent with mean/std/median; it stays NaN otherwise).
+            cust === nothing || (cust[b] = _apply_stat(statistic, (@view y[m]), @view w[m]))
         end
         yb = @view y[m]
-        mn[b] = minimum(yb); mx[b] = maximum(yb)
-        cust === nothing || (cust[b] = _apply_stat(statistic, yb, @view w[m]))
+        mn[b] = minimum(yb); mx[b] = maximum(yb)   # min/max are weight-independent → fine for any non-empty bin
     end
     base = (mean=mean, std=std, var=std.^2, sem=sem, neff=neff, min=mn, max=mx, median=med,
             quantiles=qa, qlevels=qs, skewness=skew, kurtosis=kurt)
@@ -443,7 +463,11 @@ profile of `:vlos`). For the `:r`/`:x`/`:y` cases `center` (default: the map cen
 (`range_unit` accepted as an alias) while `xrange` is in `xunit` (the radius is converted from code units
 via the map's `scale`). `edges`, `geometry`
 (`:cylindrical` annulus area for a 2-D map), `cumulative` and `statistic` work as in the data method.
-Returns the same fields as the data method.
+
+# Returns
+The same per-bin statistic fields as the data [`profile`](@ref) method, plus `var` (the binned map
+variable), `xvar`, `weight`, `xunit`, `unit` (the mapped variable's unit, from the projection), and
+`source=:map`.
 """
 function profile(m::DataMapsType, var::Symbol; xvar::Symbol=:r, weight::Union{Symbol,AbstractVector}=:none,
         nbins::Int=50, xrange=nothing, scale::Symbol=:linear,
@@ -483,7 +507,10 @@ function profile(m::DataMapsType, var::Symbol; xvar::Symbol=:r, weight::Union{Sy
     res = _profile1d(xv[fin], wv[fin], yv[fin], nbins, xrange, scale, quantiles;
                      edges=edges, geometry=geometry, cumulative=cumulative, statistic=statistic, normalize=normalize,
                      binsize=bsz, nboot=bootstrap, ci_level=confidence_level, ci_method=ci, rng=rng)
-    return merge(res, (var=var, xvar=xvar, weight=_wprov(weight), xunit=xunit, source=:map))
+    # carry the mapped variable's unit (from the projection) so the return matches data-`profile`'s
+    # contract, which also reports `unit`.
+    munit = isdefined(m, :maps_unit) ? get(m.maps_unit, var, :standard) : :standard
+    return merge(res, (var=var, xvar=xvar, weight=_wprov(weight), xunit=xunit, unit=munit, source=:map))
 end
 
 """
@@ -499,6 +526,12 @@ selects a richer per-bin reduction of `cvar` in addition to `mean`: `:std`, `:me
 `:max`, `:full` (all four), or a function `f(cview, wview)` (→ `custom`). Any non-`:mean` `cstat`
 also returns a per-bin weighted `quantiles` array (`nbx × nby × length(quantiles)`) at the
 `quantiles` levels (with `qlevels`).
+
+# Returns
+A `NamedTuple` with `xedges`, `yedges` (bin edges), `H` (the `nbx × nby` summed-weight grid),
+`xvar`/`yvar`, `weight`, `xunit`/`yunit`, and `source=:data`. With `normalize`, also `fraction`/`pdf`.
+With a `cvar`: `mean` (and, for a non-`:mean` `cstat`, the corresponding `std`/`median`/`min`/`max`/
+`quantiles`/`custom` grids), plus `cvar`/`cunit`.
 """
 function phase(dataobject, xvar::Symbol, yvar::Symbol, cvar=nothing; weight::Union{Symbol,AbstractVector}=:mass,
         nbins=(100,100), xrange=nothing, yrange=nothing, xscale::Symbol=:linear, yscale::Symbol=:linear,
@@ -528,6 +561,10 @@ end
 
 **2D phase diagram from a projected map** — bin two map variables against each other, weighted by
 `:none`/`:area` or another map key, optionally colouring by the weighted mean of a third map `cvar`.
+
+# Returns
+The same fields as the data [`phase`](@ref) method (`xedges`, `yedges`, `H`, the `cstat` grids when
+a `cvar` is given, and `fraction`/`pdf` when normalized), with `source=:map`.
 """
 function phase(m::DataMapsType, xvar::Symbol, yvar::Symbol, cvar=nothing; weight::Union{Symbol,AbstractVector}=:none,
         nbins=(100,100), xrange=nothing, yrange=nothing, xscale::Symbol=:linear, yscale::Symbol=:linear,
@@ -569,11 +606,12 @@ function _cv_stats(members, cv, w, Hflat, cstat, qs)
         if sw > 0
             mu = sum(wb .* cvb) / sw
             std[k] = sqrt(max(sum(wb .* (cvb .- mu) .^ 2) / sw, 0.0))
-            med[k] = _wquantile(cvb, wb, 0.5)
-            for (j, q) in enumerate(qs); qa[k, j] = _wquantile(cvb, wb, q); end
+            med[k], qvv = _bin_quantiles(cv, w, m, qs)   # single sort → median + all quantiles
+            for j in 1:nq; qa[k, j] = qvv[j]; end
+            # weight-aware custom statistic: keep inside the sw>0 guard for consistency (NaN otherwise)
+            cust === nothing || (cust[k] = _apply_stat(cstat, cvb, wb))
         end
-        mn[k] = minimum(cvb); mx[k] = maximum(cvb)
-        cust === nothing || (cust[k] = _apply_stat(cstat, cvb, wb))
+        mn[k] = minimum(cvb); mx[k] = maximum(cvb)   # min/max weight-independent → any non-empty bin
     end
     return (std=std, min=mn, max=mx, median=med, quantiles=qa, custom=cust, isfunc=isfunc)
 end

--- a/src/functions/profile.jl
+++ b/src/functions/profile.jl
@@ -719,6 +719,23 @@ convenience wrapper; see the profiles tutorial for the manual recipe.
 
 Returns `x` (bin centres), `edges`, `count`, `sigma` (total), `sigma_components` (`nbins × n`) and
 `mean_components` (`nbins × n`) with the `components` order, and `neff` (Kish — small ⇒ noisy σ).
+
+!!! note "What kind of dispersion this is (3-D, per-annulus)"
+    This is the **3-D, per-bin** dispersion: all cells in a radial bin, variance of the velocity
+    *component* about the **single per-bin mean**. The bin-mean rotation/streaming is removed, but a
+    velocity **gradient across the bin** (e.g. the rotation curve varying over the annulus width, a
+    warp, or vertical structure binned only in radius) is *not* — by the law of total variance
+    `σ²_bin = ⟨σ²_local⟩ + Var[⟨v⟩_local]`, this σ also carries the intra-bin shear term, so it is an
+    **upper bound** on the local random dispersion. Shrink the bins, or bin in 2-D/3-D
+    ([`profile3d`](@ref)/[`phase`](@ref) in R and z or azimuth), to localise it.
+
+    For a **local, per-pixel** dispersion of the *line-of-sight* velocity instead, use the projected
+    map `projection(obj, :σlos)` (or [`los_moments`](@ref)/[`los_component`](@ref)`(...; dispersion=true)`)
+    and profile it (`profile(proj, :σlos; xvar=:r, weight=:sd)`). There σ = √(⟨v²⟩−⟨v⟩²) is taken about
+    **each pixel's own mean** (the local bulk/rotation velocity is removed per pixel), so it is locally
+    rest-frame; it still includes sub-pixel / along-the-line-of-sight ordered motion (beam smearing).
+    Note these two are also physically different quantities — a 3-D velocity *component* vs a projected
+    line-of-sight dispersion.
 """
 function velocitydispersion(dataobject; rvar::Symbol=:r_cylinder,
         components=(:vr_cylinder, :vϕ_cylinder, :vz), weight::Union{Symbol,AbstractVector}=:mass,

--- a/test/36_offaxis_features_tests.jl
+++ b/test/36_offaxis_features_tests.jl
@@ -6,6 +6,30 @@
 # Each test is an analytic oracle or a conservation/identity check.
 # Required datasets: :spiral_clumps (AMR) and :spiral_ugrid (uniform).
 
+# Data-free profile/phase unit tests (pure-function kernels — run even without simulation data):
+# binning input-validation guards and weighted-statistic oracles against hand-computed values.
+@testset "profile: binning guards + weighted-stat oracles (data-free)" begin
+    # --- binning input validation (silent-mis-bin guards) ---
+    @test_throws ArgumentError Mera._edges_by_step(10.0, 1.0, 1.0)               # reversed range (binsize)
+    @test_throws ArgumentError Mera._edges_by_step(5.0, 5.0, 1.0)                # degenerate lo == hi
+    @test_throws ArgumentError Mera._bin_edges([1.,2,3], (10.,1.), :linear, 5)   # reversed (count path)
+    @test_throws ArgumentError Mera._bin_edges([1.,2,3], (5.,5.),  :linear, 5)   # lo == hi (count path)
+    @test_throws ArgumentError Mera._bin_edges([1.,2,3], (1.,Inf), :linear, 5)   # non-finite explicit range
+    @test_throws ArgumentError Mera._resolve_binsize(-1.0, nothing, :standard, :linear)  # negative binsize
+    # non-finite DATA is dropped (not a crash) on the auto-range path
+    e = Mera._bin_edges([1.0, NaN, 3.0, Inf], nothing, :linear, 4)
+    @test length(e) == 5 && first(e) ≈ 1.0 && last(e) ≈ 3.0
+
+    # --- weighted-statistic oracle: two bins [0,1),[1,2], hand-computed ---
+    x = [0.5, 0.5, 1.5, 1.5]; w = [1.0, 3.0, 2.0, 2.0]; y = [10.0, 20.0, 5.0, 15.0]
+    r = Mera._profile1d(x, w, y, 2, (0.0, 2.0), :linear, [0.5]; edges=[0.0, 1.0, 2.0])
+    @test r.mean[1]   ≈ 17.5 && r.mean[2]   ≈ 10.0   # Σ(w·y)/Σw  = (10+60)/4 , (10+30)/4
+    @test r.median[1] ≈ 20.0 && r.median[2] ≈ 5.0    # weighted lower-convention median
+    @test r.count[1]  == 2   && r.count[2]  == 2
+    @test r.sum[1]    ≈ 4.0  && r.sum[2]    ≈ 4.0     # Σ weight per bin
+    @test r.quantiles[1,1] ≈ r.median[1]             # the q=0.5 column equals the median
+end
+
 if !DATA_AVAILABLE
     @warn "Skipping off-axis feature tests - simulation data not available"
     @test_skip "Simulation data not available"


### PR DESCRIPTION
Remediation of the profile/phase expert-panel findings (panel 8.0/10 — the statistical core is sound). All three tiers.

## Tier 1 — must-fix correctness (silent mis-binning)
The only confirmed defects, both in the binning layer, both reproducible with tiny synthetic vectors:
- **A1 (CRITICAL)** — `_edges_by_step` returned a **decreasing** edge vector for a reversed range (`xrange=(hi,lo)` with a `binsize`), so `searchsortedlast` mis-assigned **every** point and the profile was silently wrong. Now requires `lo < hi`.
- **A2 (HIGH)** — `lo == hi` (single-valued field / `xrange=(r,r)`) produced degenerate zero-width bins → divide-by-width `Inf`/`NaN`. Covered by the same guard, mirrored into the linear count path (the `:log` branch already guarded).
- **Non-finite inputs** — `_bin_edges` now drops `NaN`/`Inf` data before `extrema`/`quantile` (NaN crashed `extrema`; Inf gave non-finite edges) and rejects a non-finite explicit range.

## Tier 2 — consistency / usability
- `_reduce_one` & `_cv_stats`: the weight-aware **custom statistic** now runs only inside the `sw > 0` guard (consistent with mean/std/median; `NaN` otherwise).
- `_cv_stats`: median + quantiles from a **single sort** (was one `_wquantile` sort per level) — perf parity with the 1-D path.
- `_resolve_binsize`: rejects a non-positive `binsize` with a specific error.
- **map-profile** now returns the mapped variable's `unit` (from the projection), matching the data-profile return contract.

## Tier 3 — tests / docs
- `test/36`: a **data-free** testset — the binning guards plus **weighted mean / median / quantile oracles** checked against hand-computed values (the science-load-bearing stats were previously only range-checked).
- Docstrings: added **Returns** sections to `phase` (data + map); documented map-profile's `var`/`unit`/`source`.

## Reviewed and found correct (no change)
The weighted moments, Kish effective-sample-size SEM, the **BCa bootstrap**, and the `_erf`/Acklam inverse-CDF numerics — 4 "wrong coefficient" allegations were rejected 0/3 under adversarial verification.

## Verification
- New data-free testset 12/12; all existing profile/phase tests green (incl. the modified `_cv_stats` `cstat=:full` path); package loads; docs build clean.