### PR TITLE
Descriptor-driven database column names for hydro + particles

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,9 @@ using Mera
 quicklook(80; path="/path/to/simulation")
 ```
 
-![quicklook dashboard: gas surface-density projections, stellar and dark-matter maps, a density–temperature phase diagram, and a per-component census](docs/src/assets/features/quicklook_dashboard.png)
-
-*One call: mass-weighted gas Σ (face-on + two edge-on views), stellar and dark-matter surface
-density, the ρ–T phase diagram, and a census of cell/particle counts, component masses and SFR.*
+*One call produces a first-look dashboard: mass-weighted gas Σ (face-on + two edge-on views), stellar
+and dark-matter surface density, the ρ–T phase diagram, and a census of cell/particle counts,
+component masses and SFR.*
 
 ## 30-second quickstart
 
@@ -113,15 +112,17 @@ Barnes–Hut self-potential, SUBFIND-style unbinding and tidal (Hill-radius) tru
 
 ## A taste of the features
 
-| Feature | Use case | Figure |
-|---|---|---|
-| Flux budgets | inflow/outflow through surfaces (winds, accretion) | ![flux geometries](docs/src/assets/features/flux_geometries.png) |
-| Clump catalogs | star-forming clouds, halo substructure, dense cores | ![clump mass function](docs/src/assets/features/clump_massfunction.png) |
-| Covering grids | FFTs, power spectra, ML inputs | ![covering grid slice](docs/src/assets/features/covering_grid_slice.png) |
-| Phase diagrams | gas thermodynamics, phase structure | ![phase diagram](docs/src/assets/features/flux_phases.png) |
-| Derived fields | temperature, Mach, Jeans, angular momentum | ![derived fields](docs/src/assets/features/derived_fields.png) |
-| Profiles | radial density, SFR, metallicity | ![profile](docs/src/assets/features/fluxprofile.png) |
-| Radiative transfer | Strömgren sphere, ionization fronts | ![RT Strömgren](docs/src/assets/features/rt_stromgren.png) |
+| Feature | Use case |
+|---|---|
+| Flux budgets | inflow/outflow through surfaces (winds, accretion) |
+| Clump catalogs | star-forming clouds, halo substructure, dense cores |
+| Covering grids | FFTs, power spectra, ML inputs |
+| Phase diagrams | gas thermodynamics, phase structure |
+| Derived fields | temperature, Mach, Jeans, angular momentum |
+| Profiles | radial density, SFR, metallicity |
+| Radiative transfer | Strömgren sphere, ionization fronts |
+
+See the [documentation](https://manuelbehrendt.github.io/Mera.jl/stable/) for worked examples and figures.
 
 ## Installation
 

--- a/docs/src/00_multi_FirstSteps.md
+++ b/docs/src/00_multi_FirstSteps.md
@@ -157,7 +157,7 @@ level(s): 6 - 10 --> cellsize(s): 750.0 [pc] - 46.88 [pc]
 -------------------------------------------------------
 hydro:         true
 hydro-variables:
-7  --> (:rho, :vx, :vy, :vz, :p, :var6, :var7)
+7  --> (:rho, :vx, :vy, :vz, :p, :scalar_00, :scalar_01)
 hydro-descriptor: (:density, :velocity_x, :velocity_y, :velocity_z, :pressure, :scalar_00, :scalar_01)
 γ: 1.6667
 -------------------------------------------------------
@@ -278,7 +278,7 @@ nvarh	= 7
 nvarp	= 7
 nvarrt	= 0
 variable_list	=
-[:rho, :vx, :vy, :vz, :p, :var6, :var7]
+[:rho, :vx, :vy, :vz, :p, :scalar_00, :scalar_01]
 gravity_variable_list	= [:epot, :ax, :ay, :az]
 particles_variable_list	= [:vx, :vy, :vz, :mass, :family, :tag, :birth]
 rt_variable_list	= Symbol[]

--- a/docs/src/01_clumps_First_Inspection.md
+++ b/docs/src/01_clumps_First_Inspection.md
@@ -139,7 +139,7 @@ level(s): 6 - 14 --> cellsize(s): 750.0 [pc] - 2.93 [pc]
 -------------------------------------------------------
 hydro:         true
 hydro-variables:
-7  --> (:rho, :vx, :vy, :vz, :p, :var6, :var7)
+7  --> (:rho, :vx, :vy, :vz, :p, :passive_scalar_1, :passive_scalar_2)
 hydro-descriptor: (:density, :velocity_x, :velocity_y, :velocity_z, :thermal_pressure, :passive_scalar_1, :passive_scalar_2)
 γ: 1.6667
 -------------------------------------------------------

--- a/docs/src/01_gravity_First_Inspection.md
+++ b/docs/src/01_gravity_First_Inspection.md
@@ -131,7 +131,7 @@ level(s): 6 - 10 --> cellsize(s): 750.0 [pc] - 46.88 [pc]
 -------------------------------------------------------
 hydro:         true
 hydro-variables:
-7  --> (:rho, :vx, :vy, :vz, :p, :var6, :var7)
+7  --> (:rho, :vx, :vy, :vz, :p, :scalar_00, :scalar_01)
 hydro-descriptor: (:density, :velocity_x, :velocity_y, :velocity_z, :pressure, :scalar_00, :scalar_01)
 γ: 1.6667
 -------------------------------------------------------

--- a/docs/src/01_hydro_First_Inspection.md
+++ b/docs/src/01_hydro_First_Inspection.md
@@ -48,7 +48,8 @@ info.descriptor.hydro[2] = :vel_x                     # Customize variable names
 propertynames(info.descriptor)                        # All descriptor properties
 
 # Access predefined variables (always available)
-# :rho, :vx, :vy, :vz, :p, :var6, :var7, ...
+# :rho, :vx, :vy, :vz, :p, then passive scalars by descriptor name
+# (e.g. :metallicity, :scalar_00, ...) or positional :var6, :var7, ... without a descriptor
 ```
 
 ### IndexedTables Operations
@@ -153,7 +154,7 @@ level(s): 6 - 10 --> cellsize(s): 750.0 [pc] - 46.88 [pc]
 -------------------------------------------------------
 hydro:         true
 hydro-variables:
-7  --> (:rho, :vx, :vy, :vz, :p, :var6, :var7)
+7  --> (:rho, :vx, :vy, :vz, :p, :scalar_00, :scalar_01)
 hydro-descriptor: (:density, :velocity_x, :velocity_y, :velocity_z, :pressure, :scalar_00, :scalar_01)
 γ: 1.6667
 -------------------------------------------------------
@@ -190,7 +191,7 @@ The output above provides a comprehensive overview of the loaded hydro data prop
 
 ## Variable Names and Descriptors
 
-**Predefined Variable Names**: Mera.jl recognizes standard hydro variable names such as `:rho`, `:vx`, `:vy`, `:vz`, `:p`, `:var6`, `:var7`, etc. These provide a consistent interface for accessing common hydrodynamic quantities across different simulations.
+**Predefined Variable Names**: Mera.jl recognizes the standard hydro variable names `:rho`, `:vx`, `:vy`, `:vz`, `:p`. Passive scalars beyond pressure are named from the `hydro_file_descriptor.txt` when present (e.g. `:metallicity`, `:scalar_00`, `:scalar_01`), and fall back to positional names (`:var6`, `:var7`, ...) only when the output ships no descriptor. Positional `:varN` selectors keep working in both cases, so older scripts continue to load the same columns.
 
 **Custom Variable Descriptors**: In future versions, you will be able to use variable names directly from the hydro descriptor by setting `info.descriptor.usehydro = true`. Currently, you can customize variable names by modifying the descriptor array manually.
 
