### PR TITLE
MHD: descriptor-aware variable naming + cell-centred B + magnetosonic Mach

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -51,6 +51,8 @@ makedocs(modules = [Mera],
 
                           "How Quantities Are Computed" => "computation_reference.md",
 
+                          "Magnetic Fields (MHD)" => "magnetic_fields.md",
+
                           "First Look"          => "report.md",
 
                           "Clump Finding"       => "clumpfind.md",

--- a/docs/src/computation_reference.md
+++ b/docs/src/computation_reference.md
@@ -129,7 +129,11 @@ corresponding specific component).
 
 ## Mach numbers
 
-*Data: **hydro**. The magnetosonic Mach numbers (`:mach_alfven`, `:mach_fast`, `:mach_slow`) need an MHD run with `:bx,:by,:bz`.*
+*Data: **hydro**. The magnetosonic Mach numbers (`:mach_alfven`, `:mach_fast`, `:mach_slow`) need an
+**MHD run**. RAMSES stores the field as 6 constrained-transport faces (`:b{x,y,z}_left/right`); Mera
+detects MHD from the `hydro_file_descriptor` (any descriptor version), names the variables canonically
+(`:rho/:vx/:vy/:vz/:p` at their true indices), and derives the cell-centred components
+`:bx,:by,:bz = ½(B_left + B_right)`. The Alfvén speed is `vₐ = |B|/√(4πρ)` (Gaussian-CGS).*
 
 | Quantity | Formula |
 |---|---|

