### PR TITLE
getvar(MHD): add :bmag, :pmag, :beta, :v_alfven, :e_magnetic (+ :nG unit)

### DIFF
--- a/docs/src/computation_reference.md
+++ b/docs/src/computation_reference.md
@@ -146,6 +146,28 @@ The magnetosonic numbers require an MHD run with `:bx,:by,:bz`; the magnetic fie
 RAMSES code units and converted to Gaussian-CGS internally (hence the ``4\pi``). They error if the
 field components are absent.
 
+## Magnetic quantities
+
+*Data: **hydro** (MHD). Built from the cell-centred field ``\mathbf B = (B_x,B_y,B_z)``. **Code-unit
+convention:** RAMSES-MHD absorbs the Gaussian ``4\pi`` into the field, so in code units the magnetic
+pressure is ``P_\mathrm{mag} = B^2/2`` and the Alfvén speed is ``v_A = |\mathbf B|/\sqrt{\rho}``; the
+factor reappears only in the physical-unit conversion ``B_\mathrm{phys}[\mathrm{G}] = B_\mathrm{code}\cdot\texttt{scale.Gauss}``,
+``\texttt{scale.Gauss} = \sqrt{4\pi\,\rho_0 v_0^2}``. No new unit type is required.*
+
+| Quantity | Formula | Units |
+|---|---|---|
+| Field magnitude `:bmag` | ``|\mathbf B| = \sqrt{B_x^2+B_y^2+B_z^2}`` | `:Gauss`, `:muG`, `:microG`, `:nG`, `:Tesla` |
+| Magnetic pressure `:pmag` | ``P_\mathrm{mag} = \dfrac{B^2}{8\pi}`` (``=B^2/2`` in code units) | `:Ba`, `:g_cm_s2` |
+| Plasma beta `:beta` | ``\beta = \dfrac{P_\mathrm{thermal}}{P_\mathrm{mag}}`` | dimensionless |
+| Alfvén speed `:v_alfven` | ``v_A = \dfrac{|\mathbf B|}{\sqrt{4\pi\rho}}`` (``=|\mathbf B|/\sqrt{\rho}`` in code units) | `:km_s`, `:cm_s` |
+| Magnetic energy `:e_magnetic` | ``E_\mathrm{mag} = P_\mathrm{mag}\cdot V_\mathrm{cell}`` | `:erg` |
+
+All five reuse existing unit scales — magnetic-field strengths (`:Gauss`/`:muG`/`:microG`/`:nG`/`:Tesla`),
+pressure (`:Ba`/`:g_cm_s2`), velocity (`:km_s`/`:cm_s`) and energy (`:erg`) — so introducing MHD
+analysis needed **no new unit dimensions**. The quantities require an MHD run and error if the field
+components are absent. (`:nG`, nanogauss = `scale.Gauss·10⁹`, is the one unit added, for IGM /
+cosmological field strengths.)
+
 ## Jeans & collapse
 
 *Data: **hydro** — needs `:cs` (`:p`) and `:rho`.*

--- a/docs/src/magnetic_fields.md
+++ b/docs/src/magnetic_fields.md
@@ -58,19 +58,36 @@ getvar(gas, :T, :K)        # temperature, from the *correct* pressure
 
 ## Derived magnetic quantities
 