@@ -318,7 +319,7 @@ gas = gethydro(info);
 ```
 [Mera]: Get hydro data: 2026-06-01T14:05:24.175
 Key vars=(:level, :cx, :cy, :cz)
-Using var(s)=(1, 2, 3, 4, 5, 6, 7) = (:rho, :vx, :vy, :vz, :p, :var6, :var7)
+Using var(s)=(1, 2, 3, 4, 5, 6, 7) = (:rho, :vx, :vy, :vz, :p, :scalar_00, :scalar_01)
 domain:
 xmin::xmax: 0.0 :: 1.0  	==> 0.0 [kpc] :: 48.0 [kpc]
 ymin::ymax: 0.0 :: 1.0  	==> 0.0 [kpc] :: 48.0 [kpc]
@@ -410,7 +411,7 @@ viewfields(gas)
 ```
 
 ```
-data ==> IndexedTables: (:level, :cx, :cy, :cz, :rho, :vx, :vy, :vz, :p, :var6, :var7)
+data ==> IndexedTables: (:level, :cx, :cy, :cz, :rho, :vx, :vy, :vz, :p, :scalar_00, :scalar_01)
 info ==> subfields: (:output, :path, :fnames, :simcode, :mtime, :ctime, :ncpu, :ndim, :levelmin, :levelmax, :boxlen, :time, :aexp, :H0, :omega_m, :omega_l, :omega_k, :omega_b, :unit_l, :unit_d, :unit_m, :unit_v, :unit_t, :gamma, :hydro, :nvarh, :nvarp, :nvarrt, :variable_list, :gravity_variable_list, :particles_variable_list, :rt_variable_list, :clumps_variable_list, :sinks_variable_list, :descriptor, :amr, :gravity, :particles, :rt, :clumps, :sinks, :namelist, :namelist_content, :headerfile, :makefile, :files_content, :timerfile, :compilationfile, :patchfile, :Narraysize, :scale, :grid_info, :part_info, :compilation, :constants)
 lmin	= 6
 lmax	= 10
@@ -451,7 +452,7 @@ gas = gethydro(info, smallr=1e-11);
 ```
 [Mera]: Get hydro data: 2026-06-01T14:06:24.574
 Key vars=(:level, :cx, :cy, :cz)
-Using var(s)=(1, 2, 3, 4, 5, 6, 7) = (:rho, :vx, :vy, :vz, :p, :var6, :var7)
+Using var(s)=(1, 2, 3, 4, 5, 6, 7) = (:rho, :vx, :vy, :vz, :p, :scalar_00, :scalar_01)
 domain:
 xmin::xmax: 0.0 :: 1.0  	==> 0.0 [kpc] :: 48.0 [kpc]
 ymin::ymax: 0.0 :: 1.0  	==> 0.0 [kpc] :: 48.0 [kpc]

--- a/docs/src/01_particles_First_Inspection.md
+++ b/docs/src/01_particles_First_Inspection.md
@@ -134,7 +134,7 @@ level(s): 6 - 10 --> cellsize(s): 750.0 [pc] - 46.88 [pc]
 -------------------------------------------------------
 hydro:         true
 hydro-variables:
-7  --> (:rho, :vx, :vy, :vz, :p, :var6, :var7)
+7  --> (:rho, :vx, :vy, :vz, :p, :scalar_00, :scalar_01)
 hydro-descriptor: (:density, :velocity_x, :velocity_y, :velocity_z, :pressure, :scalar_00, :scalar_01)
 γ: 1.6667
 -------------------------------------------------------

--- a/docs/src/02_clumps_Load_Selections.md
+++ b/docs/src/02_clumps_Load_Selections.md
@@ -115,7 +115,7 @@ level(s): 6 - 14 --> cellsize(s): 750.0 [pc] - 2.93 [pc]
 -------------------------------------------------------
 hydro:         true
 hydro-variables:
-7  --> (:rho, :vx, :vy, :vz, :p, :var6, :var7)
+7  --> (:rho, :vx, :vy, :vz, :p, :passive_scalar_1, :passive_scalar_2)
 hydro-descriptor: (:density, :velocity_x, :velocity_y, :velocity_z, :thermal_pressure, :passive_scalar_1, :passive_scalar_2)
 γ: 1.6667
 -------------------------------------------------------

--- a/docs/src/02_gravity_Load_Selections.md
+++ b/docs/src/02_gravity_Load_Selections.md
@@ -118,7 +118,7 @@ level(s): 6 - 10 --> cellsize(s): 750.0 [pc] - 46.88 [pc]
 -------------------------------------------------------
 hydro:         true
 hydro-variables:
-7  --> (:rho, :vx, :vy, :vz, :p, :var6, :var7)
+7  --> (:rho, :vx, :vy, :vz, :p, :scalar_00, :scalar_01)
 hydro-descriptor: (:density, :velocity_x, :velocity_y, :velocity_z, :pressure, :scalar_00, :scalar_01)
 γ: 1.6667
 -------------------------------------------------------

--- a/docs/src/02_hydro_Load_Selections.md
+++ b/docs/src/02_hydro_Load_Selections.md
@@ -119,7 +119,7 @@ level(s): 6 - 10 --> cellsize(s): 750.0 [pc] - 46.88 [pc]
 -------------------------------------------------------
 hydro:         true
 hydro-variables:
-7  --> (:rho, :vx, :vy, :vz, :p, :var6, :var7)
+7  --> (:rho, :vx, :vy, :vz, :p, :scalar_00, :scalar_01)
 hydro-descriptor: (:density, :velocity_x, :velocity_y, :velocity_z, :pressure, :scalar_00, :scalar_01)
 γ: 1.6667
 -------------------------------------------------------
@@ -182,7 +182,7 @@ gas = gethydro(info);
 ```
 [Mera]: Get hydro data: 2026-06-01T14:13:18.380
 Key vars=(:level, :cx, :cy, :cz)
-Using var(s)=(1, 2, 3, 4, 5, 6, 7) = (:rho, :vx, :vy, :vz, :p, :var6, :var7)
+Using var(s)=(1, 2, 3, 4, 5, 6, 7) = (:rho, :vx, :vy, :vz, :p, :scalar_00, :scalar_01)
 domain:
 xmin::xmax: 0.0 :: 1.0  	==> 0.0 [kpc] :: 48.0 [kpc]
 ymin::ymax: 0.0 :: 1.0  	==> 0.0 [kpc] :: 48.0 [kpc]
@@ -478,7 +478,7 @@ gas = gethydro(info, lmax=8,
 ```
 [Mera]: Get hydro data: 2026-06-01T14:15:44.404
 Key vars=(:level, :cx, :cy, :cz)
