### PR TITLE
regions panel remediation (all tiers): fix :standard center bug + direction + gravity cylinder

### DIFF
--- a/docs/src/03_hydro_Get_Subregions.md
+++ b/docs/src/03_hydro_Get_Subregions.md
@@ -425,9 +425,9 @@ cb = colorbar(im, label=labeltext);
 
 Define cylindrical selection parameters:
 - **Radius**: Circular cross-section extent in specified units
-- **Height**: Cylinder length along the axis direction (total height, extending in both directions from center)
+- **Height**: the **half-height** — the cylinder extends ±`height` from the center along the axis, so the total length is `2·height`
 - **Center**: Reference point with flexible coordinate specification (`:bc` for box center)
-- **Direction**: Cylinder axis orientation (`:z` by default)
+- **Direction**: Cylinder axis orientation (currently `:z` only; `:x`/`:y` are not yet implemented and raise an error)
 
 Extract cylindrical region with specified radius and height in physical units. The height parameter refers to the total extent in both directions from the central plane.
 

--- a/src/functions/prepranges.jl
+++ b/src/functions/prepranges.jl
@@ -168,8 +168,11 @@ function prepranges(    dataobject::InfoType,
             zmin = - radius + center[3]
             zmax =   radius + center[3]
         end
-        # given center relative to the data range in units: cell centers
-        #todo
+        # In :standard units, center/radius/height are ALREADY fractional box coordinates [0,1] — the
+        # same space the cell helpers (get_radius_sphere/_cylinder) and particle filters compare against.
+        # These shifts were previously left at 0.0 (the #todo), so a :standard sphere/cylinder ignored
+        # `center` and selected about the origin. (radius_shift/height_shift already default correctly.)
+        cx_shift = center[1]; cy_shift = center[2]; cz_shift = center[3]
 
     else
         selected_unit = getunit(dataobject, range_unit)
@@ -278,8 +281,9 @@ function prep_cylindrical_shellranges(    dataobject::InfoType,
         zmin = - height + center[3]
         zmax =   height + center[3]
 
-        # given center relative to the data range in units: cell centers
-        #todo
+        # :standard center is already fractional [0,1] (see prepranges sphere/cylinder note); set the
+        # axis shifts so cylindrical shells honour `center` instead of selecting about the origin.
+        cx_shift = center[1]; cy_shift = center[2]; cz_shift = center[3]
 
     else
         selected_unit = getunit(dataobject, range_unit)
@@ -386,8 +390,10 @@ function prep_spherical_shellranges(    dataobject::InfoType,
         zmin = - radius_out + center[3]
         zmax =   radius_out + center[3]
 
-        # given center relative to the data range in units: cell centers
-        #todo
+        # :standard center is already fractional [0,1] (see the prepranges note); set the shifts so the
+        # spherical shell honours `center` instead of selecting about the origin. (radius_*_shift already
+        # default correctly at the top.)
+        cx_shift = center[1]; cy_shift = center[2]; cz_shift = center[3]
 
     else
         selected_unit = getunit(dataobject, range_unit)

--- a/src/functions/regions/shellregion.jl
+++ b/src/functions/regions/shellregion.jl
@@ -68,6 +68,9 @@ function shellregion(dataobject::DataSetType, shape::Symbol=:cylinder;
     
     # subregion = wrapper over all subregion shell functions
     if shape == :cylinder || shape == :disc
+        # `direction` is not yet implemented for cylindrical shells (radial test always on x,y, height
+        # on z). Reject :x/:y rather than silently returning a z-oriented shell.
+        direction === :z || error("shellregion :cylinder currently supports only direction=:z; direction=:$(direction) is not implemented.")
         if typeof(dataobject) == HydroDataType || typeof(dataobject) == GravDataType
             return shellregioncylinder(dataobject,
                                         radius=radius,

--- a/src/functions/regions/subregion.jl
+++ b/src/functions/regions/subregion.jl
@@ -67,6 +67,8 @@ function subregion(dataobject::DataSetType, shape::Symbol=:cuboid;
     range_unit::Symbol=:standard,           # all
     cell::Bool=true,                        # hydro and gravity
     inverse::Bool=false,                    # all
+    smooth_boundary::Bool=false,            # hydro cylinder only
+    boundary_width::Real=0.1,               # hydro cylinder only
     verbose::Bool=true,             # all
     myargs::ArgumentsType=ArgumentsType() ) # all
 
@@ -83,6 +85,11 @@ function subregion(dataobject::DataSetType, shape::Symbol=:cuboid;
 
 
     verbose = checkverbose(verbose)
+    # `cell` (cell-overlap vs cell-centre selection) applies only to AMR cell data; warn if a user
+    # sets it on particles/clumps, where it is silently ignored.
+    if cell == false && !(typeof(dataobject) == HydroDataType || typeof(dataobject) == GravDataType || typeof(dataobject) == RtDataType)
+        @warn "subregion: `cell` only applies to AMR cell data (hydro/gravity/RT); it is ignored for $(typeof(dataobject))."
+    end
     # subregion = wrapper over all subregion functions
     if shape == :cuboid
         if typeof(dataobject) == HydroDataType || typeof(dataobject) == GravDataType
@@ -103,7 +110,11 @@ function subregion(dataobject::DataSetType, shape::Symbol=:cuboid;
         end
 
     elseif shape == :cylinder || shape == :disc
-        if typeof(dataobject) == HydroDataType || typeof(dataobject) == GravDataType
+        # `direction` is not yet implemented in the cylinder filter (the radial test is always on x,y
+        # and the height on z). Reject :x/:y rather than silently returning a z-oriented cylinder.
+        direction === :z || error("subregion :cylinder currently supports only direction=:z; direction=:$(direction) is not implemented (it would silently return a z-oriented cylinder).")
+        if typeof(dataobject) == HydroDataType
+            # only the hydro cylinder filter implements the smooth-boundary kwargs
             return subregioncylinder(dataobject,
                             radius=radius,
                             height=height,
@@ -112,8 +123,20 @@ function subregion(dataobject::DataSetType, shape::Symbol=:cuboid;
                             direction=direction,
                             cell=cell,
                             inverse=inverse,
-                            smooth_boundary=false,  # Default to sharp boundaries for backward compatibility
-                            boundary_width=0.1,     # Default boundary width
+                            smooth_boundary=smooth_boundary,
+                            boundary_width=boundary_width,
+                            verbose=verbose)
+        elseif typeof(dataobject) == GravDataType || typeof(dataobject) == RtDataType
+            # gravity/RT are AMR cells (accept `cell`) but do NOT take smooth_boundary — passing it
+            # here previously raised a MethodError, so cylinder subregions never worked for them.
+            return subregioncylinder(dataobject,
+                            radius=radius,
+                            height=height,
+                            center=center,
+                            range_unit=range_unit,
+                            direction=direction,
+                            cell=cell,
+                            inverse=inverse,
                             verbose=verbose)
         else
             return subregioncylinder(dataobject,

--- a/test/07_regions.jl
+++ b/test/07_regions.jl
@@ -572,22 +572,18 @@ end
     # preferred axis).  For a real fixture mass-counts may differ slightly
     # due to non-isotropy; assert that all three orientations select a
     # NON-EMPTY region with comparable mass (within a factor of 2).
-    @testset "Cylinder direction=:x/:y/:z" begin
+    # `direction` is only implemented for :z. :x/:y were previously a silent no-op (they returned a
+    # z-oriented cylinder, so this test passed tautologically with mass ratio 1.0); they now error.
+    @testset "Cylinder direction: :z works, :x/:y rejected" begin
         radius_kpc = boxlen_kpc / 4
         height_kpc = boxlen_kpc / 2
-        masses = Float64[]
-        for dir in [:x, :y, :z]
-            sub = subregion(hydro, :cylinder,
-                radius=radius_kpc, height=height_kpc,
-                direction=dir,
-                center=[:boxcenter], range_unit=:kpc, verbose=false)
-            @test sub isa Mera.HydroDataType
-            @test length(sub.data) > 0
-            push!(masses, msum(sub))
-        end
-        # All three orientations should be comparable in mass on a
-        # roughly-isotropic fixture.
-        @test maximum(masses) / minimum(masses) < 2.0
+        subz = subregion(hydro, :cylinder, radius=radius_kpc, height=height_kpc, direction=:z,
+                         center=[:boxcenter], range_unit=:kpc, verbose=false)
+        @test subz isa Mera.HydroDataType && length(subz.data) > 0
+        @test_throws ErrorException subregion(hydro, :cylinder, radius=radius_kpc, height=height_kpc,
+                         direction=:x, center=[:boxcenter], range_unit=:kpc, verbose=false)
+        @test_throws ErrorException subregion(hydro, :cylinder, radius=radius_kpc, height=height_kpc,
+                         direction=:y, center=[:boxcenter], range_unit=:kpc, verbose=false)
     end
 
     # ========================================================================
@@ -699,6 +695,45 @@ end
             end
         else
             @test_skip "spiral_ugrid not available for particle subregion tests"
+        end
+    end
+
+    # ========================================================================
+    # Regression: :standard center honored for sphere/cylinder/shell (A1/A2/A3)
+    # ========================================================================
+    # The :standard branch of prepranges left the center shifts at 0, so :standard sphere/cylinder/
+    # shell selected about the ORIGIN regardless of `center` (masked: fixtures have 1 code length ≈
+    # 1 kpc AND no off-origin :standard test existed). Lock-in: an off-origin :standard selection must
+    # return the SAME cells/particles as the equivalent :kpc selection, for every data type.
+    @testset "off-origin :standard selection == :kpc (center honored)" begin
+        cfrac = [0.6, 0.55, 0.5]; ckpc = cfrac .* boxlen_kpc
+        rfrac = 0.12; rkpc = rfrac * boxlen_kpc
+        hfrac = 0.08; hkpc = hfrac * boxlen_kpc
+        grav = load_test_gravity(:spiral_clumps)
+        for (nm, obj) in (("hydro", hydro), ("gravity", grav))
+            s_std = subregion(obj, :sphere, center=cfrac, radius=rfrac, range_unit=:standard, verbose=false)
+            s_kpc = subregion(obj, :sphere, center=ckpc,  radius=rkpc,  range_unit=:kpc,      verbose=false)
+            @test 0 < length(s_std.data) == length(s_kpc.data)
+            c_std = subregion(obj, :cylinder, center=cfrac, radius=rfrac, height=hfrac, range_unit=:standard, verbose=false)
+            c_kpc = subregion(obj, :cylinder, center=ckpc,  radius=rkpc,  height=hkpc,  range_unit=:kpc,      verbose=false)
+            @test 0 < length(c_std.data) == length(c_kpc.data)
+            sh_std = shellregion(obj, :sphere, center=cfrac, radius=[0.04, 0.14], range_unit=:standard, verbose=false)
+            sh_kpc = shellregion(obj, :sphere, center=ckpc,  radius=[0.04boxlen_kpc, 0.14boxlen_kpc], range_unit=:kpc, verbose=false)
+            @test 0 < length(sh_std.data) == length(sh_kpc.data)
+            # the selected sphere is actually centred at cfrac≈0.6 (NOT the origin — that was the bug)
+            xf = getvar(s_std, :x) ./ boxlen
+            @test 0.45 < (minimum(xf) + maximum(xf)) / 2 < 0.75
+        end
+        # particles (A3): off-origin :standard sphere == :kpc
+        ds_p = DATASETS[:spiral_ugrid]
+        if isdir(ds_p.path) && ds_p.has_particles
+            part = getparticles(getinfo(ds_p.output, ds_p.path, verbose=false), verbose=false, show_progress=false)
+            if length(part.data) > 0
+                bpk = part.boxlen * part.info.scale.kpc
+                ps_std = subregion(part, :sphere, center=[0.6,0.55,0.5], radius=0.12, range_unit=:standard, verbose=false)
+                ps_kpc = subregion(part, :sphere, center=[0.6bpk,0.55bpk,0.5bpk], radius=0.12bpk, range_unit=:kpc, verbose=false)
+                @test 0 < length(ps_std.data) == length(ps_kpc.data)
+            end
         end
     end
 


### PR DESCRIPTION
Remediation of the regions/subregions expert-panel findings (panel 5.5/10 — lowest of the sweep; the geometry math is sound but a silent wrong-selection bug dragged it down). All three tiers, plus a pre-existing bug the gravity coverage test surfaced.

## Tier 1 — CRITICAL correctness (silent wrong-selection)
- **`:standard` center ignored (A1/A2/A3, empirically verified).** The `:standard` branches of the sphere/cylinder, cylindrical-shell, and spherical-shell prep functions in `prepranges.jl` never set `cx/cy/cz_shift` (left `0.0` with a literal `#todo`), so a `:standard`-unit sphere/cylinder/shell selected about the **origin** regardless of `center`. Before: `subregion(:sphere, center=[0.7,0.5,0.5], range_unit=:standard)` selected x∈(0.008,0.102); after: matches the `:kpc` equivalent exactly. Masked because the fixtures have 1 code length ≈ 1 kpc **and** no off-origin `:standard` test existed. Fix: set the (already-fractional) shifts in all three `:standard` branches.
- **Cylinder `direction` was a silent no-op (B1/B2).** `:x`/`:y` returned a z-oriented cylinder; they now raise a clear error (axis-aware selection is future work).
- **Gravity/RT cylinder subregions never worked** *(found by the new gravity test)*: the dispatcher passed `smooth_boundary` to the gravity/RT `subregioncylinder` methods, which don't accept it → `MethodError`. Split the dispatch so only hydro gets `smooth_boundary`; gravity/RT take the `cell` path.

## Tier 2 — robustness / usability
- Exposed `smooth_boundary`/`boundary_width` through `subregion` (were hardcoded `false`/`0.1`, inaccessible).
- Warn when `cell=false` is passed to non-AMR data (silently ignored there).

## Tier 3 — tests / docs
- `test/07`: off-origin `:standard` vs `:kpc` regression for sphere/cylinder/shell across **hydro + gravity + particles** (would have caught A1/A2/A3); `direction` `:z` works / `:x`/`:y` error; gravity region coverage (which surfaced the dispatcher `MethodError`).
- Docs: cylinder `height` documented as the **half-height** (extends ±height; total 2·height); `direction` is `:z`-only.

## Verification
Off-origin `:standard` == `:kpc` confirmed for all data types; `test/07` (76) + `10_io_export` + `06_projections` green (no regression from the shared `prepranges` change); docs build clean.

Note: the `03_hydro_Get_Subregions.md` wording edit is in the rendered `docs/src` copy; the source notebook should get the same on its next render. Axis-aware `direction` (`:x`/`:y`) is left as a future feature (errors clearly for now).