-```julia
-# field magnitude |B| (code units) from the cell-centred components
-bx, by, bz = getvar(gas, [:bx, :by, :bz])
-Bmag = sqrt.(bx.^2 .+ by.^2 .+ bz.^2)
+All of these are **built-in `getvar` quantities** computed from the cell-centred field — no manual
+arithmetic needed — and each takes the units shown:
 
-# magnetosonic Mach numbers (need the magnetic field)
-mA = getvar(gas, :mach_alfven)   # M_A = |v| / v_A,  v_A = |B|/√(4πρ)  (Gaussian-CGS)
+```julia
+# field magnitude |B|  (field-strength units: :Gauss, :muG, :microG, :nG, :Tesla)
+Bmag    = getvar(gas, :bmag)          # code units
+Bmag_uG = getvar(gas, :bmag, :muG)    # μG
+
+# magnetic pressure P_mag = B²/8π  and plasma β = P_thermal / P_mag
+Pmag = getvar(gas, :pmag, :Ba)        # magnetic pressure [barye = erg/cm³]  (also :g_cm_s2)
+beta = getvar(gas, :beta)             # plasma β (dimensionless)
+
+# Alfvén speed and magnetic energy per cell
+vA   = getvar(gas, :v_alfven, :km_s)  # v_A = |B|/√(4πρ)
+Emag = getvar(gas, :e_magnetic, :erg) # magnetic energy per cell = (B²/8π)·V_cell
+
+# magnetosonic Mach numbers
+mA = getvar(gas, :mach_alfven)   # M_A = |v| / v_A
 mf = getvar(gas, :mach_fast)     # fast:  v_f = √(c_s² + v_A²)
 ms = getvar(gas, :mach_slow)     # slow:  v_s = c_s·v_A/√(c_s² + v_A²)
 ```
 
-The exact formulas (and the Alfvén-speed unit conversion) are listed in
-[How Quantities Are Computed](computation_reference.md#Mach-numbers).
+No new units were needed: `B` reuses the field-strength scales (`:Gauss`, `:muG`, `:microG`, `:nG`,
+`:Tesla`), magnetic pressure/energy-density reuse the pressure scales (`:Ba`, `:g_cm_s2`), the Alfvén
+speed reuses the velocity scales (`:km_s`, `:cm_s`), and the magnetic energy reuses `:erg`. (`:nG`,
+nanogauss, is new — handy for IGM/cosmological field strengths.)
+
+The exact formulas (incl. the RAMSES code-unit convention `P_mag = B²/2` and the Alfvén-speed
+conversion) are listed in
+[How Quantities Are Computed](computation_reference.md#Magnetic-quantities).
 
 ## Projecting the magnetic field
 
@@ -90,4 +107,5 @@ heatmap(bx.maps[:bx])
   (e.g. resistivity) are not separate fields.
 - `:bx/:by/:bz` are the **cell-centred** average of the faces; the raw faces remain available as
   `:bx_left`, `:bx_right`, … if you need the divergence-free face representation.
-- On a non-MHD run, `:bx/:by/:bz` and the magnetosonic Mach numbers error with a clear message.
+- On a non-MHD run, `:bx/:by/:bz`, the derived quantities (`:bmag`, `:pmag`, `:beta`, `:v_alfven`,
+  `:e_magnetic`) and the magnetosonic Mach numbers all error with a clear message.

--- a/src/functions/getvar/fields.jl
+++ b/src/functions/getvar/fields.jl
@@ -74,6 +74,10 @@ const FIELD_DEPS = Dict{Symbol, Dict{Symbol,Vector{Symbol}}}(
     :mach_alfven=>[:v,:bx,:by,:bz,:rho],
     :mach_fast=>[:v,:cs,:bx,:by,:bz,:rho],
     :mach_slow=>[:v,:cs,:bx,:by,:bz,:rho],
+    # derived magnetic quantities: |B|, magnetic pressure B²/2, plasma β = P_th/P_mag,
+    # Alfvén speed |B|/√ρ, magnetic energy per cell (B²/2)·V
+    :bmag=>[:bx,:by,:bz], :pmag=>[:bx,:by,:bz], :beta=>[:p,:bx,:by,:bz],
+    :v_alfven=>[:bx,:by,:bz,:rho], :e_magnetic=>[:bx,:by,:bz,:volume],
     :ekin=>[:mass,:v], :etherm=>[:p,:volume],
   ),
 

--- a/src/functions/getvar/getvar_hydro.jl
+++ b/src/functions/getvar/getvar_hydro.jl
@@ -837,6 +837,38 @@ function get_data(  dataobject::HydroDataType,
                 end
             end
 
+        # Derived magnetic quantities from the cell-centred field. RAMSES-MHD code units put the
+        # magnetic pressure at B²/2 (the Gaussian 4π is absorbed: B_phys[G] = B_code·scale.Gauss =
+        # B_code·√(4π ρ₀v₀²), so B²/2 in code → ×scale.Ba = B²/8π in erg/cm³). Hence, in code units,
+        # P_mag = B²/2, u_mag = P_mag, v_A = |B|/√ρ, E_mag = P_mag·V. Each reuses an existing unit:
+        # :bmag → :Gauss/:muG/:Tesla, :pmag → :Ba, :v_alfven → :km_s, :e_magnetic → :erg; :beta is
+        # dimensionless. (|B| is the cell-centred field from the constrained-transport faces.)
+        elseif i == :bmag || i == :pmag || i == :beta || i == :v_alfven || i == :e_magnetic
+            has_faces = (:bx_left in column_names && :by_left in column_names && :bz_left in column_names)
+            has_cc    = (:bx in column_names && :by in column_names && :bz in column_names)
+            if !(has_faces || has_cc)
+                error("getvar :$i needs the magnetic field (:bx/:by/:bz, or the MHD face fields " *
+                      ":b*_left/:b*_right); load an MHD run.")
+            end
+            selected_unit = getunit(dataobject, i, vars, units)
+            bx = getvar(filtered_dataobject, :bx, mask=use_mask_in_recursion)
+            by = getvar(filtered_dataobject, :by, mask=use_mask_in_recursion)
+            bz = getvar(filtered_dataobject, :bz, mask=use_mask_in_recursion)
+            bmag = sqrt.(bx.^2 .+ by.^2 .+ bz.^2)                          # |B|, code units
+            if i === :bmag
+                vars_dict[:bmag] = bmag .* selected_unit
+            elseif i === :pmag                                            # magnetic pressure = B²/2 (code)
+                vars_dict[:pmag] = 0.5 .* bmag.^2 .* selected_unit
+            elseif i === :beta                                            # plasma β = P_thermal / P_mag
+                p = select(masked_data, :p)
+                vars_dict[:beta] = (p ./ (0.5 .* bmag.^2)) .* selected_unit
+            elseif i === :v_alfven                                        # v_A = |B|/√ρ (code velocity)
+                rho = select(masked_data, :rho)
+                vars_dict[:v_alfven] = (bmag ./ sqrt.(rho)) .* selected_unit
+            else                                                          # :e_magnetic = (B²/2)·V per cell
+                vol = getvar(filtered_dataobject, :volume, mask=use_mask_in_recursion)
+                vars_dict[:e_magnetic] = 0.5 .* bmag.^2 .* vol .* selected_unit
+            end
 
         elseif i == :ekin
             selected_unit = getunit(dataobject, :ekin, vars, units)

--- a/src/functions/miscellaneous.jl
+++ b/src/functions/miscellaneous.jl
@@ -204,6 +204,7 @@ function createscales(unit_l::Float64, unit_d::Float64, unit_t::Float64, unit_m:
     scale.Gauss     = sqrt(4π * unit_m / (unit_l * unit_t^2))                   # [G] Magnetic field strength  
     scale.muG       = scale.Gauss * 1e6                                          # [μG] Micro-Gauss
     scale.microG    = scale.muG                                                  # Alternative notation
+    scale.nG        = scale.Gauss * 1e9                                          # [nG] Nano-Gauss (IGM/cosmological fields)
     scale.Tesla     = scale.Gauss * 1e-4                                         # [T] Tesla (SI)
     
     # Energy and luminosity scales (corrected)
@@ -403,6 +404,7 @@ function createscales(unit_l::Float64, unit_d::Float64, unit_t::Float64, unit_m:
     scale.Gauss     = sqrt(4π * unit_m / (unit_l * unit_t^2))                   # [G] Magnetic field strength  
     scale.muG       = scale.Gauss * 1e6                                          # [μG] Micro-Gauss
     scale.microG    = scale.muG                                                  # Alternative notation
+    scale.nG        = scale.Gauss * 1e9                                          # [nG] Nano-Gauss (IGM/cosmological fields)
     scale.Tesla     = scale.Gauss * 1e-4                                         # [T] Tesla (SI)
     
     # Energy and luminosity scales (corrected)

--- a/src/types.jl
+++ b/src/types.jl
@@ -103,6 +103,7 @@ mutable struct ScalesType002
    Gauss::Float64
    muG::Float64
    microG::Float64
+   nG::Float64
    Tesla::Float64
 
    # Energy scales

--- a/test/03_data_readers.jl
+++ b/test/03_data_readers.jl
@@ -816,5 +816,21 @@ if @isdefined(DATASETS) && haskey(DATASETS, :ramses_mhd) && isdir(DATASETS[:rams
             m = getvar(gas, q)
             @test all(isfinite.(m)) && all(m .>= 0)
         end
+
+        # derived magnetic quantities: |B|, magnetic pressure B²/2, plasma β, Alfvén speed, magnetic energy
+        bmag = getvar(gas, :bmag); pmag = getvar(gas, :pmag); beta = getvar(gas, :beta)
+        va   = getvar(gas, :v_alfven); emag = getvar(gas, :e_magnetic)
+        @test all(isfinite, bmag) && all(bmag .> 0) && all(pmag .> 0) && all(beta .> 0)
+        @test bmag ≈ sqrt.(getvar(gas,:bx).^2 .+ getvar(gas,:by).^2 .+ getvar(gas,:bz).^2)  # |B|
+        @test pmag ≈ 0.5 .* bmag.^2                              # magnetic pressure = B²/2 (code units)
+        @test beta ≈ getvar(gas,:p) ./ pmag                      # plasma β = P_thermal / P_mag
+        @test va   ≈ bmag ./ sqrt.(getvar(gas,:rho))             # Alfvén speed v_A = |B|/√ρ
+        @test getvar(gas,:mach_alfven) ≈ getvar(gas,:v) ./ va    # consistent with the Alfvén Mach number
+        @test emag ≈ pmag .* getvar(gas,:volume)                 # magnetic energy per cell = P_mag·V
+        # units resolve via the existing scale (B → μG, pressure → Ba, speed → km/s, energy → erg)
+        @test getvar(gas,:bmag,:muG) ≈ bmag .* info.scale.muG
+        @test getvar(gas,:pmag,:Ba)  ≈ getvar(gas,:p,:Ba) ./ beta   # P_mag in barye, cross-checked vs β
+        @test all(isfinite, getvar(gas,:v_alfven,:km_s)) && all(isfinite, getvar(gas,:e_magnetic,:erg))
+        @test info.scale.nG ≈ info.scale.Gauss * 1e9            # new nanogauss unit
     end
 end

--- a/test/37_derived_fields_tests.jl
+++ b/test/37_derived_fields_tests.jl
@@ -130,6 +130,7 @@
             skip = Dict(
                 :hydro    => Set([:delta, :overdensity,                       # cosmological only
                                   :bx, :by, :bz,                              # need magnetic field
+                                  :bmag, :pmag, :beta, :v_alfven, :e_magnetic,# need magnetic field
                                   :mach_alfven, :mach_fast, :mach_slow]),     # need magnetic field
                 :gravity  => Set{Symbol}(),
                 :particle => Set([:formation_redshift, :formation_time, :zform]),  # cosmological only


### PR DESCRIPTION
Adds the derived magnetic quantities users reach for, built from the cell-centred field:

| Quantity | Formula | Units |
|---|---|---|
| `:bmag` | `|B| = √(Bx²+By²+Bz²)` | `:Gauss/:muG/:microG/:nG/:Tesla` |
| `:pmag` | `B²/8π` (= B²/2 in code units) | `:Ba/:g_cm_s2` |
| `:beta` | `P_thermal / P_mag` | dimensionless |
| `:v_alfven` | `|B|/√(4πρ)` (= |B|/√ρ code) | `:km_s/:cm_s` |
| `:e_magnetic` | `P_mag·V_cell` | `:erg` |

**No new unit dimensions** — all reuse existing scales (field strength / pressure / velocity / energy). The one unit added is **`:nG`** (nanogauss) for IGM/cosmological fields.

Wired into `FIELD_DEPS` (projection/profile auto-read the right faces) and the test/37 magnetic skip-set. Tests in test/03 verify the formulas + unit conversions against real `ramses_mhd_128` (incl. consistency with the existing `:mach_alfven`). Docs: `magnetic_fields.md` + new "Magnetic quantities" section in `computation_reference.md`.

Full test suite green (0 fail / 0 error).