### PR TITLE
docs: scrub leaked temp path from LOS cubes tutorial

### DIFF
--- a/docs/src/12_multi_LosCubes.md
+++ b/docs/src/12_multi_LosCubes.md
@@ -255,9 +255,9 @@ rm(tmp, force=true)
 ```
 
 ```
-Saved LOS cube (351, 346, 60) → /tmp/claude-502/jl_xAtypA3Uxq.jld2
+Saved LOS cube (351, 346, 60) → /tmp/jl_tmpcube.jld2
 Loaded LOS cube (351, 346, 60) ←
-/tmp/claude-502/jl_xAtypA3Uxq.jld2
+/tmp/jl_tmpcube.jld2
 round-trip identical: true
 ```
 


### PR DESCRIPTION
Replaces a session-specific temp path that leaked into the rendered output of the LOS cubes tutorial with a neutral path.

- docs/src/12_multi_LosCubes.md: a machine-specific /tmp/... path -> /tmp/jl_tmpcube.jld2 (2 occurrences, in a savecube/loadcube output block)

The code uses tempname(), so the original path was just whatever the render machine produced; the neutral path keeps the example output realistic without exposing an environment path.

Note: this is notebook-derived output. If the tutorial is re-rendered from its source notebook, the path could reappear unless the source notebook's stored output is also updated.
