### PR TITLE
getvar(RT): H2-aware species layout + xHI/xH2/n_H2 + H2-correct mu

### DIFF
--- a/docs/src/computation_reference.md
+++ b/docs/src/computation_reference.md
@@ -148,47 +148,55 @@ erroring.
 
 ## Radiative-transfer (RT) quantities
 
-These need an **RT run**: the ionization fractions are passive hydro scalars whose positions come
-from the RT descriptor (`info.descriptor.rt`, key `:iIons`, in RAMSES order HII, HeII, HeIII), and
-each quantity errors with a clear message on a non-RT run. The hydrogen number density used
-throughout is
+These need an **RT run**: the ionization fractions are passive hydro scalars located via the RT
+descriptor (`info.descriptor.rt`, key `:iIons`), and each quantity errors with a clear message on a
+non-RT run. RAMSES-RT stores them in a fixed order — ``[x_\mathrm{HI}`` *(only with H₂ chemistry)*
+``, x_\mathrm{HII}, x_\mathrm{HeII}, x_\mathrm{HeIII}`` *(only with He)* ``]`` — but writes no
+`isH2` flag, so Mera infers the layout from the species **count**:
+``n_\mathrm{Ions} = 1 + \mathtt{isH2} + 2\,\mathtt{isHe}`` ⇒ ``\mathtt{isH2} = \mathrm{iseven}(n_\mathrm{Ions})``
+(``\in\{2,4\}``) and ``\mathtt{isHe} = n_\mathrm{Ions}\ge 3``, and remaps every species accordingly.
+The hydrogen number density used throughout is
 
 ```math
 n_H = \rho\,\cdot\,\texttt{scale.nH}\,\cdot\,\frac{X}{0.76},
 ```
 
 i.e. `scale.nH` ``= (0.76/m_H)\,\mathrm{unit}_d`` rescaled by the run's **actual** hydrogen mass
-fraction ``X`` from the descriptor — so a pure-hydrogen (``X=1``) Strömgren test is correct, and the
-factor is 1 for the default ``X=0.76``.
+fraction ``X`` from the descriptor (so a pure-hydrogen ``X=1`` Strömgren test is correct; the factor
+is 1 for the default ``X=0.76``).
 
 ### Mean molecular weight & RT temperature
 
 | Quantity | Formula |
 |---|---|
-| Mean molecular weight `:mu` (RT) | ``\mu = \Big[\,X_H(1+x_\mathrm{HII}) + \tfrac{X_\mathrm{He}}{4}(1+x_\mathrm{HeII}+2x_\mathrm{HeIII}) + \tfrac{Z}{A_Z}\,\Big]^{-1}`` |
+| Mean molecular weight `:mu` | ``\mu = \Big[\,X_H\,h_p + \tfrac{X_\mathrm{He}}{4}(1+x_\mathrm{HeII}+2x_\mathrm{HeIII}) + \tfrac{Z}{A_Z}\,\Big]^{-1}`` |
 | RT-aware temperature `:T_rt` | ``T_\mathrm{rt} = (p/\rho)\cdot\texttt{scale.T\_mu}\cdot\mu`` |
 
-with ``X_H = X(1-Z)/(X+Y)`` and ``X_\mathrm{He} = Y(1-Z)/(X+Y)`` (so ``X_H+X_\mathrm{He}+Z = 1`` per
-cell), the primordial fractions ``X,Y`` from the RT descriptor, ``Z`` the local metal mass fraction
-(the `:metallicity` scalar; ``0`` if absent), and ``A_Z \approx 16`` a representative metal atomic
-mass. When He ionization is not tracked (``n_\mathrm{Ions} < 3``) He is taken neutral and the
-metal free-electron term is dropped (a sub-percent correction). The resulting ``\mu`` runs from
-``\approx 1.32`` (neutral) through ``\approx 0.6`` (ionized H+He) to ``\approx 0.5`` (ionized
-pure-H). On a **non-RT** run, `:mu` returns the constant `scale.K/scale.T_mu` and `:T_rt` reduces
+where the hydrogen particle count per H nucleus is ``h_p = 1 + x_\mathrm{HII}`` without H₂ chemistry,
+or ``h_p = x_\mathrm{HI} + 2x_\mathrm{HII} + x_{\mathrm{H_2}}`` with it (``h_p \to 1,\,0.5,\,2`` for
+neutral-atomic, fully-ionized, fully-molecular pure H). ``X_H = X(1-Z)/(X+Y)`` and ``X_\mathrm{He} =
+Y(1-Z)/(X+Y)`` (so ``X_H+X_\mathrm{He}+Z = 1`` per cell), with ``X,Y`` the primordial fractions, ``Z``
+the local metal mass fraction (`:metallicity`; ``0`` if absent), and ``A_Z \approx 16``. He is taken
+neutral when not tracked; metal free electrons are neglected (sub-percent). So ``\mu`` runs from
+``\approx 2`` (fully molecular) through ``\approx 1.32`` (neutral atomic) to ``\approx 0.5\text{–}0.6``
+(ionized). On a **non-RT** run, `:mu` returns the constant `scale.K/scale.T_mu` and `:T_rt` reduces
 exactly to `:T`.
 