--- a/docs/src/magnetic_fields.md
+++ b/docs/src/magnetic_fields.md
@@ -1,0 +1,93 @@
+# Magnetic Fields (MHD)
+
+Mera reads **RAMSES MHD** (ideal magnetohydrodynamics) outputs and exposes the magnetic field for
+analysis. RAMSES evolves **B** with a *constrained-transport* scheme, so the field is stored as the
+**six face-centred components** `B_{x,y,z}_left` and `B_{x,y,z}_right` in the ordinary hydro files
+(there are no separate magnetic-field files). The physically meaningful **cell-centred** field is the
+average of the two opposing faces,
+
+```math
+B_i = \tfrac12\,(B_{i,\text{left}} + B_{i,\text{right}}), \qquad i\in\{x,y,z\}.
+```
+
+## How Mera detects and names MHD variables
+
+In an MHD hydro file the variable order is
+
+```
+density, vx, vy, vz, B_x_left, B_y_left, B_z_left, B_x_right, B_y_right, B_z_right, [non-thermal], pressure, [scalars…]
+```
+
+so the thermal **pressure sits at index 11**, not 5 (index 5 is `B_x_left`). Mera handles this
+automatically across RAMSES versions:
+
+- **With a `hydro_file_descriptor.txt`** (post-2019 and 2025 outputs) Mera reads the variable names
+  directly and maps them to its canonical symbols (`density→:rho`, `velocity_*→:vx/:vy/:vz`,
+  `pressure→:p` at its true index, `B_*_{left,right}→:b*_{left,right}`).
+- **Without a descriptor** (older outputs) Mera uses the community heuristic (matching `yt`): a 3-D run
+  with `nvar ≥ 11` is treated as MHD (the constrained-transport module adds the three `B_right`
+  components). A short `@info` line is printed when this heuristic is applied.
+
+Either way you get canonical names and the cell-centred field `:bx`, `:by`, `:bz`.
+
+!!! note "Ambiguous no-descriptor case"
+    Without a descriptor, a *hydro* run that happens to carry exactly six passive scalars also has
+    `nvar = 11` and would be read as MHD. Modern RAMSES writes the descriptor, which removes the
+    ambiguity; if you hit this, the columns are still available positionally (`:var6…`).
+
+## A reproducible example (yt sample dataset)
+
+The yt project hosts a small RAMSES MHD test (a 3-D MHD tube). Download and extract it:
+
+```julia
+# in a shell:
+#   curl -LO https://yt-project.org/data/ramses_mhd_128.tar.gz
+#   tar -xzf ramses_mhd_128.tar.gz
+```
+
+```julia
+using Mera
+info = getinfo(27, "ramses_mhd_128")          # prints the MHD-layout info note
+gas  = gethydro(info)
+
+# canonical names: pressure is correct (index 11), B faces are present
+getvar(gas, :p)            # thermal pressure
+getvar(gas, :bx)           # cell-centred Bx = ½(bx_left + bx_right)
+getvar(gas, :T, :K)        # temperature, from the *correct* pressure
+```
+
+## Derived magnetic quantities
+
+```julia
+# field magnitude |B| (code units) from the cell-centred components
+bx, by, bz = getvar(gas, [:bx, :by, :bz])
+Bmag = sqrt.(bx.^2 .+ by.^2 .+ bz.^2)
+
+# magnetosonic Mach numbers (need the magnetic field)
+mA = getvar(gas, :mach_alfven)   # M_A = |v| / v_A,  v_A = |B|/√(4πρ)  (Gaussian-CGS)
+mf = getvar(gas, :mach_fast)     # fast:  v_f = √(c_s² + v_A²)
+ms = getvar(gas, :mach_slow)     # slow:  v_s = c_s·v_A/√(c_s² + v_A²)
+```
+
+The exact formulas (and the Alfvén-speed unit conversion) are listed in
+[How Quantities Are Computed](computation_reference.md#Mach-numbers).
+
+## Projecting the magnetic field
+
+The cell-centred components project like any other field — e.g. a mass-weighted map of `:bx`, or a
+column-density map alongside it:
+
+```julia
+using CairoMakie
+sd = projection(gas, :sd, :Msol_pc2; direction=:z)
+bx = projection(gas, :bx;            direction=:z)   # mass-weighted ⟨Bx⟩ map
+heatmap(bx.maps[:bx])
+```
+
+## Caveats
+
+- Mera reads **ideal-MHD** RAMSES outputs (the constrained-transport `B` faces). Non-ideal terms
+  (e.g. resistivity) are not separate fields.
+- `:bx/:by/:bz` are the **cell-centred** average of the faces; the raw faces remain available as
+  `:bx_left`, `:bx_right`, … if you need the divergence-free face representation.
+- On a non-MHD run, `:bx/:by/:bz` and the magnetosonic Mach numbers error with a clear message.

--- a/src/functions/getvar/fields.jl
+++ b/src/functions/getvar/fields.jl
@@ -68,6 +68,8 @@ const FIELD_DEPS = Dict{Symbol, Dict{Symbol,Vector{Symbol}}}(
     :mach_r_cylinder=>[:vr_cylinder,:cs], :mach_phi_cylinder=>[:vϕ_cylinder,:cs],
     :mach_r_sphere=>[:vr_sphere,:cs], :mach_theta_sphere=>[:vθ_sphere,:cs],
     :mach_phi_sphere=>[:vϕ_sphere,:cs],
+    # cell-centred magnetic field = mean of the constrained-transport faces (MHD runs)
+    :bx=>[:bx_left,:bx_right], :by=>[:by_left,:by_right], :bz=>[:bz_left,:bz_right],
     # magnetosonic Mach numbers (need the magnetic field components in addition to v / cs / rho)
     :mach_alfven=>[:v,:bx,:by,:bz,:rho],
     :mach_fast=>[:v,:cs,:bx,:by,:bz,:rho],

--- a/src/functions/getvar/getvar_hydro.jl
+++ b/src/functions/getvar/getvar_hydro.jl
@@ -791,84 +791,50 @@ function get_data(  dataobject::HydroDataType,
         elseif i == :mach_phi_sphere # azimuthal Mach number (spherical)
             vars_dict[:mach_phi_sphere] = getvar(filtered_dataobject, :vϕ_sphere, center=center, mask=use_mask_in_recursion) ./ getvar(filtered_dataobject, :cs, mask=use_mask_in_recursion)
 
-        # Magnetic Mach numbers (require magnetic field data)
-        elseif i == :mach_alfven # Alfvén Mach number
-            # Requires :bx, :by, :bz fields in the data
-            if :bx in column_names && :by in column_names && :bz in column_names
-                # Alfvén speed: v_A = B / sqrt(μ₀ * ρ) in SI or B / sqrt(4π * ρ) in Gaussian CGS
-                # For RAMSES code units: B is dimensionless, need to convert to physical units
-                B_total = sqrt.(select(masked_data, :bx).^2 .+ 
-                               select(masked_data, :by).^2 .+ 
-                               select(masked_data, :bz).^2)
-                rho = select(masked_data, :rho)
-                
-                # Convert B from code units to physical units (Gaussian CGS)
-                # In RAMSES: B_code = B_physical / sqrt(4π * ρ₀ * v₀²)
-                # So: B_physical = B_code * sqrt(4π * ρ₀ * v₀²)
-                unit_rho = dataobject.info.unit_d # g/cm³
-                unit_v = dataobject.info.unit_v   # cm/s
-                B_physical = B_total .* sqrt(4π * unit_rho * unit_v^2)
-                rho_physical = rho .* unit_rho
-                
-                # Alfvén speed in physical units: v_A = B / sqrt(4π * ρ) [cm/s]
-                v_alfven_physical = B_physical ./ sqrt.(4π .* rho_physical)
-                
-                # Convert back to code units for Mach number calculation
-                v_alfven = v_alfven_physical ./ unit_v
-                vars_dict[:mach_alfven] = getvar(filtered_dataobject, :v, mask=use_mask_in_recursion) ./ v_alfven
+        # Cell-centred magnetic field from the constrained-transport faces: B = ½(B_left + B_right).
+        # RAMSES-MHD stores the 6 face values (:b*_left/:b*_right); on a non-MHD run these columns
+        # are absent and :bx/:by/:bz error with a clear message.
+        elseif i == :bx || i == :by || i == :bz
+            faces = i === :bx ? (:bx_left, :bx_right) :
+                    i === :by ? (:by_left, :by_right) : (:bz_left, :bz_right)
+            selected_unit = getunit(dataobject, i, vars, units)
+            if faces[1] in column_names && faces[2] in column_names
+                vars_dict[i] = 0.5 .* (select(masked_data, faces[1]) .+ select(masked_data, faces[2])) .* selected_unit
+            elseif i in column_names                       # already cell-centred (manual)
+                vars_dict[i] = select(masked_data, i) .* selected_unit
             else
-                error("Magnetic field components (:bx, :by, :bz) not available for Alfvén Mach number calculation")
+                error("getvar :$i needs the magnetic field — load an MHD run (face fields " *
+                      ":$(faces[1])/:$(faces[2])); the default gethydro(info) (:all) reads them.")
             end
 
-        elseif i == :mach_fast # Fast magnetosonic Mach number
-            if :bx in column_names && :by in column_names && :bz in column_names
-                # Fast magnetosonic speed: v_f = sqrt(cs² + v_A²)
-                B_total = sqrt.(select(masked_data, :bx).^2 .+ 
-                               select(masked_data, :by).^2 .+ 
-                               select(masked_data, :bz).^2)
-                rho = select(masked_data, :rho)
-                
-                # Convert B from code units to physical units (same as above)
-                unit_rho = dataobject.info.unit_d
-                unit_v = dataobject.info.unit_v
-                B_physical = B_total .* sqrt(4π * unit_rho * unit_v^2)
-                rho_physical = rho .* unit_rho
-                
-                v_alfven_physical = B_physical ./ sqrt.(4π .* rho_physical)
-                v_alfven = v_alfven_physical ./ unit_v
-                
-                cs = getvar(filtered_dataobject, :cs, mask=use_mask_in_recursion)
-                v_fast = sqrt.(cs.^2 .+ v_alfven.^2)
-                vars_dict[:mach_fast] = getvar(filtered_dataobject, :v, mask=use_mask_in_recursion) ./ v_fast
-            else
-                error("Magnetic field components (:bx, :by, :bz) not available for fast magnetosonic Mach number calculation")
+        # Magnetic Mach numbers (Alfvén / fast / slow) — use the cell-centred B above.
+        elseif i == :mach_alfven || i == :mach_fast || i == :mach_slow
+            has_faces = (:bx_left in column_names && :by_left in column_names && :bz_left in column_names)
+            has_cc    = (:bx in column_names && :by in column_names && :bz in column_names)
+            if !(has_faces || has_cc)
+                error("Magnetic field (:bx/:by/:bz, or the MHD face fields :b*_left/:b*_right) " *
+                      "not available for the :$i calculation; load an MHD run.")
             end
-
-        elseif i == :mach_slow # Slow magnetosonic Mach number  
-            if :bx in column_names && :by in column_names && :bz in column_names
-                # Slow magnetosonic speed calculation
-                # Full formula: v_s = sqrt((cs² + v_A² - sqrt((cs² + v_A²)² - 4cs²v_A²cos²θ))/2)
-                # Isotropic approximation: v_s ≈ cs*v_A/sqrt(cs² + v_A²)
-                B_total = sqrt.(select(masked_data, :bx).^2 .+ 
-                               select(masked_data, :by).^2 .+ 
-                               select(masked_data, :bz).^2)
-                rho = select(masked_data, :rho)
-                
-                # Convert B from code units to physical units (same as above)
-                unit_rho = dataobject.info.unit_d
-                unit_v = dataobject.info.unit_v
-                B_physical = B_total .* sqrt(4π * unit_rho * unit_v^2)
-                rho_physical = rho .* unit_rho
-                
-                v_alfven_physical = B_physical ./ sqrt.(4π .* rho_physical)
-                v_alfven = v_alfven_physical ./ unit_v
-                
-                cs = getvar(filtered_dataobject, :cs, mask=use_mask_in_recursion)
-                # Improved slow magnetosonic speed approximation
-                v_slow = (cs .* v_alfven) ./ sqrt.(cs.^2 .+ v_alfven.^2)
-                vars_dict[:mach_slow] = getvar(filtered_dataobject, :v, mask=use_mask_in_recursion) ./ v_slow
+            bx = getvar(filtered_dataobject, :bx, mask=use_mask_in_recursion)
+            by = getvar(filtered_dataobject, :by, mask=use_mask_in_recursion)
+            bz = getvar(filtered_dataobject, :bz, mask=use_mask_in_recursion)
+            B_total = sqrt.(bx.^2 .+ by.^2 .+ bz.^2)               # |B|, code units
+            rho = select(masked_data, :rho)
+            # B code→physical (Gaussian CGS): B_phys = B_code·√(4π ρ₀ v₀²); v_A = B_phys/√(4π ρ_phys)
+            unit_rho = dataobject.info.unit_d   # g/cm³
+            unit_v   = dataobject.info.unit_v   # cm/s
+            B_physical = B_total .* sqrt(4π * unit_rho * unit_v^2)
+            v_alfven   = (B_physical ./ sqrt.(4π .* rho .* unit_rho)) ./ unit_v   # → code units
+            v = getvar(filtered_dataobject, :v, mask=use_mask_in_recursion)
+            if i === :mach_alfven
+                vars_dict[i] = v ./ v_alfven
             else
-                error("Magnetic field components (:bx, :by, :bz) not available for slow magnetosonic Mach number calculation")
+                cs = getvar(filtered_dataobject, :cs, mask=use_mask_in_recursion)
+                if i === :mach_fast
+                    vars_dict[i] = v ./ sqrt.(cs.^2 .+ v_alfven.^2)              # v_f = √(cs²+v_A²)
+                else  # :mach_slow — isotropic approximation v_s = cs·v_A/√(cs²+v_A²)
+                    vars_dict[i] = v ./ ((cs .* v_alfven) ./ sqrt.(cs.^2 .+ v_alfven.^2))
+                end
             end
 
 

--- a/src/read_data/RAMSES/getinfo.jl
+++ b/src/read_data/RAMSES/getinfo.jl
@@ -187,6 +187,29 @@ function readamrfile1!(dataobject::InfoType)
 
 end
 
+# Map a RAMSES hydro_file_descriptor variable name to Mera's canonical symbol.
+# Works for both descriptor versions (v0 "variable # i: name", v1 "ivar, name, type")
+# since both are parsed to the same name symbols. Recognised:
+#   density→:rho, velocity_{x,y,z}→:v{x,y,z}, (thermal_)pressure→:p,
+#   B_{x,y,z}_{left,right}→:b{x,y,z}_{left,right}.
+# Anything else is passed through lower-cased (e.g. :scalar_00, :metallicity).
+function _canonical_hydro_name(raw)
+    s = lowercase(strip(String(raw)))
+    s == "density"                                && return :rho
+    s == "velocity_x"                             && return :vx
+    s == "velocity_y"                             && return :vy
+    s == "velocity_z"                             && return :vz
+    (s == "pressure" || s == "thermal_pressure")  && return :p
+    m = match(r"^b_([xyz])_(left|right)$", s)
+    m !== nothing && return Symbol("b", m.captures[1], "_", m.captures[2])
+    return Symbol(s)
+end
+
+# A run is MHD (constrained transport) iff its hydro descriptor carries the
+# face-centred magnetic field components B_{x,y,z}_{left,right}.
+_is_mhd_descriptor(names) =
+    any(n -> occursin(r"^b_[xyz]_(left|right)$", lowercase(strip(String(n)))), names)
+
 function readhydrofile1!(dataobject::InfoType)
 
 
@@ -259,6 +282,16 @@ function readhydrofile1!(dataobject::InfoType)
 
     if !isfile(dataobject.fnames.hydro_descriptor)
         variable_descriptor_list = variable_list
+    end
+
+    # MHD (constrained transport): the hydro file stores 6 face-centred B components and
+    # shifts the thermal pressure, so the positional [:rho,:vx,:vy,:vz,:p,:var6…] guess is
+    # wrong (index 5 is B_x_left, not pressure). When the descriptor reveals MHD, take the
+    # variable names canonically from it (density→:rho, pressure→:p at its true index,
+    # B_*_{left,right}→:b*_{left,right}). Non-MHD layouts keep the positional names.
+    if descriptor_file && length(variable_descriptor_list) == nvarh &&
+       _is_mhd_descriptor(variable_descriptor_list)
+        variable_list = [_canonical_hydro_name(n) for n in variable_descriptor_list]
     end
 
     dataobject.hydro            = hydro_files

--- a/src/read_data/RAMSES/getinfo.jl
+++ b/src/read_data/RAMSES/getinfo.jl
@@ -210,6 +210,18 @@ end
 _is_mhd_descriptor(names) =
     any(n -> occursin(r"^b_[xyz]_(left|right)$", lowercase(strip(String(n)))), names)
 
+# Canonical hydro variable_list for an OLD (no-descriptor) 3D RAMSES MHD output. The MHD
+# solver adds 6 constrained-transport faces and shifts thermal pressure to index 11 (the
+# "+3" being B_right). Matches yt's no-descriptor heuristic (nvar ≥ 11, 3D ⇒ MHD); any
+# variables beyond pressure are kept as positional :var12, :var13, …
+function _mhd_nodescriptor_varlist(nvarh::Integer)
+    vl = [:rho, :vx, :vy, :vz, :bx_left, :by_left, :bz_left, :bx_right, :by_right, :bz_right, :p]
+    for i in 12:nvarh
+        push!(vl, Symbol("var$i"))
+    end
+    return vl
+end
+
 function readhydrofile1!(dataobject::InfoType)
 
 
@@ -292,6 +304,14 @@ function readhydrofile1!(dataobject::InfoType)
     if descriptor_file && length(variable_descriptor_list) == nvarh &&
        _is_mhd_descriptor(variable_descriptor_list)
         variable_list = [_canonical_hydro_name(n) for n in variable_descriptor_list]
+    elseif !descriptor_file && dataobject.ndim == 3 && nvarh >= 11
+        # No hydro descriptor (older RAMSES MHD): match yt's heuristic — a 3D run with
+        # nvar ≥ 11 is MHD (the CT module silently adds 3 to nvar). B faces at 5–10,
+        # thermal pressure at 11. (Regression-safe: non-MHD test runs all have nvarh ≤ 8.)
+        @info "Mera: no hydro descriptor and nvarh=$nvarh (≥11) on a 3D run — assuming a RAMSES " *
+              "MHD layout (B faces at 5–10, pressure at 11). If this is hydro with ≥6 passive " *
+              "scalars instead, the names are positional (:var6…)."
+        variable_list = _mhd_nodescriptor_varlist(nvarh)
     end
 
     dataobject.hydro            = hydro_files

--- a/src/read_data/RAMSES/prepvariablelist.jl
+++ b/src/read_data/RAMSES/prepvariablelist.jl
@@ -11,7 +11,36 @@ function prepvariablelist(dataobject::InfoType, datatype::Symbol, vars::Array{Sy
         hydrovar_buffer = copy(vars)
         used_descriptors = Dict()
 
-        if in(:all, hydrovar_buffer) #hydrovar_buffer == [:all]
+        # MHD runs carry canonical per-index names in variable_list (incl. :b*_left/:b*_right
+        # and :p at its true, shifted index), so resolve requested symbols by NAME from it.
+        # Non-MHD outputs keep the original positional resolution (:p→5, :varN→N) unchanged.
+        vlist_mhd = dataobject.variable_list
+        is_mhd = any(v -> occursin(r"^b[xyz]_(left|right)$", string(v)), vlist_mhd)
+        if is_mhd
+            if in(:cpu, hydrovar_buffer) || in(:varn1, hydrovar_buffer)
+                read_cpu = true
+            end
+            if in(:all, hydrovar_buffer)
+                nvarh_list = collect(1:nvarh)
+            else
+                for x in hydrovar_buffer
+                    (x === :cpu || x === :varn1 || x === :all) && continue
+                    idx = findfirst(==(x), vlist_mhd)
+                    if idx !== nothing
+                        push!(nvarh_list, idx)
+                    elseif occursin("var", string(x))     # explicit :varN index still works
+                        push!(nvarh_list, parse(Int, string(x)[4:end]))
+                    else
+                        error("[Mera]: variable :$x not found in this MHD hydro output. " *
+                              "Available names: $(vlist_mhd)")
+                    end
+                end
+            end
+            for i in unique(nvarh_list)
+                used_descriptors[i] = vlist_mhd[i]
+            end
+
+        elseif in(:all, hydrovar_buffer) #hydrovar_buffer == [:all]
             nvarh_list=[1,2,3,4,5]
 
             # read_cpu = true
@@ -110,15 +139,13 @@ function prepvariablelist(dataobject::InfoType, datatype::Symbol, vars::Array{Sy
         nvarh_list_strings= Symbol[]
         if read_cpu append!(nvarh_list_strings, [:cpu]) end
         for i in nvarh_list
-            #if !haskey(used_descriptors, i)
-                if i < 6
-                    append!(nvarh_list_strings, [Symbol("$(indices_tovariables[i])")])
-                elseif i > 5
-                    append!(nvarh_list_strings, [Symbol("var$i")])
-                end
-            #else
-            #    append!(nvarh_list_strings, [used_descriptors[i]])
-            #end
+            if haskey(used_descriptors, i)            # MHD / descriptor-named columns
+                append!(nvarh_list_strings, [used_descriptors[i]])
+            elseif i < 6
+                append!(nvarh_list_strings, [Symbol("$(indices_tovariables[i])")])
+            else
+                append!(nvarh_list_strings, [Symbol("var$i")])
+            end
         end
 
 

--- a/test/03_data_readers.jl
+++ b/test/03_data_readers.jl
@@ -56,6 +56,30 @@
 # whole file is skipped via @test_skip.  Individual missing datasets
 # inside the file degrade to per-testset skips.
 
+# Data-free: MHD / hydro-descriptor name handling (constrained-transport B fields).
+# Runs on the full CI matrix; verifies the version-robust descriptor → canonical-name
+# mapping and MHD detection without needing a simulation on disk.
+@testset "MHD descriptor naming (data-free)" begin
+    cn = Mera._canonical_hydro_name
+    ismhd = Mera._is_mhd_descriptor
+    # canonical name normalisation (same for descriptor v0 and v1 — both parse to these names)
+    @test cn("density") == :rho
+    @test cn("velocity_x") == :vx && cn("velocity_y") == :vy && cn("velocity_z") == :vz
+    @test cn("pressure") == :p && cn("thermal_pressure") == :p
+    @test cn("B_x_left") == :bx_left && cn("B_z_right") == :bz_right
+    @test cn("scalar_00") == :scalar_00 && cn("metallicity") == :metallicity
+    # MHD detection from the face fields
+    mhd_names = [:density, :velocity_x, :velocity_y, :velocity_z,
+                 Symbol("B_x_left"), Symbol("B_y_left"), Symbol("B_z_left"),
+                 Symbol("B_x_right"), Symbol("B_y_right"), Symbol("B_z_right"), :pressure]
+    hyd_names = [:density, :velocity_x, :velocity_y, :velocity_z, :pressure, :scalar_00]
+    @test ismhd(mhd_names) == true
+    @test ismhd(hyd_names) == false
+    # the resulting canonical variable_list places :p at its true (shifted) index, B at the faces
+    @test [cn(n) for n in mhd_names] ==
+          [:rho, :vx, :vy, :vz, :bx_left, :by_left, :bz_left, :bx_right, :by_right, :bz_right, :p]
+end
+
 if !DATA_AVAILABLE
     @warn "Skipping Data Readers tests - simulation data not available"
     @test_skip "Simulation data not available"

--- a/test/03_data_readers.jl
+++ b/test/03_data_readers.jl
@@ -782,3 +782,39 @@ end
     end
 
 end
+
+# Real RAMSES MHD output (yt sample "ramses_mhd_128"): exercises MHD detection, the
+# constrained-transport face fields, the shifted pressure index, and cell-centred B.
+if @isdefined(DATASETS) && haskey(DATASETS, :ramses_mhd) && isdir(DATASETS[:ramses_mhd].path)
+    @testset "MHD reading (ramses_mhd_128)" begin
+        ds   = DATASETS[:ramses_mhd]
+        info = getinfo(ds.output, ds.path, verbose=false)
+
+        # MHD layout: B faces at 5–10, thermal pressure at index 11 (NOT index 5)
+        @test info.variable_list[1] == :rho
+        @test info.variable_list[5] == :bx_left
+        @test info.variable_list[11] == :p
+        @test :bx_right in info.variable_list && :bz_left in info.variable_list
+
+        gas  = gethydro(info, verbose=false, show_progress=false)
+        cols = propertynames(gas.data.columns)
+        @test :p in cols && :bx_left in cols && :bx_right in cols
+
+        # pressure must be the real (positive, varying) thermal pressure, not the constant
+        # B_x field that index 5 would have given under the old positional mislabelling
+        p = getvar(gas, :p)
+        @test all(p .> 0)
+        @test maximum(p) > minimum(p)            # it varies (a shock tube), unlike |B_x|
+
+        # cell-centred B equals the mean of the two stored faces
+        bx   = getvar(gas, :bx)
+        bxl  = select(gas.data, :bx_left); bxr = select(gas.data, :bx_right)
+        @test bx ≈ 0.5 .* (bxl .+ bxr)
+
+        # magnetosonic Mach numbers now compute (require B) and are finite & non-negative
+        for q in (:mach_alfven, :mach_fast, :mach_slow)
+            m = getvar(gas, q)
+            @test all(isfinite.(m)) && all(m .>= 0)
+        end
+    end
+end

--- a/test/test_config.jl
+++ b/test/test_config.jl
@@ -110,6 +110,20 @@ const DATASETS = Dict(
         has_clumps = false,
         has_rt = true
     ),
+    # RAMSES MHD (constrained transport) — yt community sample "ramses_mhd_128"
+    # (3-D MHD tube test, output_00027). Ships WITHOUT a hydro_file_descriptor
+    # (older format), so MHD is detected from the nvar≥11 / 3-D heuristic; the 6
+    # face-centred B components give cell-centred :bx/:by/:bz = ½(left+right).
+    # Download: https://yt-project.org/data/ramses_mhd_128.tar.gz (extract output_00027 here)
+    :ramses_mhd => (
+        path = joinpath(SIMULATION_PATH, "ramses_mhd_128"),
+        output = 27,
+        has_hydro = true,
+        has_gravity = false,
+        has_particles = false,
+        has_clumps = false,
+        has_mhd = true
+    ),
 )
 
 # Test tolerances


### PR DESCRIPTION
Makes Mera read **RAMSES MHD** (constrained-transport) outputs correctly, across descriptor versions (pre-2019 v0, post-2019 v1, 2025), verified against the RAMSES source (`hydro/output_hydro.f90`) **and a real yt MHD dataset**.

## Problem
In an MHD hydro file the variable order is `density, vx, vy, vz, B_x_left, B_y_left, B_z_left, B_x_right, B_y_right, B_z_right, [non-thermal], pressure, …` — so index 5 is **B_x_left**, not pressure. Mera's positional default mislabelled index 5 as `:p` (so `:T`/`:cs`/`:p` used B_x_left as pressure), never cell-centred the B field, and the magnetosonic Mach numbers required columns literally named `:bx/:by/:bz` (so they errored).

## Fix
- **MHD detection across versions:**
  - *With a `hydro_file_descriptor`* (post-2019 / 2025): detect MHD from the face fields `B_*_left/right` and name variables canonically from the descriptor.
  - *Without a descriptor* (older RAMSES): match yt's heuristic — a 3-D run with `nvar ≥ 11` is MHD (the CT module adds 3 for `B_right`); emits an `@info` note. Regression-safe (all non-MHD test data have `nvarh ≤ 8`).
- **Canonical naming:** `density→:rho`, `velocity_*→:vx..`, `(thermal_)pressure→:p` at its true index, `B_*_{left,right}→:b*_{left,right}`; `prepvariablelist` resolves symbols by name. **Non-MHD layouts unchanged** (positional path intact).
- **Cell-centred field:** new getvar `:bx/:by/:bz = ½(B_left + B_right)`; the magnetosonic Mach numbers now use them. Alfvén speed `vₐ=|B|/√(4πρ)` unchanged.

## Verification
- **Real RAMSES MHD data** — added the yt community sample `ramses_mhd_128` (3-D MHD tube, no descriptor) to the suite. New data-backed test (`test/03`) confirms: pressure read at index 11 (positive & varying — not the constant `|B_x|`), `:bx = ½(faces)`, magnetosonic Mach finite/≥0.
- **Data-free unit tests** (`test/03`): canonical-name mapping, MHD detection, shifted-pressure layout — runs on the full CI matrix.
- **Regression on real non-MHD data: 203/203** (readers incl. the MHD block) and previously 472/472 across readers/derived/RT — no behaviour change for existing runs.

## Docs
- New tutorial **Magnetic Fields (MHD)** (`docs/src/magnetic_fields.md`, in nav) — storage, version-robust detection, cell-centred B, magnetosonic Mach, and a reproducible example using the downloadable yt sample.
- `computation_reference` Mach-number note updated.

Source: yt RAMSES MHD heuristic ([field_handlers.py](https://github.com/yt-project/yt)); dataset [ramses_mhd_128.tar.gz](https://yt-project.org/data/ramses_mhd_128.tar.gz).
