### PR TITLE
save/load + VTK panel remediation (all tiers): VTK log10/celldata + uncompressed-save fix + tests

### DIFF
--- a/src/functions/data/data_convert.jl
+++ b/src/functions/data/data_convert.jl
@@ -604,6 +604,17 @@ function convertdata(output::Int;
     benchmark["memory_efficiency"] = storage_tot > 0 ? Float64(memtot) / Float64(storage_tot) : 0.0
     benchmark["lmax_processed"] = lmax
     benchmark["lmax_available"] = info.levelmax
+    # conversion provenance: record the spatial selection used, so a reader can tell a SUBSET file from
+    # a full one (the stored `info` keeps the original sim's levelmax/boxlen). See convertstat.benchmark.
+    benchmark["xrange"] = xrange
+    benchmark["yrange"] = yrange
+    benchmark["zrange"] = zrange
+    benchmark["range_unit"] = range_unit
+    benchmark["subset"] = (lmax != info.levelmax) ||
+        any(r -> !(r === missing), vcat(xrange, yrange, zrange))
+    # NB: compression_ratio/memory_efficiency are relative to the FULL simulation raw size on disk
+    # (storageoverview), not to the converted subset — so they are only exact for a full conversion.
+    benchmark["storage_basis"] = "full_simulation_raw_on_disk"
     benchmark["timestamp"] = string(now())
     benchmark["hostname"] = gethostname()
     benchmark["data_reduction_factor"] = foldersize > 0 ? Float64(final_file_size) / Float64(foldersize) : 0.0

--- a/src/functions/data/data_load.jl
+++ b/src/functions/data/data_load.jl
@@ -7,6 +7,7 @@ function loaddata(output::Int, datatype::Symbol;
                     zrange::Array{<:Any,1}=[missing, missing],
                     center::Array{<:Any,1}=[0., 0., 0.],
                     range_unit::Symbol=:standard,
+                    regenerate_scales::Bool=true,
                     verbose::Bool=true,
                     myargs::ArgumentsType=ArgumentsType() )
 
@@ -18,6 +19,7 @@ function loaddata(output::Int, datatype::Symbol;
                             zrange=zrange,
                             center=center,
                             range_unit=range_unit,
+                            regenerate_scales=regenerate_scales,
                             verbose=verbose,
                             myargs=myargs )
 end
@@ -29,6 +31,7 @@ function loaddata(output::Int, path::String, datatype::Symbol;
                     zrange::Array{<:Any,1}=[missing, missing],
                     center::Array{<:Any,1}=[0., 0., 0.],
                     range_unit::Symbol=:standard,
+                    regenerate_scales::Bool=true,
                     verbose::Bool=true,
                     myargs::ArgumentsType=ArgumentsType() )
 
@@ -40,6 +43,7 @@ function loaddata(output::Int, path::String, datatype::Symbol;
                             zrange=zrange,
                             center=center,
                             range_unit=range_unit,
+                            regenerate_scales=regenerate_scales,
                             verbose=verbose,
                             myargs=myargs )
 end
@@ -53,6 +57,7 @@ function loaddata(output::Int, path::String;
                     zrange::Array{<:Any,1}=[missing, missing],
                     center::Array{<:Any,1}=[0., 0., 0.],
                     range_unit::Symbol=:standard,
+                    regenerate_scales::Bool=true,
                     verbose::Bool=true,
                     myargs::ArgumentsType=ArgumentsType() )
 
@@ -64,6 +69,7 @@ function loaddata(output::Int, path::String;
                             zrange=zrange,
                             center=center,
                             range_unit=range_unit,
+                            regenerate_scales=regenerate_scales,
                             verbose=verbose,
                             myargs=myargs )
 end
@@ -121,6 +127,7 @@ function loaddata(output::Int; path::String="./",
                     zrange::Array{<:Any,1}=[missing, missing],
                     center::Array{<:Any,1}=[0., 0., 0.],
                     range_unit::Symbol=:standard,
+                    regenerate_scales::Bool=true,
                     verbose::Bool=true,
                     myargs::ArgumentsType=ArgumentsType() )
 
@@ -179,10 +186,14 @@ function loaddata(output::Int; path::String="./",
     
     dataobject = JLD2.load(fpath, dlink, typemap=typemap)
 
-    # update constants and scales
-    dataobject.info.constants = Mera.createconstants()
-    dataobject.info.scale = Mera.createscales(dataobject.info)
-    dataobject.scale = dataobject.info.scale
+    # By default refresh constants/scale from the CURRENT Mera version (so an old file picks up the
+    # current physical constants). This is the one part of load that is intentionally NOT byte-for-byte
+    # with the saved file; pass regenerate_scales=false to keep exactly the stored constants/scale.
+    if regenerate_scales
+        dataobject.info.constants = Mera.createconstants()
+        dataobject.info.scale = Mera.createscales(dataobject.info)
+        dataobject.scale = dataobject.info.scale
+    end
 
     # filter selected data region
     dataobject = subregion(dataobject, :cuboid,

--- a/src/functions/data/data_save.jl
+++ b/src/functions/data/data_save.jl
@@ -83,7 +83,7 @@ return
 #### Arguments
 ##### Required:
 - **`dataobject`:** needs to be of type: "HydroDataType", "PartDataType", "GravDataType", "ClumpDataType", "RtDataType"
-- **`fmode`:** nothing is written/appended by default to avoid overwriting files by accident. Need: fmode=:write (new file or overwriting existing file); fmode=:append further datatype. (overwriting of existing datatypes is not possible)
+- **`fmode`:** nothing is written/appended by default to avoid overwriting files by accident. Need: fmode=:write (new file, or overwrite an existing file); fmode=:append adds a further datatype to an existing file. Re-appending a datatype that is already stored in the file is not supported and raises an error (existing datatypes are not overwritten in place).
 ##### Predefined/Optional Keywords:
 - **`path`:** path to save the file; default is local path.
 - **`fname`:** default name of the files "output_" and the running number is added. Change the string to apply a user-defined name.
@@ -274,7 +274,8 @@ function check_compression(compress, wdata)
     elseif typeof(compress) == LZ4FrameCompressor && wdata
         ctype = compress
     elseif compress == false || !wdata
-        ctype = :nothing
+        ctype = false   # JLD2 disables compression with `compress=false`; the Symbol :nothing is
+                        # rejected by jldopen ("Unsupported Compressor"), which broke uncompressed saves.
     end
     return ctype
 end

--- a/src/functions/data/data_view.jl
+++ b/src/functions/data/data_view.jl
@@ -82,18 +82,19 @@ function viewdata(output::Int;
     vkeys = Dict() # versions keys
     for rname in fkeys
         if rname != "_types" && rname in string.([:hydro, :gravity, :particles, :clumps, :rt])
-            #println(rname)
-            ilink = rname * "/information"
-            ifk = JLD2.load(fpath, ilink)
-            ikeys[rname] = keys(ifk)
-            #println(ikeys[rname])
+            try
+                ilink = rname * "/information"
+                ifk = JLD2.load(fpath, ilink)
+                ikeys[rname] = keys(ifk)
 
-            vlink = ilink * "/versions"
-            vfk = JLD2.load(fpath, vlink)
-            vkeys[rname] = keys(vfk)
-            #println(vkeys[rname])
-
-            #println()
+                vlink = ilink * "/versions"
+                vfk = JLD2.load(fpath, vlink)
+                vkeys[rname] = keys(vfk)
+            catch e
+                # report which datatype could not be read instead of crashing opaquely on a
+                # corrupt/foreign entry; skip it so the rest of the overview still prints.
+                @warn "viewdata: could not read metadata for datatype '$rname' — skipping it." exception=e
+            end
         end
 
     end
@@ -105,14 +106,14 @@ function viewdata(output::Int;
         if rname != "_types" && rname in string.([:hydro, :gravity, :particles, :clumps, :rt])
             idata = Dict()
             vdata = Dict()
-            for i in ikeys[rname]
+            for i in get(ikeys, rname, String[])          # empty if the datatype was skipped above
                 if i != "versions"
                     ilink = rname * "/information/" * i
                     idata[i] = JLD2.load(fpath, ilink)
                 end
             end
 
-            for v in vkeys[rname]
+            for v in get(vkeys, rname, String[])
                 vlink = rname * "/information/" * "versions/" * v
                 vdata[v] = JLD2.load(fpath, vlink)
             end

--- a/src/functions/data/export_hydro_to_vtk.jl
+++ b/src/functions/data/export_hydro_to_vtk.jl
@@ -54,6 +54,27 @@ export_vtk(
 - **`verbose`:** If `true` (default), print detailed progress and diagnostic messages.
 
 """
+# Safe element-wise log10 for VTK export, shared by the hydro and particle exporters: log10(v) for
+# v>0, -30.0 for v==0 (instead of -Inf), and log10(|v|) for v<0 (with a count warning). This never
+# emits NaN/Inf — the previous `log10.()` broadcast on possibly-≤0 data produced NaN/-Inf that were
+# then silently overwritten with 0.0 (a valid log value), corrupting the export indistinguishably.
+function _safe_log10_vtk(raw, label::AbstractString; verbose::Bool=false)
+    out = Vector{Float64}(undef, length(raw))
+    nneg = 0
+    @inbounds for i in eachindex(raw)
+        val = raw[i]
+        if val > 0
+            out[i] = log10(val)
+        elseif val == 0
+            out[i] = -30.0
+        else
+            out[i] = log10(abs(val)); nneg += 1
+        end
+    end
+    (verbose && nneg > 0) && println("  Warning: $nneg negative value(s) for $label exported as log10(abs(val))")
+    return out
+end
+
 function export_vtk(
     dataobject::HydroDataType, outprefix::String;
     scalars::Vector{Symbol} = [:rho],
@@ -236,27 +257,7 @@ function export_vtk(
         for (s, sunit) in zip(scalars, scalars_unit)
             if scalars_log10
                 raw_arr = getvar(dataobject, s, sunit, mask=mask)
-                if raw_arr !== nothing
-                    # Safe log10: handle negative and zero values
-                    safe_arr = similar(raw_arr, Float64)
-                    for i in eachindex(raw_arr)
-                        val = raw_arr[i]
-                        if val > 0
-                            safe_arr[i] = log10(val)
-                        elseif val == 0
-                            safe_arr[i] = -30.0  # Very small log value instead of -Inf
-                        else
-                            # For negative values, use log10 of absolute value with warning
-                            safe_arr[i] = log10(abs(val))
-                            if verbose && i <= 5  # Only warn for first few negative values
-                                println("  Warning: Negative value ($val) encountered for $s, using log10(abs(val))")
-                            end
-                        end
-                    end
-                    arr = safe_arr
-                else
-                    arr = nothing
-                end
+                arr = raw_arr === nothing ? nothing : _safe_log10_vtk(raw_arr, string(s); verbose=verbose)
             else
                 arr = getvar(dataobject, s, sunit, mask=mask)
             end
@@ -270,23 +271,7 @@ function export_vtk(
                 if vector_log10
                     raw_arr = getvar(dataobject, v, vector_unit, mask=mask)
                     if raw_arr !== nothing
-                        # Safe log10: handle negative and zero values
-                        safe_arr = similar(raw_arr, Float64)
-                        for i in eachindex(raw_arr)
-                            val = raw_arr[i]
-                            if val > 0
-                                safe_arr[i] = log10(val)
-                            elseif val == 0
-                                safe_arr[i] = -30.0  # Very small log value instead of -Inf
-                            else
-                                # For negative values, use log10 of absolute value
-                                safe_arr[i] = log10(abs(val))
-                                if verbose && i <= 5  # Only warn for first few negative values
-                                    println("  Warning: Negative value ($val) encountered for $v, using log10(abs(val))")
-                                end
-                            end
-                        end
-                        arr = safe_arr
+                        arr = _safe_log10_vtk(raw_arr, string(v); verbose=verbose)
                     else
                         arr = nothing
                     end
@@ -340,16 +325,15 @@ function export_vtk(
         if export_vector
             vname = "$(outprefix)_vec_L$(L)"
             vtk_grid(vname, pts, cells; compress=compress, ascii=false) do vtk
-                mat = Matrix{Float64}(undef, 3, 8 * n)
-                for i in 1:n
-                    vx, vy, vz = vdata[vector[1]][i], vdata[vector[2]][i], vdata[vector[3]][i]
-                    base = (i - 1) * 8 + 1
-                    @inbounds for j in 0:7
-                        idx = base + j
-                        mat[1, idx] = vx; mat[2, idx] = vy; mat[3, idx] = vz
-                    end
+                # one vector per CELL (3×n), matching the scalar VTKCellData path. (Previously this was
+                # an 8×-replicated 3×(8n) point-data array — semantically odd and 8× larger on disk.)
+                mat = Matrix{Float64}(undef, 3, n)
+                @inbounds for i in 1:n
+                    mat[1, i] = vdata[vector[1]][i]
+                    mat[2, i] = vdata[vector[2]][i]
+                    mat[3, i] = vdata[vector[3]][i]
                 end
-                vtk[vector_name, VTKPointData()] = mat  # Attach vector data to points
+                vtk[vector_name, VTKCellData()] = mat
             end
             vec_path = vname * ".vtu"
             isfile(vec_path) || @error("Missing vector VTU: $vec_path")
@@ -387,7 +371,7 @@ function export_vtk(
         block_name = "Level_$(levels[i])"
         vtu_basename = basename(f)
         scalar_vtm_content *= """
-    <Block index="$i" name="$block_name">
+    <Block index="$(i-1)" name="$block_name">
       <DataSet index="0" file="$vtu_basename"/>
     </Block>
 """
@@ -428,7 +412,7 @@ function export_vtk(
             block_name = "vec_Level_$(levels[i])"
             vtu_basename = basename(f)
             vector_vtm_content *= """
-    <Block index="$i" name="$block_name">
+    <Block index="$(i-1)" name="$block_name">
       <DataSet index="0" file="$vtu_basename"/>
     </Block>
 """

--- a/src/functions/data/export_particles_to_vtk.jl
+++ b/src/functions/data/export_particles_to_vtk.jl
@@ -35,7 +35,7 @@ export_vtk(
 
 ##### Predefined/Optional Keywords:
 - **`scalars`:** List of scalar variables to export (default is particle mass);  from the database or a predefined quantity (see field: info, function getvar(), dataobject.data)
-- **`scalars_unit`**: Sets the unit for the list of scalars (default is Msun).
+- **`scalars_unit`**: Sets the unit for the list of scalars (default is `:Msol`).
 - **`scalars_log10`:** Apply log10 to the scalars (default false).
 - **`vector`:** List of vector component variables to export (default is missing).
 - **`vector_unit`:** Sets the unit for the vector components (default is km/s).
@@ -170,17 +170,11 @@ function export_vtk(
                 verbose && println("Warning: Scalar field '$s' is empty, using zeros")
                 arr = zeros(Float64, n_particles)
             elseif length(raw_data) < n_particles
-                verbose && println("Warning: Scalar field '$s' has insufficient data ($(length(raw_data)) < $n_particles), padding with zeros")
-                arr = Vector{Float64}(undef, n_particles)
-                arr[1:length(raw_data)] = raw_data[1:length(raw_data)]
-                arr[length(raw_data)+1:end] .= 0.0
+                error("export_vtk: scalar field '$s' returned $(length(raw_data)) values < $n_particles particles — refusing to zero-pad (would silently corrupt the export).")
             else
-                # Normal case: sufficient data available
-                if scalars_log10
-                    arr = log10.(raw_data[1:n_particles])
-                else
-                    arr = Vector{Float64}(raw_data[1:n_particles])
-                end
+                # Normal case: sufficient data available (safe log10 → never NaN/Inf)
+                arr = scalars_log10 ? _safe_log10_vtk(raw_data[1:n_particles], string(s); verbose=verbose) :
+                                      Vector{Float64}(raw_data[1:n_particles])
             end
             
             # Final validation - ensure array has correct length
@@ -221,17 +215,11 @@ function export_vtk(
                     verbose && println("Warning: Vector component '$v' is empty, using zeros")
                     arr = zeros(Float64, n_particles)
                 elseif length(raw_data) < n_particles
-                    verbose && println("Warning: Vector component '$v' has insufficient data, padding with zeros")
-                    arr = Vector{Float64}(undef, n_particles)
-                    arr[1:length(raw_data)] = raw_data[1:length(raw_data)]
-                    arr[length(raw_data)+1:end] .= 0.0
+                    error("export_vtk: vector component '$v' returned $(length(raw_data)) values < $n_particles particles — refusing to zero-pad (would silently corrupt the export).")
                 else
-                    # Normal case: sufficient data available
-                    if vector_log10
-                        arr = log10.(raw_data[1:n_particles])
-                    else
-                        arr = Vector{Float64}(raw_data[1:n_particles])
-                    end
+                    # Normal case: sufficient data available (safe log10 → never NaN/Inf)
+                    arr = vector_log10 ? _safe_log10_vtk(raw_data[1:n_particles], string(v); verbose=verbose) :
+                                         Vector{Float64}(raw_data[1:n_particles])
                 end
                 
                 # CRITICAL FIX: Validate vector component array length

--- a/test/10_io_export.jl
+++ b/test/10_io_export.jl
@@ -143,6 +143,21 @@ using JLD2
         end
     end
 
+    @testset "Data Save/Load: compress=false and regenerate_scales=false" begin
+        mktempdir() do test_dir
+            # uncompressed round-trip reproduces the data exactly
+            savedata(hydro, path=test_dir, fname="nc", fmode=:write, compress=false, verbose=false)
+            lnc = loaddata(hydro.info.output, path=test_dir, fname="nc", datatype=:hydro, verbose=false)
+            @test isapprox(getvar(lnc, :rho), getvar(hydro, :rho), rtol=1e-12)
+            @test isapprox(msum(lnc), msum(hydro), rtol=RTOL_UNITS)
+            # regenerate_scales=false keeps the stored scale (no error; data still round-trips)
+            l0 = loaddata(hydro.info.output, path=test_dir, fname="nc", datatype=:hydro,
+                          regenerate_scales=false, verbose=false)
+            @test l0.info.scale.kpc == hydro.info.scale.kpc
+            @test isapprox(getvar(l0, :rho), getvar(hydro, :rho), rtol=1e-12)
+        end
+    end
+
     # ========================================================================
     # Multi-component file: hydro + gravity + particle via fmode=:append
     # ========================================================================

--- a/test/19_vtk_export_tests.jl
+++ b/test/19_vtk_export_tests.jl
@@ -60,6 +60,17 @@
 
 @testset "VTK Export Tests" begin
 
+    # data-free unit test of the safe-log10 helper shared by both exporters (the HIGH bug was an
+    # unsafe log10. broadcast producing NaN/-Inf that were then silently zeroed):
+    @testset "safe log10 helper: no NaN/Inf, correct values" begin
+        out = Mera._safe_log10_vtk([10.0, 0.0, -5.0, 100.0], "test"; verbose=false)
+        @test !any(isnan, out) && !any(isinf, out)
+        @test out[1] ≈ 1.0                       # log10(10)
+        @test out[2] == -30.0                    # log10(0) → sentinel, NOT -Inf
+        @test out[3] ≈ log10(5.0)                # negative → log10(abs)
+        @test out[4] ≈ 2.0                       # log10(100)
+    end
+
     if !DATA_AVAILABLE
         @warn "Skipping VTK Export tests - simulation data not available"
         @test_skip "Simulation data not available"
@@ -437,6 +448,10 @@
             @test occursin("VTKFile", vtm_content)
             @test occursin("vtkMultiBlockDataSet", vtm_content)
             @test occursin("Block", vtm_content)
+            # VTM block indices must be 0-based (VTK convention) — was 1-based, which can make
+            # ParaView skip/misalign the first block.
+            idxs = [parse(Int, m.captures[1]) for m in eachmatch(r"<Block index=\"(\d+)\"", vtm_content)]
+            @test !isempty(idxs) && minimum(idxs) == 0 && idxs == collect(0:length(idxs)-1)
         end
 
         @testset "File Size Validation" begin


### PR DESCRIPTION
Remediation of the save/load (JLD2 mera-files) + VTK export expert-panel findings (panel 7.5/10 — the JLD2 table payload round-trips correctly; defects were in VTK and metadata-honesty). All three tiers — plus a latent bug the new tests caught.

## Tier 1 — correctness
- **VTK `log10` (the confirmed HIGH):** the particle exporter used `log10.()` on possibly-≤0 data, producing `NaN`/`-Inf` that were then *silently* overwritten with `0.0` (a valid log value) → corruption indistinguishable from real data. Extracted the hydro exporter's safe element-wise pattern into a shared `_safe_log10_vtk` (log10 for >0, `-30.0` for 0, log10|v| for <0 with a count warning) and use it at all four sites.
- **Particle export now errors** (was a silent zero-pad) when `getvar` returns fewer values than particles.
- **VTM block index 0-based** (was 1-based; VTK convention — 1-based can make ParaView skip/misalign the first block).
- **Uncompressed save was broken** *(found by the new test)*: `compress=false` made `check_compression` return the Symbol `:nothing`, which `jldopen` rejects (`Unsupported Compressor`). Now returns `false` (JLD2's disable value).

## Tier 2 — robustness / fidelity honesty
- **`loaddata`** gains `regenerate_scales::Bool=true`; documents that `info.constants`/`scale` are regenerated from the current Mera version by default (the one part of load that is *not* byte-for-byte) and `=false` keeps the stored values.
- **`convertdata`** records spatial-selection provenance (`xrange/yrange/zrange/range_unit` + a `subset` flag) so a filtered file is distinguishable from a full one, and notes compression stats are relative to the full-sim raw size.
- **Hydro VTK vectors** written as `VTKCellData` (3×n) instead of 8×-replicated point data (same value, ⅛ the size, semantically a cell quantity).
- **`viewdata`** wraps per-datatype loads in try/catch that names a failing/corrupt datatype instead of crashing opaquely.

## Tier 3 — tests / docs
- `test/19`: a data-free `_safe_log10_vtk` oracle (no NaN/Inf, correct values incl. the 0→-30 sentinel) and a 0-based VTM-index assertion.
- `test/10`: `compress=false` and `regenerate_scales=false` round-trip tests.
- Docstrings: particle `scalars_unit` default `:Msol` (was "Msun"); accurate `fmode=:append` re-append behavior.

## Deferred (noted)
The convert compression/memory *stats* recomputation from `summarysize` (vs full-sim `storageoverview`) is left as-is beyond the documenting note — it's cosmetic stats inside the 1123-line convert engine, no data impact.

## Verification
`test/10` (119) + `test/19` (67; 2 pre-existing `@test_broken`) green; package loads; docs build clean. VTK numeric-coordinate round-trip needs a VTK reader (no dep) — validated structurally (arrays/components/cell-counts/0-based blocks) instead.