-### Ionization fractions & number densities
+### Ionization & molecular fractions, number densities
 
 | Quantity | Formula |
 |---|---|
-| Ionized fractions `:xHII`, `:xHeII`, `:xHeIII` | passive scalars at descriptor `:iIons` (+0 / +1 / +2) |
-| Neutral H fraction `:xHI` | ``x_\mathrm{HI} = 1 - x_\mathrm{HII}`` |
+| Ionized fractions `:xHII`, `:xHeII`, `:xHeIII` | stored passive scalars (positions from the H₂-aware layout above) |
+| Neutral atomic-H fraction `:xHI` | a stored scalar with H₂ chemistry, else the closure ``1 - x_\mathrm{HII}`` |
+| Molecular-H fraction `:xH2` *(H₂ runs)* | ``x_{\mathrm{H_2}} = (1 - x_\mathrm{HI} - x_\mathrm{HII})/2`` |
 | Ionized-H density `:n_HII` | ``n_\mathrm{HII} = n_H\,x_\mathrm{HII}`` |
-| Neutral-H density `:n_HI` | ``n_\mathrm{HI} = n_H\,(1 - x_\mathrm{HII})`` |
+| Neutral-H density `:n_HI` | ``n_\mathrm{HI} = n_H\,x_\mathrm{HI}`` |
+| Molecular-H density `:n_H2` *(H₂ runs)* | ``n_{\mathrm{H_2}} = n_H\,x_{\mathrm{H_2}}`` |
 | Free-electron density `:n_e` | ``n_e = n_H\,x_\mathrm{HII} + n_\mathrm{He}\,(x_\mathrm{HeII} + 2x_\mathrm{HeIII})`` |
 
-with the helium number density ``n_\mathrm{He} = n_H\,Y/(4X)``. The He term in ``n_e`` is included
-only when He ionization is tracked (``n_\mathrm{Ions}\ge 3``); otherwise ``n_e = n_H\,x_\mathrm{HII}``.
+with ``n_\mathrm{He} = n_H\,Y/(4X)`` (the He term in ``n_e`` enters only when He is tracked; H₂ is
+neutral and contributes no electrons). `:xH2`/`:n_H2` require an H₂-chemistry run (even
+``n_\mathrm{Ions}``) and error otherwise.
 
 ### Recombination
 

--- a/src/functions/getvar/getvar.jl
+++ b/src/functions/getvar/getvar.jl
@@ -180,10 +180,18 @@ plus `[:L0_eV]`, `[:L1_eV]`, `[:spec2group]`).
 The ionization fractions are passive **hydro** scalars (located via the RT descriptor
 `info.descriptor.rt[:iIons]`); request them on the hydro object (`gas = gethydro(info)`):
 - **`:xHII`, `:xHeII`, `:xHeIII`**  ionization fractions (dimensionless)
