### PR TITLE
quicklook: MHD-aware dashboard — face-on |B| panel + |B|/β census

### DIFF
--- a/docs/src/magnetic_fields.md
+++ b/docs/src/magnetic_fields.md
@@ -101,6 +101,9 @@ bx = projection(gas, :bx;            direction=:z)   # mass-weighted ⟨Bx⟩ ma
 heatmap(bx.maps[:bx])
 ```
 
+On an MHD run the [first-look dashboard](report.md) does this for you: `quicklook(output)` adds a
+face-on `|B|` panel and reports the `|B|` and plasma-β ranges automatically.
+
 ## Caveats
 
 - Mera reads **ideal-MHD** RAMSES outputs (the constrained-transport `B` faces). Non-ideal terms

--- a/ext/MeraMakieExt.jl
+++ b/ext/MeraMakieExt.jl
@@ -26,7 +26,16 @@ _poscolor(z) = (v = filter(x -> isfinite(x) && x > 0, vec(z)); isempty(v) ? (not
 function _loghm!(ax, xs, ys, A; colormap)
     L = map(v -> (isfinite(v) && v > 0) ? log10(v) : NaN, A)
     fin = filter(isfinite, vec(L))
-    cr = isempty(fin) ? (0.0, 1.0) : (minimum(fin), max(maximum(fin), minimum(fin) + eps()))
+    if isempty(fin)
+        cr = (0.0, 1.0)
+    else
+        lo, hi = minimum(fin), maximum(fin)
+        if hi <= lo                                   # constant map → widen by a RELATIVE amount so
+            d = max(abs(lo), 1.0) * 1e-6              # the bump survives at large |log10| (eps(1) would
+            lo, hi = lo - d, hi + d                   # be absorbed); Makie errors on a zero-width range
+        end
+        cr = (lo, hi)
+    end
     Makie.heatmap!(ax, xs, ys, L; colormap, colorrange=cr)
 end
 
@@ -113,7 +122,8 @@ end
 # (warm/stellar), dark matter = cividis (the CVD-optimised cool map), ρ–T phase = viridis (the 2D-
 # histogram standard). A user-supplied `colormap` overrides all of them.
 const _QL_CMAP = Dict(:z => :viridis, :x => :viridis, :y => :viridis,
-                      :stars => :magma, :dm => :cividis, :phase => :batlow)
+                      :stars => :magma, :dm => :cividis, :phase => :batlow,
+                      :bmag => :plasma)   # magnetic field |B| — distinct from the gas viridis maps
 # :batlow (Crameri) is a multi-hue perceptually-uniform, colorblind-safe map — the recommended
 # rainbow alternative — giving the ρ–T phase histogram more colour range than the single-hue viridis.
 
@@ -134,9 +144,10 @@ function Mera._plot_quicklook(q::Mera.QuickLookResult; size=nothing, colormap=no
                :x     => ("Gas Σ (edge-on, x)",     "y [kpc]", "z [kpc]"),
                :y     => ("Gas Σ (edge-on, y)",     "x [kpc]", "z [kpc]"),
                :stars => ("Stars Σ (face-on)",      "x [kpc]", "y [kpc]"),
-               :dm    => ("Dark matter Σ (face-on)","x [kpc]", "y [kpc]"))
+               :dm    => ("Dark matter Σ (face-on)","x [kpc]", "y [kpc]"),
+               :bmag  => ("|B| (face-on)",          "x [kpc]", "y [kpc]"))
     specs = Any[]
-    for k in (:z, :x, :y, :stars, :dm)
+    for k in (:z, :x, :y, :stars, :dm, :bmag)
         haskey(m, k) && push!(specs, (m[k], lbl[k]..., k))
     end
     havephase = q.phase !== nothing
@@ -164,12 +175,14 @@ function Mera._plot_quicklook(q::Mera.QuickLookResult; size=nothing, colormap=no
                                        ticklabelsize=9, ticksize=3)
 
     for (i, (proj, title, xl, yl, key)) in enumerate(specs)
-        r, c = gpos(i); mp = proj.maps[:sd]; ex = proj.extent .* skpc .* lenfac
+        r, c = gpos(i)
+        mapkey = key === :bmag ? :bmag : :sd        # the |B| panel projects :bmag, the others :sd
+        mp = proj.maps[mapkey]; ex = proj.extent .* skpc .* lenfac
         ax = Makie.Axis(fig[r, c]; title=title, xlabel=relabel(xl), ylabel=relabel(yl),
                         aspect=Makie.DataAspect(), AX...)
         xs = range(ex[1], ex[2], length=Base.size(mp, 1)); ys = range(ex[3], ex[4], length=Base.size(mp, 2))
         hm = _loghm!(ax, xs, ys, mp; colormap=cmapof(key))
-        cb(fig[r, c][1, 2], hm; label="log₁₀ Σ")
+        cb(fig[r, c][1, 2], hm; label=key === :bmag ? "log₁₀ ⟨|B|⟩ [μG]" : "log₁₀ Σ")
     end
     if havephase
         r, c = gpos(length(specs) + 1); ph = q.phase
@@ -205,6 +218,11 @@ function Mera._plot_quicklook(q::Mera.QuickLookResult; size=nothing, colormap=no
         push!(L, ""); push!(L, "RANGES" * (q.sampled ? " (smoothed)" : ""))
         push!(L, "  nH  $(nf(s.nH_range[1]))…$(nf(s.nH_range[2]))")
         push!(L, "  T   $(nf(s.T_range_K[1]))…$(nf(s.T_range_K[2])) K")
+    end
+    if get(s, :bmag_range_muG, nothing) !== nothing            # MHD run
+        push!(L, ""); push!(L, "MAGNETIC")
+        push!(L, "  |B|  $(nf(s.bmag_range_muG[1]))…$(nf(s.bmag_range_muG[2])) μG")
+        push!(L, "  β    $(nf(s.beta_range[1]))…$(nf(s.beta_range[2]))")
     end
     axt = Makie.Axis(fig[rt, ct]; title="census", titlesize=13, titlegap=4,
                      backgroundcolor=(:gray, 0.05))

--- a/src/functions/quicklook.jl
+++ b/src/functions/quicklook.jl
@@ -19,8 +19,9 @@
 Result of [`quicklook`](@ref). Fields: `info`, `levelmin`, `levelmax`, `lmax_used`
 (level actually read, `nothing` for a header-only call), `ncells` (cells read),
 `sampled` (true ⇒ coarse/partial ⇒ estimates are approximate), `maps` (a `NamedTuple`
-of surface-density projections: gas `x, y, z` plus face-on `stars`/`dm` when particles are
-present, or `nothing`), `phase` (the ρ–T histogram, or `nothing`), `budget` (a `NamedTuple` global snapshot
+of surface-density projections: gas `x, y, z`, face-on `stars`/`dm` when particles are present,
+plus a face-on magnetic-field map `bmag` (μG) on an MHD run, or `nothing`), `phase` (the ρ–T
+histogram, or `nothing`), `budget` (a `NamedTuple` global snapshot
 budget — gas/stellar/DM mass and current SFR — or `nothing`), and `summary`
 (a `NamedTuple` of facts + estimates).
 """
@@ -95,7 +96,8 @@ levels, finest cell, time/redshift, and the cell & particle census) and — unle
 single **budgeted** hydro read (only the coarse AMR levels when the full output would exceed `budget`
 cells), then builds surface-density projections along **each axis** (`.maps.x/.y/.z` — face-on plus the
 two edge-on views), a ρ–T phase diagram, a **global snapshot budget** (gas / stellar / dark-matter mass
-and the current SFR), and prints a compact dashboard.
+and the current SFR), and prints a compact dashboard. On an **MHD run** it additionally reads the
+magnetic field and adds a face-on `|B|` map (`.maps.bmag`, μG) plus `|B|` and plasma-β ranges.
 
 * `budget` — cell-count cap; if the full output is predicted larger, only coarse levels are read and
   the result is flagged `sampled=true` (estimates labelled APPROXIMATE). `lmax` overrides the choice.
@@ -163,6 +165,7 @@ function quicklook(output::Int; path::String=".", budget::Int=2_000_000,
     maps = NamedTuple(); ph = nothing
     n = 0; luse = info.levelmax; sampled = false
     gas_mass = nothing; nH_range = nothing; T_range = nothing
+    bmag_range = nothing; beta_range = nothing
 
     # --- gas (hydro): budgeted read → Σ map(s) along the selected axes + ρ–T phase + ranges ---
     # Guard on info.hydro too (mirrors the info.particles guard below): a gravity-/particle-/clumps-only
@@ -170,7 +173,10 @@ function quicklook(output::Int; path::String=".", budget::Int=2_000_000,
     if want.hydro && info.hydro
         luse, sampled = lmax === nothing ? _quicklook_level(info, budget) :
                         (clamp(Int(lmax), info.levelmin, info.levelmax), Int(lmax) < info.levelmax)
-        qlvars = getvar_requirements(:hydro, [:sd, :T, :rho])      # read only the needed vars (else full)
+        # MHD run? then also read the magnetic field so the dashboard can show a |B| map + β stats.
+        is_mhd = any(v -> occursin(r"^b[xyz]_(left|right)$", string(v)), info.variable_list)
+        qlreq  = is_mhd ? [:sd, :T, :rho, :bmag] : [:sd, :T, :rho]
+        qlvars = getvar_requirements(:hydro, qlreq)                # read only the needed vars (else full)
         gas = (!isempty(qlvars) && all(in(info.variable_list), qlvars)) ?
               gethydro(info, qlvars, lmax=luse, verbose=false, show_progress=false) :
               gethydro(info, lmax=luse, verbose=false, show_progress=false)
@@ -182,6 +188,12 @@ function quicklook(output::Int; path::String=".", budget::Int=2_000_000,
                    xunit=:nH, yunit=:K)
         gas_mass = sum(getvar(gas, :mass, :Msol))
         nH_range = extrema(getvar(gas, :rho, :nH)); T_range = extrema(getvar(gas, :T, :K))
+        if is_mhd                          # face-on (mass-weighted) |B| map + |B| / plasma-β ranges
+            bproj = projection(gas, :bmag, :muG; direction=:z, center=[:bc], res=res,
+                               verbose=false, show_progress=false)
+            maps = merge(maps, (bmag = bproj,))
+            bmag_range = extrema(getvar(gas, :bmag, :muG)); beta_range = extrema(getvar(gas, :beta))
+        end
     end
 
     # --- particles (read once, when wanted & present): budget + face-on stellar / dark-matter Σ maps.
@@ -217,7 +229,8 @@ function quicklook(output::Int; path::String=".", budget::Int=2_000_000,
                             npart=ns+nd+facts.nsinks, nstars=ns, ndm=nd, particle_subsample=psub,
                             stellar_mass_Msol=bud.stellar_mass_Msol, dm_mass_Msol=bud.dm_mass_Msol,
                             sfr10=bud.sfr10, sfr100=bud.sfr100,
-                            nH_range=nH_range, T_range_K=T_range, seconds=time()-t0))
+                            nH_range=nH_range, T_range_K=T_range,
+                            bmag_range_muG=bmag_range, beta_range=beta_range, seconds=time()-t0))
     verbose && _quicklook_print(summary, t0)
     return QuickLookResult(info, info.levelmin, info.levelmax, luse, n, sampled, mapsout, ph, bud, summary)
 end
@@ -245,6 +258,10 @@ function _quicklook_print(s, t0)
         rnote = s.sampled ? "  ⚠ peaks smoothed (lower bound)" : ""
         g(:nH_range) !== nothing && println("│ nH range   : $(nf(s.nH_range[1])) … $(nf(s.nH_range[2])) cm⁻³$(rnote)")
         g(:T_range_K) !== nothing && println("│ T  range   : $(nf(s.T_range_K[1])) … $(nf(s.T_range_K[2])) K$(rnote)")
+    end
+    if g(:bmag_range_muG) !== nothing              # MHD run — magnetic field + plasma β
+        println("│ |B| range  : $(nf(s.bmag_range_muG[1])) … $(nf(s.bmag_range_muG[2])) μG")
+        println("│ plasma β   : $(nf(s.beta_range[1])) … $(nf(s.beta_range[2]))  (β<1 ⇒ B-dominated)")
     end
     if g(:stellar_mass_Msol) !== nothing           # particle masses + SFR
         println("│ star mass  : $(nf(s.stellar_mass_Msol)) M⊙        DM mass : $(nf(s.dm_mass_Msol)) M⊙")

--- a/test/38_report_tests.jl
+++ b/test/38_report_tests.jl
@@ -61,6 +61,8 @@
             # maps holds Σ projected along each axis (z face-on + x,y edge-on)
             @test haskey(q.maps.z.maps, :sd) && haskey(q.maps.x.maps, :sd) && haskey(q.maps.y.maps, :sd)
             @test haskey(q.phase, :H)
+            # spiral_ugrid is non-MHD → no magnetic panel / ranges
+            @test !haskey(q.maps, :bmag) && q.summary.bmag_range_muG === nothing
             # header particle census (summed from per-family counts; available header-only too)
             @test q.summary.npart > 0 && q.summary.nstars > 0 && q.summary.ndm >= 0
             @test q.summary.npart == q.summary.nstars + q.summary.ndm + q.summary.nsinks
@@ -84,6 +86,24 @@
                 f = tempname() * ".png"; CairoMakie.save(f, fig)
                 @test isfile(f) && filesize(f) > 0
                 rm(f, force=true)
+            end
+        end
+
+        @testset "quicklook MHD panel (ramses_mhd_128)" begin
+            if haskey(DATASETS, :ramses_mhd) && isdir(DATASETS[:ramses_mhd].path)
+                mhd = DATASETS[:ramses_mhd]
+                qm  = quicklook(mhd.output; path=mhd.path, verbose=false)
+                # MHD run → a face-on |B| map (projected :bmag) plus |B| and plasma-β summary ranges
+                @test haskey(qm.maps, :bmag) && haskey(qm.maps.bmag.maps, :bmag)
+                @test qm.summary.bmag_range_muG !== nothing && qm.summary.bmag_range_muG[2] > 0
+                @test qm.summary.beta_range !== nothing && qm.summary.beta_range[1] > 0
+                if Base.find_package("CairoMakie") !== nothing
+                    @eval using CairoMakie
+                    fig = quicklookplot(qm)                       # the |B| panel must render too
+                    @test occursin("Figure", string(typeof(fig)))
+                end
+            else
+                @test_skip "ramses_mhd_128 not available"
             end
         end
 


### PR DESCRIPTION
Natural follow-up to #116. On an **MHD run**, `quicklook` now also reads the magnetic field and adds:
- a face-on (mass-weighted) **|B| map** → `q.maps.bmag` (projected `:bmag`, μG), rendered as a distinct `:plasma` panel
- **|B|** and **plasma-β** ranges in the summary, printed dashboard, and plotted census (β<1 ⇒ B-dominated)

The B faces are added to the budgeted read only when MHD is detected, so **non-MHD quicklook is unchanged**.

Also fixes a latent robustness bug in `_loghm!`: a constant map produced a zero-width colorrange (the `eps(1)` bump was absorbed at large `|log10|`), which made Makie throw `cmin == cmax`. Now widened by a relative amount — so degenerate/constant panels render fine.

Verified on real `ramses_mhd_128` (|B| panel + β range 0.07–4.0, renders cleanly). Tests (test/38): MHD run gets the panel + ranges; non-MHD spiral_ugrid has neither. Full suite green.