### PR TITLE
docs: fix First Look nav (broken ref + duplicate from #114)

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -22,7 +22,7 @@ makedocs(modules = [Mera],
          
 		authors = "Manuel Behrendt",
 		pages = Any[ "Home"                  => "index.md",
-		              "First Look"             => "first_look.md",
+		              "First Look"             => "report.md",
 		              "Getting Started"        => "00_multi_FirstSteps.md",
                       
                       "Core Workflows" => Any[
@@ -53,8 +53,6 @@ makedocs(modules = [Mera],
                           "How Quantities Are Computed" => "computation_reference.md",
 
                           "Magnetic Fields (MHD)" => "magnetic_fields.md",
-
-                          "First Look"          => "report.md",
 
                           "Clump Finding"       => "clumpfind.md",
 


### PR DESCRIPTION
Corrects a staging slip in #114: a fatal `git add` pathspec on the already-deleted `first_look.md` aborted the add, so the `make.jl` consolidation never committed. Master ended up referencing the deleted `first_look.md` (broken nav) and still had two "First Look" entries. This sets the intended state — a single **First Look → report.md** at nav position #2. Docs build green.