-- **`:xHI`**                        neutral-hydrogen fraction = 1 − xHII (dimensionless)
-- **`:n_HII`, `:n_HI`, `:n_e`**     HII / HI / free-electron number density  [cm⁻³]
+- **`:xHI`**                        neutral atomic-hydrogen fraction (a *stored* scalar with H2 chemistry, else the closure 1 − xHII; dimensionless)
+- **`:xH2`**                        molecular-hydrogen fraction = (1 − xHI − xHII)/2 (**H2-chemistry runs only**; ½ ⇒ fully molecular)
+- **`:n_HII`, `:n_HI`, `:n_e`, `:n_H2`**  HII / HI / free-electron / H₂ number density  [cm⁻³] (`:n_H2` is H2-chemistry only)
 - **`:em_recomb`**                  recombination-emissivity proxy ∝ nₑ·n_HII ≈ n_HII²  [cm⁻⁶] (project with `mode=:sum` for a mock emission map)
-- **`:mu`**                         RT-aware mean molecular weight from the ionization state **and metallicity**: μ = 1/[X_H(1+xHII) + (X_He/4)(1+xHeII+2xHeIII) + Z/A_Z], with X_H/X_He scaled by the local metal mass fraction Z (the `:metallicity` scalar, 0 if absent) and A_Z≈16. Metal free electrons are neglected (RT does not track metal ionization).
+- **`:mu`**                         RT-aware mean molecular weight from the ionization (and, with H2 chemistry, molecular) state **and metallicity**: μ = 1/[X_H·hₚ + (X_He/4)(1+xHeII+2xHeIII) + Z/A_Z], where hₚ = 1+xHII (no H2) or xHI+2·xHII+xH2 (H2); X_H/X_He scaled by the local metal mass fraction Z (the `:metallicity` scalar, 0 if absent) and A_Z≈16. Metal free electrons are neglected (RT does not track metal ionization).
+
+!!! note "H₂-enabled RAMSES-RT runs"
+    With molecular-hydrogen chemistry (Nickerson et al. 2018) RAMSES stores an extra `xHI`
+    scalar *before* `xHII`, so the species order becomes `[xHI, xHII, xHeII, xHeIII]` and
+    `nIons` is even. Mera detects this from `nIons` (`isH2 = iseven(nIons)`, `isHe = nIons≥3`)
+    and remaps `:xHII`/`:xHeII`/`:xHeIII`/`:n_*`/`:mu`/`:T_rt` accordingly, and exposes `:xHI`,
+    `:xH2`, `:n_H2`. (Standard non-H₂ runs are unchanged.)
 - **`:T_rt`**                       gas temperature [K] using the **local** μ (= (P/ρ)·scale.T_mu·μ). Plain `:T` (unit=:K) bakes in a *constant* μ (= scale.K/scale.T_mu ≈ 1/0.76 ≈ 1.32, the fixed primordial default — independent of the run's X), so it over-estimates the ionized-gas temperature by μ_const/μ_local (e.g. ≈1.32/0.5 ≈ 2.6× for fully-ionized pure hydrogen). Prefer `:T_rt` for RT runs.
 
 ```julia

--- a/src/functions/getvar/getvar_hydro.jl
+++ b/src/functions/getvar/getvar_hydro.jl
@@ -1,29 +1,61 @@
-# RT-aware mean molecular weight μ from the tracked ionization state, including
-# metallicity when a per-cell metal mass fraction is available:
-#   μ = 1 / [ X_H(1+xHII) + (X_He/4)(1+xHeII+2xHeIII) + Z/A_Z ]
-# with X_H = X(1-Z)/(X+Y), X_He = Y(1-Z)/(X+Y) so that X_H+X_He+Z = 1 per cell.
+# RT-aware mean molecular weight μ from the tracked ionization (and, with H2 chemistry,
+# molecular) state, including metallicity when a per-cell metal mass fraction is available:
+#   μ = 1 / [ X_H·h_p + (X_He/4)(1+xHeII+2xHeIII) + Z/A_Z ]
+# where h_p is the number of hydrogen particles per H nucleus:
+#   h_p = 1 + xHII                  without H2 chemistry, or
+#   h_p = xHI + 2·xHII + xH2        with H2 chemistry, xH2 = (1−xHI−xHII)/2
+# (h_p → 1 / 0.5 / 2 for neutral-atomic / fully-ionized / fully-molecular pure H, so
+#  μ → 1 / 0.5 / 2 respectively). X_H = X(1-Z)/(X+Y), X_He = Y(1-Z)/(X+Y) ⇒ X_H+X_He+Z=1.
 #  • X, Y are the primordial H/He mass fractions from the RT descriptor (info_rt).
 #  • Z is the local metal mass fraction (the :metallicity hydro scalar); 0 if absent.
 #  • A_Z ≈ 16 is a representative mean atomic mass of metals (O-dominated).
-#  • He is assumed neutral when its ionization is not tracked (nIons < 3).
-#  • Metal FREE ELECTRONS are neglected: RAMSES-RT does not track metal ionization,
-#    and the metal electron term is a sub-percent correction to μ.
+#  • He is neutral when its ionization is not tracked; metal free electrons are neglected
+#    (RAMSES-RT does not track metal ionization; a sub-percent correction to μ).
 const _RT_A_METAL = 16.0
+
+# RAMSES-RT stores the ionization fractions as passive hydro scalars in a fixed order
+# (set in rt/rt_init.f90): [xHI (only with H2 chemistry), xHII, xHeII, xHeIII (only with
+# He)]. RAMSES writes no isH2 flag, so the species COUNT fixes the layout:
+#   nIons = 1 + isH2 + 2·isHe   ⇒   isH2 = iseven(nIons) (∈ {2,4}),  isHe = nIons ≥ 3.
+# `iIons` points at the FIRST stored fraction (xHI with H2, else xHII). Returns the
+# 1-based variable_list index of each species (0 if that species is not stored).
+function _rt_species(rtd)
+    i0 = rtd[:iIons]
+    nI = get(rtd, :nIons, 1)
+    isH2 = iseven(nI)
+    isHe = nI >= 3
+    iHII = i0 + (isH2 ? 1 : 0)
+    return (isH2=isH2, isHe=isHe,
+            iHI    = isH2 ? i0 : 0,
+            iHII   = iHII,
+            iHeII  = isHe ? iHII + 1 : 0,
+            iHeIII = isHe ? iHII + 2 : 0)
+end
+
 function _rt_mu(dataobject, data, rtd)
+    sp = _rt_species(rtd)
     vlist = dataobject.info.variable_list
     X = get(rtd, :X_fraction, 0.76)
     Y = get(rtd, :Y_fraction, 1.0 - X)
-    xHII = select(data, vlist[rtd[:iIons]])
+    xHII = select(data, vlist[sp.iHII])
     # local metal mass fraction (passive scalar) if the run tracks it
     Z = in(:metallicity, propertynames(data.columns)) ? select(data, :metallicity) : zero(xHII)
     XH  = @. X * (1.0 - Z) / (X + Y)
     XHe = @. Y * (1.0 - Z) / (X + Y)
-    if get(rtd, :nIons, 1) >= 3
-        xHeII  = select(data, vlist[rtd[:iIons] + 1])
-        xHeIII = select(data, vlist[rtd[:iIons] + 2])
-        return @. 1.0 / (XH*(1.0 + xHII) + (XHe/4)*(1.0 + xHeII + 2.0*xHeIII) + Z/_RT_A_METAL)
+    # hydrogen particles per H nucleus (atoms + protons + electrons, + H2 molecules)
+    if sp.isH2
+        xHI = select(data, vlist[sp.iHI])
+        xH2 = @. max((1.0 - xHI - xHII) / 2.0, 0.0)
+        hp  = @. xHI + 2.0*xHII + xH2
     else
-        return @. 1.0 / (XH*(1.0 + xHII) + (XHe/4) + Z/_RT_A_METAL)
+        hp  = @. 1.0 + xHII
+    end
+    if sp.isHe
+        xHeII  = select(data, vlist[sp.iHeII])
+        xHeIII = select(data, vlist[sp.iHeIII])
+        return @. 1.0 / (XH*hp + (XHe/4)*(1.0 + xHeII + 2.0*xHeIII) + Z/_RT_A_METAL)
+    else
+        return @. 1.0 / (XH*hp + (XHe/4) + Z/_RT_A_METAL)
     end
 end
 
@@ -212,17 +244,12 @@ function get_data(  dataobject::HydroDataType,
         # HII, HeII, HeIII. So :xHII = variable iIons, :xHeII = iIons+1, etc.
         elseif i == :xHII || i == :xHeII || i == :xHeIII
             rtd = dataobject.info.descriptor.rt
-            if !haskey(rtd, :iIons)
-                error("getvar :$i needs the RT ionization fractions (descriptor :iIons); load an RT run.")
-            end
-            offset = i == :xHII ? 0 : (i == :xHeII ? 1 : 2)
-            nions = get(rtd, :nIons, 0)
-            if offset + 1 > nions
-                error("getvar :$i: simulation tracks only $nions ion fraction(s).")
-            end
-            ion_var = dataobject.info.variable_list[rtd[:iIons] + offset]
+            haskey(rtd, :iIons) || error("getvar :$i needs the RT ionization fractions (descriptor :iIons); load an RT run.")
+            sp = _rt_species(rtd)                          # H2-aware species layout
+            ion_idx = i == :xHII ? sp.iHII : (i == :xHeII ? sp.iHeII : sp.iHeIII)
+            ion_idx == 0 && error("getvar :$i: this run does not track that species (nIons=$(get(rtd,:nIons,0))).")
             selected_unit = getunit(dataobject, i, vars, units)
-            vars_dict[i] = select(masked_data, ion_var) .* selected_unit
+            vars_dict[i] = select(masked_data, dataobject.info.variable_list[ion_idx]) .* selected_unit
 
         # Hydrogen recombination emissivity proxy: ∝ n_e·n_HII ≈ n_HII²  [cm^-6].
         # n_HII = n_H · xHII, with the ionization fraction taken from the hydro
@@ -233,10 +260,9 @@ function get_data(  dataobject::HydroDataType,
             if !haskey(rtd, :iIons)
                 error("getvar :em_recomb needs the RT ionization fraction (descriptor :iIons); load an RT run.")
             end
-            xion_var = dataobject.info.variable_list[rtd[:iIons]]   # e.g. :var6 = xHII
             selected_unit = getunit(dataobject, :em_recomb, vars, units)
             nH = _rt_nH(dataobject, masked_data, rtd)                     # n_H [cm^-3]
-            xhii = select(masked_data, xion_var)
+            xhii = select(masked_data, dataobject.info.variable_list[_rt_species(rtd).iHII])
             vars_dict[:em_recomb] = @. (nH * xhii)^2 * selected_unit
 
         # RT-derived number densities [cm^-3]. n_H = rho * scale.nH (= X/m_H * unit_d);
@@ -249,36 +275,70 @@ function get_data(  dataobject::HydroDataType,
             if !haskey(rtd, :iIons)
                 error("getvar :$i needs the RT ionization fractions (descriptor :iIons); load an RT run.")
             end
+            sp = _rt_species(rtd)
             selected_unit = getunit(dataobject, i, vars, units)
             vlist = dataobject.info.variable_list
             nH    = _rt_nH(dataobject, masked_data, rtd)                    # n_H [cm^-3], X from descriptor
-            xHII  = select(masked_data, vlist[rtd[:iIons]])
+            xHII  = select(masked_data, vlist[sp.iHII])
             if i == :n_HII
                 vars_dict[i] = @. nH * xHII * selected_unit
             elseif i == :n_HI
-                vars_dict[i] = @. nH * (1.0 - xHII) * selected_unit
-            else  # :n_e — free electrons from H, plus He if it is tracked (nIons >= 3)
+                # atomic neutral H: the stored xHI with H2 chemistry, else the closure 1 − xHII
+                xHI = sp.isH2 ? select(masked_data, vlist[sp.iHI]) : (1.0 .- xHII)
+                vars_dict[i] = @. nH * xHI * selected_unit
+            else  # :n_e — free electrons from H (H2 is neutral), plus He if it is tracked
                 ne = nH .* xHII
                 # Same X/Y fallback convention as _rt_mu (default X=0.76, Y=1-X) so the
                 # two paths agree when the descriptor omits the fractions.
                 Xf = get(rtd, :X_fraction, 0.76)
                 Yf = get(rtd, :Y_fraction, 1.0 - Xf)
-                if get(rtd, :nIons, 1) >= 3 && Xf > 0
+                if sp.isHe && Xf > 0
                     nHe    = nH .* (Yf / (4.0 * Xf))
-                    xHeII  = select(masked_data, vlist[rtd[:iIons] + 1])
-                    xHeIII = select(masked_data, vlist[rtd[:iIons] + 2])
+                    xHeII  = select(masked_data, vlist[sp.iHeII])
+                    xHeIII = select(masked_data, vlist[sp.iHeIII])
                     ne = @. ne + nHe * (xHeII + 2.0 * xHeIII)
                 end
                 vars_dict[i] = ne .* selected_unit
             end
 
-        # RT neutral-hydrogen fraction xHI = 1 - xHII (located via the descriptor).
+        # RT neutral atomic-hydrogen fraction xHI. With H2 chemistry RAMSES tracks xHI and
+        # xHII as SEPARATE stored scalars, so xHI is read directly; without H2 it is the
+        # closure 1 − xHII (located via the descriptor).
         elseif i == :xHI
             rtd = dataobject.info.descriptor.rt
             haskey(rtd, :iIons) || error("getvar :xHI needs the RT ionization fraction (descriptor :iIons); load an RT run.")
+            sp = _rt_species(rtd)
             selected_unit = getunit(dataobject, :xHI, vars, units)
-            xHII = select(masked_data, dataobject.info.variable_list[rtd[:iIons]])
-            vars_dict[:xHI] = (1.0 .- xHII) .* selected_unit
+            vlist = dataobject.info.variable_list
+            xHI = sp.isH2 ? select(masked_data, vlist[sp.iHI]) :
+                            (1.0 .- select(masked_data, vlist[sp.iHII]))
+            vars_dict[:xHI] = xHI .* selected_unit
+
+        # Molecular-hydrogen fraction (H2 chemistry only): xH2 = (1 − xHI − xHII)/2, the
+        # RAMSES-RT closure — H *molecules* per H nucleus (½ ⇒ fully molecular).
+        elseif i == :xH2
+            rtd = dataobject.info.descriptor.rt
+            haskey(rtd, :iIons) || error("getvar :xH2 needs an RT run with H2 chemistry (descriptor :iIons).")
+            sp = _rt_species(rtd)
+            sp.isH2 || error("getvar :xH2: this run has no H2 chemistry (nIons=$(get(rtd,:nIons,0)) is odd ⇒ xHI is not stored).")
+            selected_unit = getunit(dataobject, :xH2, vars, units)
+            vlist = dataobject.info.variable_list
+            xHI  = select(masked_data, vlist[sp.iHI])
+            xHII = select(masked_data, vlist[sp.iHII])
+            vars_dict[:xH2] = @. max((1.0 - xHI - xHII) / 2.0, 0.0) * selected_unit
+
+        # Molecular-hydrogen number density [cm^-3]: n_H2 = n_H · xH2 (molecules per H nucleus).
+        elseif i == :n_H2
+            rtd = dataobject.info.descriptor.rt
+            haskey(rtd, :iIons) || error("getvar :n_H2 needs an RT run with H2 chemistry (descriptor :iIons).")
+            sp = _rt_species(rtd)
+            sp.isH2 || error("getvar :n_H2: this run has no H2 chemistry (nIons=$(get(rtd,:nIons,0)) is odd).")
+            selected_unit = getunit(dataobject, :n_H2, vars, units)
+            vlist = dataobject.info.variable_list
+            nH   = _rt_nH(dataobject, masked_data, rtd)
+            xHI  = select(masked_data, vlist[sp.iHI])
+            xHII = select(masked_data, vlist[sp.iHII])
+            vars_dict[:n_H2] = @. nH * max((1.0 - xHI - xHII) / 2.0, 0.0) * selected_unit
 
         # Mean molecular weight μ.
         #  • RT run (descriptor :iIons present): ionization- and metallicity-dependent

--- a/test/32_rt_tests.jl
+++ b/test/32_rt_tests.jl
@@ -30,6 +30,29 @@
     @test Mera.RtDataType <: Mera.DataSetType
 end
 
+@testset "RT species layout / H2 detection (data-free)" begin
+    # RAMSES-RT stores ionization fractions in the order [xHI? , xHII, xHeII?, xHeIII?]
+    # (rt/rt_init.f90); the count fixes the layout: nIons = 1 + isH2 + 2·isHe, so
+    # isH2 = iseven(nIons) and isHe = nIons ≥ 3. _rt_species must remap accordingly.
+    sp = Mera._rt_species
+    # default (no H2, with He): [xHII, xHeII, xHeIII] — iIons → xHII (legacy layout)
+    s3 = sp(Dict(:iIons => 6, :nIons => 3))
+    @test (s3.isH2, s3.isHe) == (false, true)
+    @test (s3.iHI, s3.iHII, s3.iHeII, s3.iHeIII) == (0, 6, 7, 8)
+    # H2 + He: [xHI, xHII, xHeII, xHeIII] — iIons → xHI, everything shifts by one
+    s4 = sp(Dict(:iIons => 6, :nIons => 4))
+    @test (s4.isH2, s4.isHe) == (true, true)
+    @test (s4.iHI, s4.iHII, s4.iHeII, s4.iHeIII) == (6, 7, 8, 9)
+    # H only, no He: [xHII]
+    s1 = sp(Dict(:iIons => 6, :nIons => 1))
+    @test (s1.isH2, s1.isHe) == (false, false)
+    @test (s1.iHI, s1.iHII, s1.iHeII, s1.iHeIII) == (0, 6, 0, 0)
+    # H2, no He: [xHI, xHII]
+    s2 = sp(Dict(:iIons => 6, :nIons => 2))
+    @test (s2.isH2, s2.isHe) == (true, false)
+    @test (s2.iHI, s2.iHII, s2.iHeII, s2.iHeIII) == (6, 7, 0, 0)
+end
+
 if @isdefined(DATA_AVAILABLE) && DATA_AVAILABLE &&
    @isdefined(DATASETS) &&
    haskey(DATASETS, :rt_stromgren) && isdir(DATASETS[:rt_stromgren].path)


### PR DESCRIPTION
Makes Mera's RT-derived hydro fields correct for **H2-chemistry** RAMSES-RT runs (Nickerson, Teyssier & Rosdahl 2018), verified against the RAMSES source (rt/rt_init.f90, rt/rt_cooling_module.f90).

## Background
With H2 chemistry RAMSES stores an extra atomic-HI scalar **before** xHII, so the passive-scalar order becomes `[xHI, xHII, xHeII, xHeIII]` (vs `[xHII, xHeII, xHeIII]` by default), and the molecular fraction is the closure `xH2 = (1-xHI-xHII)/2`. RAMSES writes no isH2 flag; the count fixes it: `nIons = 1 + isH2 + 2*isHe`.

Previously Mera assumed the default order (iIons -> xHII), so on an H2 run `:xHII`/`:mu`/`:T_rt`/`:n_*` were misaligned by one and there was no molecular field.

## Changes (src/functions/getvar/getvar_hydro.jl)
- New `_rt_species(rtd)` — detects `isH2 = iseven(nIons)`, `isHe = nIons>=3`, returns the 1-based variable_list index of each species (0 if absent).
- `:xHII/:xHeII/:xHeIII`, `:n_HII/:n_HI/:n_e`, `:em_recomb` now use the H2-aware indices; `:n_HI` uses the *stored* xHI under H2 (else the 1-xHII closure).
- H2-correct mean molecular weight: hydrogen particle term `h_p = xHI + 2*xHII + xH2` (H2) vs `1 + xHII` (no H2). Limits: mu -> 2 (molecular), 1 (neutral atomic), 0.5 (ionized) for pure H.
- New fields **`:xHI`** (stored scalar under H2), **`:xH2`**, **`:n_H2`** (H2 runs only; clear error otherwise).
- Non-H2 runs are unchanged (odd nIons -> identical indices/formulas as before).

## Tests
- New data-free testset (`test/32_rt_tests.jl`) for `_rt_species` across nIons in {1,2,3,4}.
- Full RT suite green on real data: **163/163** (incl. 143 rt_stromgren real-data tests — backward compat).

## Docs
- `computation_reference.md` RT section updated: layout detection, h_p / mu, and the `:xHI/:xH2/:n_H2` rows; `getvar` docstring updated.

No new exports. `:xH2/:n_H2` resolve as getvar leaves (read-all fallback in the registry).