-Using var(s)=(1, 2, 3, 4, 5, 6, 7) = (:rho, :vx, :vy, :vz, :p, :var6, :var7)
+Using var(s)=(1, 2, 3, 4, 5, 6, 7) = (:rho, :vx, :vy, :vz, :p, :scalar_00, :scalar_01)
 domain:
 xmin::xmax: 0.2 :: 0.8  	==> 9.6 [kpc] :: 38.4 [kpc]
 ymin::ymax: 0.2 :: 0.8  	==> 9.6 [kpc] :: 38.4 [kpc]
@@ -535,7 +535,7 @@ gas = gethydro(info, lmax=8,
 ```
 [Mera]: Get hydro data: 2026-06-01T14:15:54.988
 Key vars=(:level, :cx, :cy, :cz)
-Using var(s)=(1, 2, 3, 4, 5, 6, 7) = (:rho, :vx, :vy, :vz, :p, :var6, :var7)
+Using var(s)=(1, 2, 3, 4, 5, 6, 7) = (:rho, :vx, :vy, :vz, :p, :scalar_00, :scalar_01)
 center: [0.5, 0.5, 0.5] ==> [24.0 [kpc] :: 24.0 [kpc] :: 24.0 [kpc]]
 domain:
 xmin::xmax: 0.2 :: 0.8  	==> 9.6 [kpc] :: 38.4 [kpc]
@@ -585,7 +585,7 @@ gas = gethydro(info, lmax=8,
 ```
 [Mera]: Get hydro data: 2026-06-01T14:15:59.497
 Key vars=(:level, :cx, :cy, :cz)
-Using var(s)=(1, 2, 3, 4, 5, 6, 7) = (:rho, :vx, :vy, :vz, :p, :var6, :var7)
+Using var(s)=(1, 2, 3, 4, 5, 6, 7) = (:rho, :vx, :vy, :vz, :p, :scalar_00, :scalar_01)
 domain:
 xmin::xmax: 0.0416667 :: 0.4583333  	==> 2.0 [kpc] :: 22.0 [kpc]
 ymin::ymax: 0.0416667 :: 0.4583333  	==> 2.0 [kpc] :: 22.0 [kpc]
@@ -769,7 +769,7 @@ gas = gethydro(info, lmax=8,
 ```
 [Mera]: Get hydro data: 2026-06-01T14:16:02.459
 Key vars=(:level, :cx, :cy, :cz)
-Using var(s)=(1, 2, 3, 4, 5, 6, 7) = (:rho, :vx, :vy, :vz, :p, :var6, :var7)
+Using var(s)=(1, 2, 3, 4, 5, 6, 7) = (:rho, :vx, :vy, :vz, :p, :scalar_00, :scalar_01)
 center: [0.5, 0.5, 0.5] ==> [24.0 [kpc] :: 24.0 [kpc] :: 24.0 [kpc]]
 domain:
 xmin::xmax: 0.1666667 :: 0.8333333  	==> 8.0 [kpc] :: 40.0 [kpc]
@@ -825,7 +825,7 @@ gas = gethydro(info, lmax=8,
 ```
 [Mera]: Get hydro data: 2026-06-01T14:16:05.832
 Key vars=(:level, :cx, :cy, :cz)
-Using var(s)=(1, 2, 3, 4, 5, 6, 7) = (:rho, :vx, :vy, :vz, :p, :var6, :var7)
+Using var(s)=(1, 2, 3, 4, 5, 6, 7) = (:rho, :vx, :vy, :vz, :p, :scalar_00, :scalar_01)
 center: [0.5, 0.5, 0.5]
 ==> [24.0 [kpc] :: 24.0 [kpc] :: 24.0 [kpc]]
 domain:
@@ -866,7 +866,7 @@ gas = gethydro(info, lmax=8,
 ```
 [Mera]: Get hydro data: 2026-06-01T14:16:09.252
 Key vars=(:level, :cx, :cy, :cz)
-Using var(s)=(1, 2, 3, 4, 5, 6, 7) = (:rho, :vx, :vy, :vz, :p, :var6, :var7)
+Using var(s)=(1, 2, 3, 4, 5, 6, 7) = (:rho, :vx, :vy, :vz, :p, :scalar_00, :scalar_01)
 center: [0.5, 0.5, 0.5] ==> [24.0 [kpc] :: 24.0 [kpc] :: 24.0 [kpc]]
 domain:
 xmin::xmax: 0.1666667 :: 0.8333333  	==> 8.0 [kpc] :: 40.0 [kpc]
@@ -908,7 +908,7 @@ gas = gethydro(info, lmax=8,
 ```
 [Mera]: Get hydro data: 2026-06-01T14:16:12.660
 Key vars=(:level, :cx, :cy, :cz)
-Using var(s)=(1, 2, 3, 4, 5, 6, 7) = (:rho, :vx, :vy, :vz, :p, :var6, :var7)
+Using var(s)=(1, 2, 3, 4, 5, 6, 7) = (:rho, :vx, :vy, :vz, :p, :scalar_00, :scalar_01)
 center: [0.5, 0.5, 0.5]
 ==> [24.0 [kpc] :: 24.0 [kpc] :: 24.0 [kpc]]
 domain:

--- a/docs/src/02_particles_Load_Selections.md
+++ b/docs/src/02_particles_Load_Selections.md
@@ -122,7 +122,7 @@ level(s): 6 - 10 --> cellsize(s): 750.0 [pc] - 46.88 [pc]
 -------------------------------------------------------
 hydro:         true
 hydro-variables:
-7  --> (:rho, :vx, :vy, :vz, :p, :var6, :var7)
+7  --> (:rho, :vx, :vy, :vz, :p, :scalar_00, :scalar_01)
 hydro-descriptor: (:density, :velocity_x, :velocity_y, :velocity_z, :pressure, :scalar_00, :scalar_01)
 γ: 1.6667
 -------------------------------------------------------

--- a/docs/src/03_clumps_Get_Subregions.md
+++ b/docs/src/03_clumps_Get_Subregions.md
@@ -92,7 +92,7 @@ level(s): 6 - 14 --> cellsize(s): 750.0 [pc] - 2.93 [pc]
 -------------------------------------------------------
 hydro:         true
 hydro-variables:
-7  --> (:rho, :vx, :vy, :vz, :p, :var6, :var7)
+7  --> (:rho, :vx, :vy, :vz, :p, :passive_scalar_1, :passive_scalar_2)
 hydro-descriptor: (:density, :velocity_x, :velocity_y, :velocity_z, :thermal_pressure, :passive_scalar_1, :passive_scalar_2)
 γ: 1.6667
 -------------------------------------------------------

--- a/docs/src/03_hydro_Get_Subregions.md
+++ b/docs/src/03_hydro_Get_Subregions.md
@@ -121,7 +121,7 @@ level(s): 6 - 14 --> cellsize(s): 750.0 [pc] - 2.93 [pc]
 -------------------------------------------------------
 hydro:         true
 hydro-variables:
-7  --> (:rho, :vx, :vy, :vz, :p, :var6, :var7)
+7  --> (:rho, :vx, :vy, :vz, :p, :passive_scalar_1, :passive_scalar_2)
 hydro-descriptor: (:density, :velocity_x, :velocity_y, :velocity_z, :thermal_pressure, :passive_scalar_1, :passive_scalar_2)
 γ: 1.6667
 -------------------------------------------------------

--- a/docs/src/03_particles_Get_Subregions.md
+++ b/docs/src/03_particles_Get_Subregions.md
@@ -108,7 +108,7 @@ level(s): 6 - 14 --> cellsize(s): 750.0 [pc] - 2.93 [pc]
 -------------------------------------------------------
 hydro:         true
 hydro-variables:
-7  --> (:rho, :vx, :vy, :vz, :p, :var6, :var7)
+7  --> (:rho, :vx, :vy, :vz, :p, :passive_scalar_1, :passive_scalar_2)
 hydro-descriptor: (:density, :velocity_x, :velocity_y, :velocity_z, :thermal_pressure, :passive_scalar_1, :passive_scalar_2)
 γ: 1.6667
 -------------------------------------------------------

--- a/docs/src/04_multi_Basic_Calculations.md
+++ b/docs/src/04_multi_Basic_Calculations.md
@@ -148,7 +148,7 @@ level(s): 6 - 14 --> cellsize(s): 750.0 [pc] - 2.93 [pc]
 -------------------------------------------------------
 hydro:         true
 hydro-variables:
-7  --> (:rho, :vx, :vy, :vz, :p, :var6, :var7)
+7  --> (:rho, :vx, :vy, :vz, :p, :passive_scalar_1, :passive_scalar_2)
 hydro-descriptor: (:density, :velocity_x, :velocity_y, :velocity_z, :thermal_pressure, :passive_scalar_1, :passive_scalar_2)
 γ: 1.6667
 -------------------------------------------------------

--- a/docs/src/05_multi_Masking_Filtering.md
+++ b/docs/src/05_multi_Masking_Filtering.md
@@ -108,7 +108,7 @@ level(s): 6 - 14 --> cellsize(s): 750.0 [pc] - 2.93 [pc]
 -------------------------------------------------------
 hydro:         true
 hydro-variables:
-7  --> (:rho, :vx, :vy, :vz, :p, :var6, :var7)
+7  --> (:rho, :vx, :vy, :vz, :p, :passive_scalar_1, :passive_scalar_2)
 hydro-descriptor: (:density, :velocity_x, :velocity_y, :velocity_z, :thermal_pressure, :passive_scalar_1, :passive_scalar_2)
 γ: 1.6667
 -------------------------------------------------------
@@ -134,7 +134,7 @@ patchfile:        true
 =======================================================
 [Mera]: Get hydro data: 2026-06-01T20:26:28.613
 Key vars=(:level, :cx, :cy, :cz)
-Using var(s)=(1, 2, 3, 4, 5, 6, 7) = (:rho, :vx, :vy, :vz, :p, :var6, :var7)
+Using var(s)=(1, 2, 3, 4, 5, 6, 7) = (:rho, :vx, :vy, :vz, :p, :passive_scalar_1, :passive_scalar_2)
 domain:
 xmin::xmax: 0.0 :: 1.0  	==> 0.0 [kpc] :: 48.0 [kpc]
 ymin::ymax: 0.0 :: 1.0  	==> 0.0 [kpc] :: 48.0 [kpc]

--- a/docs/src/06_hydro_Projection.md
+++ b/docs/src/06_hydro_Projection.md
@@ -121,7 +121,7 @@ level(s): 6 - 14 --> cellsize(s): 750.0 [pc] - 2.93 [pc]
 -------------------------------------------------------
 hydro:         true
 hydro-variables:
-7  --> (:rho, :vx, :vy, :vz, :p, :var6, :var7)
+7  --> (:rho, :vx, :vy, :vz, :p, :passive_scalar_1, :passive_scalar_2)
 hydro-descriptor: (:density, :velocity_x, :velocity_y, :velocity_z, :thermal_pressure, :passive_scalar_1, :passive_scalar_2)
 γ: 1.6667
 -------------------------------------------------------
@@ -147,7 +147,7 @@ patchfile:        true
 =======================================================
 [Mera]: Get hydro data: 2026-06-01T20:27:43.446
 Key vars=(:level, :cx, :cy, :cz)
-Using var(s)=(1, 2, 3, 4, 5, 6, 7) = (:rho, :vx, :vy, :vz, :p, :var6, :var7)
+Using var(s)=(1, 2, 3, 4, 5, 6, 7) = (:rho, :vx, :vy, :vz, :p, :passive_scalar_1, :passive_scalar_2)
 domain:
 xmin::xmax: 0.0 :: 1.0  	==> 0.0 [kpc] :: 48.0 [kpc]
 ymin::ymax: 0.0 :: 1.0  	==> 0.0 [kpc] :: 48.0 [kpc]

--- a/docs/src/06_particles_Projection.md
+++ b/docs/src/06_particles_Projection.md
@@ -94,7 +94,7 @@ level(s): 6 - 10 --> cellsize(s): 750.0 [pc] - 46.88 [pc]
 -------------------------------------------------------
 hydro:         true
 hydro-variables:
-7  --> (:rho, :vx, :vy, :vz, :p, :var6, :var7)
+7  --> (:rho, :vx, :vy, :vz, :p, :scalar_00, :scalar_01)
 hydro-descriptor: (:density, :velocity_x, :velocity_y, :velocity_z, :pressure, :scalar_00, :scalar_01)
 γ: 1.6667
 -------------------------------------------------------

--- a/docs/src/07_multi_Mera_Files.md
+++ b/docs/src/07_multi_Mera_Files.md
@@ -70,7 +70,7 @@ level(s): 6 - 10 --> cellsize(s): 750.0 [pc] - 46.88 [pc]
 -------------------------------------------------------
 hydro:         true
 hydro-variables:
-7  --> (:rho, :vx, :vy, :vz, :p, :var6, :var7)
+7  --> (:rho, :vx, :vy, :vz, :p, :scalar_00, :scalar_01)
 hydro-descriptor: (:density, :velocity_x, :velocity_y, :velocity_z, :pressure, :scalar_00, :scalar_01)
 γ: 1.6667
 -------------------------------------------------------
@@ -112,7 +112,7 @@ Directory: /Volumes/FASTStorage/Simulations/Mera-Tests/mw_L10
 -----------------------------------
 merafile_version: 1.0  -  Simulation code: RAMSES
 -----------------------------------
-DataType: hydro  -  Data variables: (:level, :cx, :cy, :cz, :rho, :vx, :vy, :vz, :p, :var6, :var7)
+DataType: hydro  -  Data variables: (:level, :cx, :cy, :cz, :rho, :vx, :vy, :vz, :p, :scalar_00, :scalar_01)
 -----------------------------------
 I/O mode: nothing  -  Compression: nothing
 -----------------------------------
@@ -137,7 +137,7 @@ Directory: /Volumes/FASTStorage/Simulations/Mera-Tests/mw_L10
 -----------------------------------
 merafile_version: 1.0  -  Simulation code: RAMSES
 -----------------------------------
-DataType: hydro  -  Data variables: (:level, :cx, :cy, :cz, :rho, :vx, :vy, :vz, :p, :var6, :var7)
+DataType: hydro  -  Data variables: (:level, :cx, :cy, :cz, :rho, :vx, :vy, :vz, :p, :scalar_00, :scalar_01)
 -----------------------------------
 I/O mode: write
   -  Compression: CodecLz4.LZ4FrameCompressor(Ptr
@@ -402,7 +402,7 @@ amr:           true
 level(s): 6 - 10 --> cellsize(s): 750.0 [pc] - 46.88 [pc]
 -------------------------------------------------------
 hydro:         true
-hydro-variables:  7  --> (:rho, :vx, :vy, :vz, :p, :var6, :var7)
+hydro-variables:  7  --> (:rho, :vx, :vy, :vz, :p, :scalar_00, :scalar_01)
 hydro-descriptor: (:density, :velocity_x, :velocity_y, :velocity_z, :pressure, :scalar_00, :scalar_01)
 γ: 1.6667
 -------------------------------------------------------
@@ -450,7 +450,7 @@ amr:           true
 level(s): 6 - 10 --> cellsize(s): 750.0 [pc] - 46.88 [pc]
 -------------------------------------------------------
 hydro:         true
-hydro-variables:  7  --> (:rho, :vx, :vy, :vz, :p, :var6, :var7)
+hydro-variables:  7  --> (:rho, :vx, :vy, :vz, :p, :scalar_00, :scalar_01)
 hydro-descriptor: (:density, :velocity_x, :velocity_y, :velocity_z, :pressure, :scalar_00, :scalar_01)
 γ: 1.6667
 -------------------------------------------------------
@@ -835,7 +835,7 @@ Directory: /Volumes/FASTStorage/Simulations/Mera-Tests/mw_L10
 -----------------------------------
 merafile_version: 1.0  -  Simulation code: RAMSES
 -----------------------------------
-DataType: hydro  -  Data variables: (:level, :cx, :cy, :cz, :rho, :vx, :vy, :vz, :p, :var6, :var7)
+DataType: hydro  -  Data variables: (:level, :cx, :cy, :cz, :rho, :vx, :vy, :vz, :p, :scalar_00, :scalar_01)
 -----------------------------------
 I/O mode: write  -  Compression: ZlibCompressor(level=-1, windowbits=15)
 -----------------------------------
@@ -934,7 +934,7 @@ Directory: /Volumes/FASTStorage/Simulations/Mera-Tests/mw_L10
 -----------------------------------
 merafile_version: 1.0  -  Simulation code: RAMSES
 -----------------------------------
-DataType: hydro  -  Data variables: (:level, :cx, :cy, :cz, :rho, :vx, :vy, :vz, :p, :var6, :var7)
+DataType: hydro  -  Data variables: (:level, :cx, :cy, :cz, :rho, :vx, :vy, :vz, :p, :scalar_00, :scalar_01)
 -----------------------------------
 I/O mode: write  -  Compression: CodecLz4.LZ4FrameCompressor(Ptr{CodecLz4.LZ4F_cctx}(0x0000000000000000), Base.RefValue{CodecLz4.LZ4F_preferences_t}(CodecLz4.LZ4F_preferences_t(CodecLz4.LZ4F_frameInfo_t(0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x0000000000000000, 0x00000000, 0x00000000), 0, 0x00000000, (0x00000000, 0x00000000, 0x00000000, 0x00000000))), UInt8[0x50, 0xf8, 0x44, 0x11, 0x01, 0x00, 0x00, 0x00, 0x70, 0x35, 0x25, 0x31, 0x01, 0x00, 0x00, 0x00, 0x90, 0xfd, 0x0b], false)
 -----------------------------------

--- a/docs/src/10_multi_RadiativeTransfer.md
+++ b/docs/src/10_multi_RadiativeTransfer.md
@@ -76,7 +76,7 @@ level(s): 6 - 7 --> cellsize(s): 234.38 [pc] - 117.19 [pc]
 -------------------------------------------------------
 hydro:         true
 hydro-variables:
-8  --> (:rho, :vx, :vy, :vz, :p, :var6, :var7, :var8)
+8  --> (:rho, :vx, :vy, :vz, :p, :scalar_00, :scalar_01, :scalar_02)
 hydro-descriptor: (:density, :velocity_x, :velocity_y, :velocity_z, :pressure, :scalar_00, :scalar_01, :scalar_02)
 γ: 1.4
 gravity:       false

--- a/docs/src/Miscellaneous.md
+++ b/docs/src/Miscellaneous.md
@@ -67,7 +67,7 @@ gas = gethydro(info, myargs=myargs);
 ```
 [Mera]: Get hydro data: 2026-06-01T18:51:26.187
 Key vars=(:level, :cx, :cy, :cz)
-Using var(s)=(1, 2, 3, 4, 5, 6, 7) = (:rho, :vx, :vy, :vz, :p, :var6, :var7)
+Using var(s)=(1, 2, 3, 4, 5, 6, 7) = (:rho, :vx, :vy, :vz, :p, :scalar_00, :scalar_01)
 center: [0.5, 0.5, 0.5]
 ==> [24.0 [kpc] :: 24.0 [kpc] :: 24.0 [kpc]]
 domain:
@@ -216,7 +216,7 @@ gas = gethydro(info);
 ```
 [Mera]: Get hydro data: 2026-06-01T18:53:32.408
 Key vars=(:level, :cx, :cy, :cz)
-Using var(s)=(1, 2, 3, 4, 5, 6, 7) = (:rho, :vx, :vy, :vz, :p, :var6, :var7)
+Using var(s)=(1, 2, 3, 4, 5, 6, 7) = (:rho, :vx, :vy, :vz, :p, :scalar_00, :scalar_01)
 domain:
 xmin::xmax: 0.0 :: 1.0  	==> 0.0 [kpc] :: 48.0 [kpc]
 ymin::ymax: 0.0 :: 1.0  	==> 0.0 [kpc] :: 48.0 [kpc]
@@ -278,7 +278,7 @@ gas = gethydro(info);
 ```
 [Mera]: Get hydro data: 2026-06-01T18:54:30.579
 Key vars=(:level, :cx, :cy, :cz)
-Using var(s)=(1, 2, 3, 4, 5, 6, 7) = (:rho, :vx, :vy, :vz, :p, :var6, :var7)
+Using var(s)=(1, 2, 3, 4, 5, 6, 7) = (:rho, :vx, :vy, :vz, :p, :scalar_00, :scalar_01)
 domain:
 xmin::xmax: 0.0 :: 1.0  	==> 0.0 [kpc] :: 48.0 [kpc]
 ymin::ymax: 0.0 :: 1.0  	==> 0.0 [kpc] :: 48.0 [kpc]

--- a/docs/src/fluxbudget.md
+++ b/docs/src/fluxbudget.md
@@ -32,8 +32,10 @@ mass/metals/energy `in ≤ 0` and `out ≥ 0`; for **momentum** the carried quan
 
 !!! note "`:metals` needs a `:metallicity` column"
     The `:metals` flux multiplies cell mass by the gas metallicity, read from a column literally named
-    `:metallicity`. Mera does **not** auto-treat a passive scalar (e.g. `:var6`) as metallicity, so on a
-    run without that column `:metals` raises a clear error rather than silently returning zero — alias
+    `:metallicity`. Mera names hydro columns from the `hydro_file_descriptor.txt`, so a `:metallicity`
+    column appears only when the descriptor labels a field `metallicity`; a generically named scalar
+    (e.g. `:scalar_00`) or a positional `:var6` is **not** treated as metallicity. On a run without a
+    `:metallicity` column `:metals` raises a clear error rather than silently returning zero — alias
     your metal scalar to `:metallicity` before the call if needed. Likewise `:energy` needs the thermal
     energy (pressure `:p`) and errors clearly on an isothermal/pressureless output.
 

--- a/src/functions/flux.jl
+++ b/src/functions/flux.jl
@@ -336,9 +336,10 @@ _centervec(center, info, range_unit) =
 function _flux_validate_quantities(cols, quantities)
     if :metals in quantities && !(:metallicity in cols)
         throw(ArgumentError("flux :metals needs a :metallicity column, which this output does not have " *
-            "(Mera does not auto-rename passive scalars, so a metal scalar stored as e.g. :var6 is NOT " *
-            "treated as metallicity). Alias your metal field to :metallicity before calling, or drop " *
-            ":metals from `quantities`. (Returning zero silently would be a wrong answer.)"))
+            "(Mera names hydro columns from the descriptor, so a :metallicity column appears only when the " *
+            "hydro descriptor labels a field 'metallicity'; a scalar named e.g. :scalar_00 or a positional " *
+            ":var6 is NOT treated as metallicity). Alias your metal field to :metallicity before calling, or " *
+            "drop :metals from `quantities`. (Returning zero silently would be a wrong answer.)"))
     end
     if :energy in quantities && !(:p in cols)
         throw(ArgumentError("flux :energy needs the thermal energy from pressure (:p), absent on this " *

--- a/src/read_data/RAMSES/gethydro.jl
+++ b/src/read_data/RAMSES/gethydro.jl
@@ -248,7 +248,7 @@ julia> fieldnames(gas)
 - **`dataobject`:** needs to be of type: "InfoType", created by the function *getinfo*
 ##### Predefined/Optional Keywords:
 - **`lmax`:** the maximum level to be read from the data
-- **`var(s)`:** the selected hydro variables in arbitrary order: :all (default), :cpu, :rho, :vx, :vy, :vz, :p, :var6, :var7...
+- **`var(s)`:** the selected hydro variables in arbitrary order: :all (default), :cpu, :rho, :vx, :vy, :vz, :p, and the passive scalars. When the output has a `hydro_file_descriptor.txt`, the scalars carry their descriptor names (e.g. :metallicity, :scalar_00, :scalar_01...); without a descriptor they are positional (:var6, :var7...). Positional :varN selectors keep working in either case.
 - **`xrange`:** the range between [xmin, xmax] in units given by argument `range_unit` and relative to the given `center`; zero length for xmin=xmax=0. is converted to maximum possible length
 - **`yrange`:** the range between [ymin, ymax] in units given by argument `range_unit` and relative to the given `center`; zero length for ymin=ymax=0. is converted to maximum possible length
 - **`zrange`:** the range between [zmin, zmax] in units given by argument `range_unit` and relative to the given `center`; zero length for zmin=zmax=0. is converted to maximum possible length

--- a/src/read_data/RAMSES/getinfo.jl
+++ b/src/read_data/RAMSES/getinfo.jl
@@ -296,13 +296,13 @@ function readhydrofile1!(dataobject::InfoType)
         variable_descriptor_list = variable_list
     end
 
-    # MHD (constrained transport): the hydro file stores 6 face-centred B components and
-    # shifts the thermal pressure, so the positional [:rho,:vx,:vy,:vz,:p,:var6…] guess is
-    # wrong (index 5 is B_x_left, not pressure). When the descriptor reveals MHD, take the
-    # variable names canonically from it (density→:rho, pressure→:p at its true index,
-    # B_*_{left,right}→:b*_{left,right}). Non-MHD layouts keep the positional names.
-    if descriptor_file && length(variable_descriptor_list) == nvarh &&
-       _is_mhd_descriptor(variable_descriptor_list)
+    # When a hydro descriptor is present, take ALL variable names canonically from it
+    # (density→:rho, velocity_*→:v*, (thermal_)pressure→:p, B_*_{left,right}→:b*_{left,right},
+    # and passive scalars by their descriptor name, e.g. :metallicity, :scalar_00). This both
+    # fixes the MHD layout (index 5 is B_x_left, pressure shifted) and gives passive scalars
+    # their real names instead of the positional :var6…. Layouts WITHOUT a descriptor keep the
+    # positional [:rho,:vx,:vy,:vz,:p,:var6…] names (with the no-descriptor MHD heuristic below).
+    if descriptor_file && length(variable_descriptor_list) == nvarh
         variable_list = [_canonical_hydro_name(n) for n in variable_descriptor_list]
     elseif !descriptor_file && dataobject.ndim == 3 && nvarh >= 11
         # No hydro descriptor (older RAMSES MHD): match yt's heuristic — a 3D run with

--- a/src/read_data/RAMSES/getparticles.jl
+++ b/src/read_data/RAMSES/getparticles.jl
@@ -518,6 +518,33 @@ end
 # ===== HELPER FUNCTION: TABLE COLUMN NAME GENERATION =====
 # This function creates appropriate column names for the particle data table
 # Names depend on particle format version, whether CPU info is included, and grid type
+# Resolve the database column name for a particle variable at read-index `i`.
+# Legacy (pversion 0) outputs are purely positional. Descriptor (pversion > 0)
+# outputs carry their variable names in part_file_descriptor.txt, which getinfo
+# reconstructs into `particles_variable_list`; custom fields beyond metallicity
+# (read-index > 8) therefore keep their real descriptor name instead of falling
+# back to the positional :varN. Returns `nothing` for the v1 family/tag slots
+# (indices 5 and 6), which are key columns, not data variables.
+function _particle_varname(pversion::Real, pvarlist::Vector{Symbol}, i::Integer)
+    if pversion == 0   # legacy positional layout
+        i == 1 && return :vx
+        i == 2 && return :vy
+        i == 3 && return :vz
+        i == 4 && return :mass
+        i == 5 && return :birth
+        i  > 5 && return Symbol("var$i")
+    else               # descriptor (v1) layout
+        i == 1 && return :vx
+        i == 2 && return :vy
+        i == 3 && return :vz
+        i == 4 && return :mass
+        i == 7 && return :birth
+        i == 8 && return :metals
+        i  > 8 && return (i <= length(pvarlist)) ? pvarlist[i] : Symbol("var$i")
+    end
+    return nothing     # v1 indices 5,6 (family,tag) are key columns, not data vars
+end
+
 function preptablenames_particles(dataobject::InfoType, nvarp::Int, nvarp_list::Array{Int, 1}, used_descriptors::Dict{Any,Any}, read_cpu::Bool, lmax::Real, levelmin::Real)
 
     # ===== BASE COLUMN NAMES =====
@@ -557,37 +584,8 @@ function preptablenames_particles(dataobject::InfoType, nvarp::Int, nvarp_list::
     # Different versions have different variable indices for the same physical quantities
     for i=1:nvarp
         if in(i, nvarp_list)  # Only add names for variables that were actually read
-            if dataobject.descriptor.pversion == 0  # Old particle format variable mapping
-                if i == 1
-                    append!(names_constr, [Symbol("vx")] )      # X-velocity
-                elseif i == 2
-                    append!(names_constr, [Symbol("vy")] )      # Y-velocity
-                elseif i == 3
-                    append!(names_constr, [Symbol("vz")] )      # Z-velocity
-                elseif i == 4
-                    append!(names_constr, [Symbol("mass")] )    # Particle mass
-                elseif i == 5
-                    append!(names_constr, [Symbol("birth")] )   # Birth time (for star particles)
-                elseif i > 5
-                    append!(names_constr, [Symbol("var$i")] )   # Generic names for additional variables
-                end
-            elseif dataobject.descriptor.pversion > 0  # New particle format variable mapping
-                if i == 1
-                    append!(names_constr, [Symbol("vx")] )      # X-velocity
-                elseif i == 2
-                    append!(names_constr, [Symbol("vy")] )      # Y-velocity
-                elseif i == 3
-                    append!(names_constr, [Symbol("vz")] )      # Z-velocity
-                elseif i == 4
-                    append!(names_constr, [Symbol("mass")] )    # Particle mass
-                elseif i == 7                                   # Note: birth time moved to index 7 in new format
-                    append!(names_constr, [Symbol("birth")] )   # Birth time (for star particles)
-                elseif i == 8
-                    append!(names_constr, [Symbol("metals")] )  # Metallicity (new in this format)
-                elseif i > 8
-                    append!(names_constr, [Symbol("var$i")] )   # Generic names for additional variables
-                end
-            end
+            nm = _particle_varname(dataobject.descriptor.pversion, dataobject.particles_variable_list, i)
+            nm === nothing || append!(names_constr, [nm])
         end
     end
 

--- a/src/read_data/RAMSES/prepvariablelist.jl
+++ b/src/read_data/RAMSES/prepvariablelist.jl
@@ -11,12 +11,15 @@ function prepvariablelist(dataobject::InfoType, datatype::Symbol, vars::Array{Sy
         hydrovar_buffer = copy(vars)
         used_descriptors = Dict()
 
-        # MHD runs carry canonical per-index names in variable_list (incl. :b*_left/:b*_right
-        # and :p at its true, shifted index), so resolve requested symbols by NAME from it.
-        # Non-MHD outputs keep the original positional resolution (:p→5, :varN→N) unchanged.
+        # When the output has a hydro descriptor (or is a no-descriptor MHD run), variable_list
+        # carries canonical per-index names (incl. :b*_left/:b*_right and :p at its true, shifted
+        # index, plus passive scalars by name e.g. :metallicity), so resolve requested symbols by
+        # NAME from it and name the loaded columns accordingly. Outputs WITHOUT a descriptor keep
+        # the original positional resolution (:p→5, :varN→N) unchanged.
         vlist_mhd = dataobject.variable_list
         is_mhd = any(v -> occursin(r"^b[xyz]_(left|right)$", string(v)), vlist_mhd)
-        if is_mhd
+        use_names = is_mhd || dataobject.descriptor.hydrofile
+        if use_names
             if in(:cpu, hydrovar_buffer) || in(:varn1, hydrovar_buffer)
                 read_cpu = true
             end
@@ -31,7 +34,7 @@ function prepvariablelist(dataobject::InfoType, datatype::Symbol, vars::Array{Sy
                     elseif occursin("var", string(x))     # explicit :varN index still works
                         push!(nvarh_list, parse(Int, string(x)[4:end]))
                     else
-                        error("[Mera]: variable :$x not found in this MHD hydro output. " *
+                        error("[Mera]: variable :$x not found in this hydro output. " *
                               "Available names: $(vlist_mhd)")
                     end
                 end

--- a/test/32_rt_tests.jl
+++ b/test/32_rt_tests.jl
@@ -258,7 +258,13 @@ if @isdefined(DATA_AVAILABLE) && DATA_AVAILABLE &&
             g2 = deepcopy(gas); n = length(g2.data)
             xHeII = fill(0.30, n); xHeIII = fill(0.10, n); Zmet = fill(0.02, n)
             cols = IT.columns(g2.data)
-            g2.data = IT.table(merge(cols, (var7 = xHeII, var8 = xHeIII, metallicity = Zmet)))
+            # inject the He fractions into the hydro scalars at the He-ionisation indices
+            # (xHeII = iIons+1, xHeIII = iIons+2). Name the columns via variable_list so the test
+            # tracks the descriptor-driven names (rt_stromgren → :scalar_01, :scalar_02) instead of
+            # the positional :var7/:var8 that descriptor outputs no longer produce.
+            i0 = g2.info.descriptor.rt[:iIons]
+            cHeII = g2.info.variable_list[i0 + 1]; cHeIII = g2.info.variable_list[i0 + 2]
+            g2.data = IT.table(merge(cols, NamedTuple{(cHeII, cHeIII, :metallicity)}((xHeII, xHeIII, Zmet))))
             g2.info.descriptor.rt[:X_fraction] = 0.76
             g2.info.descriptor.rt[:Y_fraction] = 0.24
             X = 0.76; Y = 0.24; AZ = 16.0

--- a/test/37_derived_fields_tests.jl
+++ b/test/37_derived_fields_tests.jl
@@ -129,6 +129,7 @@
             part = getparticles(info, verbose=false, show_progress=false)
             skip = Dict(
                 :hydro    => Set([:delta, :overdensity,                       # cosmological only
+                                  :bx, :by, :bz,                              # need magnetic field
                                   :mach_alfven, :mach_fast, :mach_slow]),     # need magnetic field
                 :gravity  => Set{Symbol}(),
                 :particle => Set([:formation_redshift, :formation_time, :zform]),  # cosmological only

--- a/test/43_fluxbudget_tests.jl
+++ b/test/43_fluxbudget_tests.jl
@@ -111,15 +111,24 @@
             end
         end
 
-        @testset "metals guard: fail loudly, not silently zero" begin
-            # spiral_clumps stores a passive scalar :var6 but NO :metallicity column, so :metals would
-            # silently return 0 — now it must throw a clear error instead.
-            @test !(:metallicity in gas.info.variable_list)
-            @test_throws ArgumentError fluxbudget(gas; surface=:sphere, radius=10.0, shell_width=2.0,
-                                                  range_unit=:kpc, quantities=[:metals], verbose=false)
-            # the same guard fires on the off-axis (tilted) path
-            @test_throws ArgumentError fluxbudget(gas; surface=:cylinder, radius=10.0, shell_width=2.0,
-                                                  range_unit=:kpc, axis=[1.0,1.0,1.0], quantities=[:metals], verbose=false)
+        @testset "metals guard & descriptor-named scalars" begin
+            # spiral_clumps' hydro descriptor labels scalar #6 'metallicity', so Mera now loads a
+            # :metallicity column (previously this scalar was the unnamed positional :var6) and the
+            # metal flux is computable.
+            @test :metallicity in gas.info.variable_list
+            @test :metallicity in propertynames(gas.data.columns)
+            @test fluxbudget(gas; surface=:sphere, radius=10.0, shell_width=2.0,
+                             range_unit=:kpc, quantities=[:metals], verbose=false) isa FluxBudgetType
+            # A descriptor that names its scalars generically (rt_stromgren: :scalar_00,…) is NOT
+            # mistaken for metallicity, so the :metals guard still fires — fail loudly, never zero.
+            if haskey(DATASETS, :rt_stromgren) && isdir(DATASETS[:rt_stromgren].path)
+                rs   = DATASETS[:rt_stromgren]
+                gas2 = gethydro(getinfo(rs.output, rs.path, verbose=false), verbose=false, show_progress=false)
+                cols2 = propertynames(gas2.data.columns)
+                @test :scalar_00 in cols2                 # descriptor name, not the positional :var6
+                @test !(:metallicity in cols2)
+                @test_throws ArgumentError Mera._flux_validate_quantities(cols2, [:metals])
+            end
             # :mass/:momentum/:energy still work on this output (have rho/v/p)
             @test fluxbudget(gas; surface=:sphere, radius=10.0, shell_width=2.0, range_unit=:kpc,
                              quantities=[:mass, :energy], verbose=false) isa FluxBudgetType

--- a/test/46_data_awareness_tests.jl
+++ b/test/46_data_awareness_tests.jl
@@ -31,6 +31,24 @@
     @test Mera._mhd_nodescriptor_varlist(13)[12:13] == [:var12, :var13]
 end
 
+@testset "Particle descriptor drives column names (data-free)" begin
+    pv = Mera._particle_varname
+    # descriptor (v1) layout reconstructed from part_file_descriptor.txt, with two
+    # custom fields beyond metallicity at read-index 9,10:
+    pvl = [:vx, :vy, :vz, :mass, :family, :tag, :birth, :metals, :chem_H, :chem_He]
+    @test pv(1, pvl, 1) == :vx && pv(1, pvl, 4) == :mass
+    @test pv(1, pvl, 7) == :birth && pv(1, pvl, 8) == :metals
+    @test pv(1, pvl, 9) == :chem_H && pv(1, pvl, 10) == :chem_He   # custom fields keep their real names…
+    # …instead of the positional :varN fallback that lost them before:
+    @test pv(1, pvl, 9) != Symbol("var9")
+    # family/tag (indices 5,6) are key columns, never emitted as data vars:
+    @test pv(1, pvl, 5) === nothing && pv(1, pvl, 6) === nothing
+    # out-of-range custom field (descriptor shorter than read-index) → safe :varN fallback:
+    @test pv(1, [:vx, :vy, :vz, :mass, :family, :tag, :birth], 9) == Symbol("var9")
+    # legacy v0 layout stays positional (no descriptor names):
+    @test pv(0, Symbol[], 5) == :birth && pv(0, Symbol[], 6) == Symbol("var6")
+end
+
 if !DATA_AVAILABLE
     @warn "Skipping data-awareness data tests - simulation data not available"
     @test_skip "Simulation data not available"
@@ -99,6 +117,49 @@ end
             # the loaded TABLE columns carry those names (the detection is actually used)
             @test (:bx_left in cols) && (:bx_right in cols) && (:p in cols)
             @test getvar(gas, :bx) ≈ 0.5 .* (select(gas.data, :bx_left) .+ select(gas.data, :bx_right))
+        end
+    end
+end
+
+@testset "Hydro descriptor drives database column names" begin
+    for (key, ds) in DATASETS
+        (isdir(ds.path) && isdir(_awareness_outdir(ds))) || continue
+        info = getinfo(ds.output, ds.path, verbose=false)
+        (info.hydro && info.descriptor.hydrofile) || continue   # descriptor-present hydro only
+        @testset "$key" begin
+            # variable_list is the canonical image of the descriptor (base vars → :rho/:v*/:p,
+            # passive scalars by their descriptor name, e.g. :metallicity, :scalar_00)
+            @test info.variable_list == [Mera._canonical_hydro_name(n) for n in info.descriptor.hydro]
+            gas  = gethydro(info, verbose=false, show_progress=false)
+            cols = propertynames(gas.data.columns)
+            keycols = (:level, :cx, :cy, :cz, :cpu)
+            datacols = filter(c -> !(c in keycols), cols)
+            # every loaded data column carries its descriptor name — none left as positional :varN
+            @test collect(datacols) == info.variable_list
+            @test !any(c -> occursin(r"^var\d+$", string(c)), datacols)
+        end
+    end
+end
+
+@testset "Particle descriptor drives database column names" begin
+    for (key, ds) in DATASETS
+        (isdir(ds.path) && isdir(_awareness_outdir(ds))) || continue
+        info = getinfo(ds.output, ds.path, verbose=false)
+        info.particles || continue
+        @testset "$key" begin
+            part = getparticles(info, verbose=false, show_progress=false)
+            cols = propertynames(part.data.columns)
+            if info.descriptor.pversion > 0   # descriptor (v1): names come from part_file_descriptor.txt
+                # the canonical data columns carry descriptor-driven (not positional :varN) names
+                @test :vx in cols && :mass in cols && :birth in cols
+                # every data variable beyond the key columns resolves to a real name
+                keycols = (:level, :x, :y, :z, :id, :family, :tag, :cpu)
+                datacols = filter(c -> !(c in keycols), cols)
+                @test !isempty(datacols)
+                @test !any(c -> occursin(r"^var\d+$", string(c)), datacols)  # no positional fallback leaked
+                # :metals appears iff the descriptor lists metallicity
+                @test (:metals in cols) == in(:metallicity, info.descriptor.particles)
+            end
         end
     end
 end


### PR DESCRIPTION
Name loaded table columns from the RAMSES descriptor files wherever one exists, instead of falling back to positional `:varN`.

## What changed

**Hydro (global).** When a `hydro_file_descriptor.txt` is present, `variable_list` and the loaded columns take the canonical descriptor names for **all** indices — so passive scalars become e.g. `:metallicity` / `:scalar_00` instead of `:var6`/`:var7`. This generalises the previous MHD-only path in `getinfo`. The selection path in `prepvariablelist` resolves requested symbols by name and **keeps positional `:varN` selectors working** (backward-compatible loading). Outputs without a descriptor keep positional names (and the no-descriptor MHD heuristic) unchanged.

**Particles.** Custom fields beyond metallicity (read-index > 8) now take their `part_file_descriptor.txt` name via the new `_particle_varname` helper, instead of `:varN`.

**flux.jl.** The `:metals` guard is unchanged but its message now reflects that a `:metallicity` column appears only when the descriptor names a field `metallicity` (a generic `:scalar_00` / positional `:var6` is not metallicity).

## Tests
- `test/46`: hydro + particle descriptor column-name coverage (data-free + data-backed).
- `test/43`: metals guard rewritten — spiral_clumps now has `:metallicity` (so `:metals` works); rt_stromgren's `:scalar_00` confirms a generic scalar is not treated as metallicity.
- `test/32`: He-ionization synthetic injection now uses the descriptor-named scalar columns (via `iIons`).
- `test/37`: add `:bx/:by/:bz` to the magnetic skip-set (pre-existing gap).

Full suite: 0 failures (the only non-passes on a full run were `ENOSPC` disk-space errors in the JLD2 save tests, which pass with free space).

## Docs
- README landing page shows only the logo; feature example images removed.
- Updated `gethydro` docstring, hydro tutorial prose, fluxbudget note, and 41 tutorial REPL snippets to the descriptor-driven names.

## Follow-up (not in this PR)
- 4 tutorial files (`10_multi:328`, `11_multi:106`, `12_multi:46`, `13_multi:55`) have `:var6/:var8` inside large `InfoType(...)` dumps that should be re-exported from the Notebooks repo with this version.