### PR TITLE
docs: descriptor names in remaining column-row / propertynames snippets

### DIFF
--- a/docs/src/01_hydro_First_Inspection.md
+++ b/docs/src/01_hydro_First_Inspection.md
@@ -694,8 +694,8 @@ Columns:
 7   vy       Float64
 8   vz       Float64
 9   p        Float64
-10  var6     Float64
-11  var7     Float64
+10  scalar_00 Float64
+11  scalar_01 Float64
 ```
 
 ### Focused Data Examination

--- a/docs/src/02_hydro_Load_Selections.md
+++ b/docs/src/02_hydro_Load_Selections.md
@@ -227,8 +227,8 @@ Columns:
 7   vy       Float64
 8   vz       Float64
 9   p        Float64
-10  var6     Float64
-11  var7     Float64
+10  scalar_00 Float64
+11  scalar_01 Float64
 ```
 
 ### Selecting Multiple Variables

--- a/docs/src/04_multi_Basic_Calculations.md
+++ b/docs/src/04_multi_Basic_Calculations.md
@@ -696,7 +696,7 @@ Predefined vars that can be calculated for each cell/particle:
 ----------------------------------------------------------------
 =============================[gas]:=============================
        -all the non derived hydro vars-
-:cpu, :level, :rho, :cx, :cy, :cz, :vx, :vy, :vz, :p, var6,...
+:cpu, :level, :rho, :cx, :cy, :cz, :vx, :vy, :vz, :p, passive_scalar_1,...
               -derived hydro vars-
 :x, :y, :z
 :mass, :cellsize, :volume, :freefall_time
@@ -930,7 +930,7 @@ Predefined vars that can be calculated for each cell/particle:
 ----------------------------------------------------------------
 =============================[gas]:=============================
        -all the non derived hydro vars-
-:cpu, :level, :rho, :cx, :cy, :cz, :vx, :vy, :vz, :p, var6,...
+:cpu, :level, :rho, :cx, :cy, :cz, :vx, :vy, :vz, :p, passive_scalar_1,...
               -derived hydro vars-
 :x, :y, :z
 :mass, :cellsize, :volume, :freefall_time

--- a/docs/src/05_multi_Masking_Filtering.md
+++ b/docs/src/05_multi_Masking_Filtering.md
@@ -468,8 +468,8 @@ Columns:
 7   vy       Float64
 8   vz       Float64
 9   p        Float64
-10  var6     Float64
-11  var7     Float64
+10  passive_scalar_1 Float64
+11  passive_scalar_2 Float64
 ```
 
 ### With IndexedTables (example B)
@@ -495,8 +495,8 @@ Columns:
 7   vy       Float64
 8   vz       Float64
 9   p        Float64
-10  var6     Float64
-11  var7     Float64
+10  passive_scalar_1 Float64
+11  passive_scalar_2 Float64
 ```
 
 ### Unit Conversion in Filtering
@@ -810,8 +810,8 @@ Columns:
 7   vy       Float64
 8   vz       Float64
 9   p        Float64
-10  var6     Float64
-11  var7     Float64
+10  passive_scalar_1 Float64
+11  passive_scalar_2 Float64
 12  mach     Float64
 ```
 
@@ -867,8 +867,8 @@ Columns:
 7   vy       Float64
 8   vz       Float64
 9   p        Float64
-10  var6     Float64
-11  var7     Float64
+10  passive_scalar_1 Float64
+11  passive_scalar_2 Float64
 ```
 
 ## Data Table Extension and Modification

--- a/docs/src/06_hydro_Projection.md
+++ b/docs/src/06_hydro_Projection.md
@@ -194,8 +194,8 @@ Columns:
 7   vy       Float64
 8   vz       Float64
 9   p        Float64
-10  var6     Float64
-11  var7     Float64
+10  passive_scalar_1 Float64
+11  passive_scalar_2 Float64
 ```
 
 ## Basic Projections
@@ -216,7 +216,7 @@ Predefined vars for projections:
 ------------------------------------------------
 =====================[gas]:=====================
        -all the non derived hydro vars-
-:cpu, :level, :rho, :cx, :cy, :cz, :vx, :vy, :vz, :p, var6,...
+:cpu, :level, :rho, :cx, :cy, :cz, :vx, :vy, :vz, :p, passive_scalar_1,...
 further possibilities: :rho, :density, :ρ
               -derived hydro vars-
 :x, :y, :z

--- a/docs/src/06_particles_Projection.md
+++ b/docs/src/06_particles_Projection.md
@@ -175,7 +175,7 @@ Predefined vars for projections:
 ------------------------------------------------
 =====================[gas]:=====================
        -all the non derived hydro vars-
-:cpu, :level, :rho, :cx, :cy, :cz, :vx, :vy, :vz, :p, var6,...
+:cpu, :level, :rho, :cx, :cy, :cz, :vx, :vy, :vz, :p, scalar_00,...
 further possibilities: :rho, :density, :ρ
               -derived hydro vars-
 :x, :y, :z


### PR DESCRIPTION
Follow-up to #111/#112. The first snippet pass only matched the `:rho, :vx, :vy, :vz, :p` overview signature and missed column-display rows (`10  var6  Float64`) and `propertynames` listings (`…, :p, var6,…`). This converts those to the descriptor-driven names (mw_L10 → `:scalar_00/:scalar_01`; manu_sim_sf_L14 → `:passive_scalar_1/:passive_scalar_2`). Convention tables, positional-naming prose, and `:varN` selector code examples are intentionally kept. Docs-only.