### PR TITLE
fix: revert :nG — it broke loading pre-existing mera files (backward compat)

### DIFF
--- a/docs/src/computation_reference.md
+++ b/docs/src/computation_reference.md
@@ -156,17 +156,16 @@ factor reappears only in the physical-unit conversion ``B_\mathrm{phys}[\mathrm{
 
 | Quantity | Formula | Units |
 |---|---|---|
-| Field magnitude `:bmag` | ``|\mathbf B| = \sqrt{B_x^2+B_y^2+B_z^2}`` | `:Gauss`, `:muG`, `:microG`, `:nG`, `:Tesla` |
+| Field magnitude `:bmag` | ``|\mathbf B| = \sqrt{B_x^2+B_y^2+B_z^2}`` | `:Gauss`, `:muG`, `:microG`, `:Tesla` |
 | Magnetic pressure `:pmag` | ``P_\mathrm{mag} = \dfrac{B^2}{8\pi}`` (``=B^2/2`` in code units) | `:Ba`, `:g_cm_s2` |
 | Plasma beta `:beta` | ``\beta = \dfrac{P_\mathrm{thermal}}{P_\mathrm{mag}}`` | dimensionless |
 | Alfvén speed `:v_alfven` | ``v_A = \dfrac{|\mathbf B|}{\sqrt{4\pi\rho}}`` (``=|\mathbf B|/\sqrt{\rho}`` in code units) | `:km_s`, `:cm_s` |
 | Magnetic energy `:e_magnetic` | ``E_\mathrm{mag} = P_\mathrm{mag}\cdot V_\mathrm{cell}`` | `:erg` |
 
-All five reuse existing unit scales — magnetic-field strengths (`:Gauss`/`:muG`/`:microG`/`:nG`/`:Tesla`),
+All five reuse existing unit scales — magnetic-field strengths (`:Gauss`/`:muG`/`:microG`/`:Tesla`),
 pressure (`:Ba`/`:g_cm_s2`), velocity (`:km_s`/`:cm_s`) and energy (`:erg`) — so introducing MHD
-analysis needed **no new unit dimensions**. The quantities require an MHD run and error if the field
-components are absent. (`:nG`, nanogauss = `scale.Gauss·10⁹`, is the one unit added, for IGM /
-cosmological field strengths.)
+analysis needed **no new units at all**. The quantities require an MHD run and error if the field
+components are absent.
 
 ## Jeans & collapse
 

--- a/docs/src/magnetic_fields.md
+++ b/docs/src/magnetic_fields.md
@@ -62,7 +62,7 @@ All of these are **built-in `getvar` quantities** computed from the cell-centred
 arithmetic needed — and each takes the units shown:
 
 ```julia
-# field magnitude |B|  (field-strength units: :Gauss, :muG, :microG, :nG, :Tesla)
+# field magnitude |B|  (field-strength units: :Gauss, :muG, :microG, :Tesla)
 Bmag    = getvar(gas, :bmag)          # code units
 Bmag_uG = getvar(gas, :bmag, :muG)    # μG
 
@@ -80,10 +80,9 @@ mf = getvar(gas, :mach_fast)     # fast:  v_f = √(c_s² + v_A²)
 ms = getvar(gas, :mach_slow)     # slow:  v_s = c_s·v_A/√(c_s² + v_A²)
 ```
 
-No new units were needed: `B` reuses the field-strength scales (`:Gauss`, `:muG`, `:microG`, `:nG`,
+No new units were needed: `B` reuses the field-strength scales (`:Gauss`, `:muG`, `:microG`,
 `:Tesla`), magnetic pressure/energy-density reuse the pressure scales (`:Ba`, `:g_cm_s2`), the Alfvén
-speed reuses the velocity scales (`:km_s`, `:cm_s`), and the magnetic energy reuses `:erg`. (`:nG`,
-nanogauss, is new — handy for IGM/cosmological field strengths.)
+speed reuses the velocity scales (`:km_s`, `:cm_s`), and the magnetic energy reuses `:erg`.
 
 The exact formulas (incl. the RAMSES code-unit convention `P_mag = B²/2` and the Alfvén-speed
 conversion) are listed in

--- a/src/functions/miscellaneous.jl
+++ b/src/functions/miscellaneous.jl
@@ -204,7 +204,6 @@ function createscales(unit_l::Float64, unit_d::Float64, unit_t::Float64, unit_m:
     scale.Gauss     = sqrt(4π * unit_m / (unit_l * unit_t^2))                   # [G] Magnetic field strength  
     scale.muG       = scale.Gauss * 1e6                                          # [μG] Micro-Gauss
     scale.microG    = scale.muG                                                  # Alternative notation
-    scale.nG        = scale.Gauss * 1e9                                          # [nG] Nano-Gauss (IGM/cosmological fields)
     scale.Tesla     = scale.Gauss * 1e-4                                         # [T] Tesla (SI)
     
     # Energy and luminosity scales (corrected)
@@ -404,7 +403,6 @@ function createscales(unit_l::Float64, unit_d::Float64, unit_t::Float64, unit_m:
     scale.Gauss     = sqrt(4π * unit_m / (unit_l * unit_t^2))                   # [G] Magnetic field strength  
     scale.muG       = scale.Gauss * 1e6                                          # [μG] Micro-Gauss
     scale.microG    = scale.muG                                                  # Alternative notation
-    scale.nG        = scale.Gauss * 1e9                                          # [nG] Nano-Gauss (IGM/cosmological fields)
     scale.Tesla     = scale.Gauss * 1e-4                                         # [T] Tesla (SI)
     
     # Energy and luminosity scales (corrected)

--- a/src/types.jl
+++ b/src/types.jl
@@ -103,7 +103,6 @@ mutable struct ScalesType002
    Gauss::Float64
    muG::Float64
    microG::Float64
-   nG::Float64
    Tesla::Float64
 
    # Energy scales

--- a/test/03_data_readers.jl
+++ b/test/03_data_readers.jl
@@ -831,6 +831,5 @@ if @isdefined(DATASETS) && haskey(DATASETS, :ramses_mhd) && isdir(DATASETS[:rams
         @test getvar(gas,:bmag,:muG) ≈ bmag .* info.scale.muG
         @test getvar(gas,:pmag,:Ba)  ≈ getvar(gas,:p,:Ba) ./ beta   # P_mag in barye, cross-checked vs β
         @test all(isfinite, getvar(gas,:v_alfven,:km_s)) && all(isfinite, getvar(gas,:e_magnetic,:erg))
-        @test info.scale.nG ≈ info.scale.Gauss * 1e9            # new nanogauss unit
     end
 end

--- a/test/27_data_conversion_tests.jl
+++ b/test/27_data_conversion_tests.jl
@@ -999,6 +999,20 @@ else
         end
     end
 
+    @testset "backward-compat: load a pre-existing (old-schema) mera file" begin
+        # Guards against silent struct-layout breakage of the serialized scale/info types: an OLD
+        # JLD2 mera file (written by an earlier Mera) must still load. Adding a field to ScalesType002
+        # once broke exactly this — old files reconstructed to a mismatched layout and threw on load.
+        jdir = joinpath(SIMULATION_PATH, "JLD2_files")
+        if isfile(joinpath(jdir, "output_00300.jld2"))
+            gas = loaddata(300, jdir, :hydro, verbose=false)
+            @test gas isa HydroDataType && length(gas.data) > 0
+            @test gas.scale.Msol > 0 && gas.scale.Gauss > 0   # the scale type that regressed is intact
+        else
+            @test_skip "old-schema mera file (JLD2_files/output_00300.jld2) not available"
+        end
+    end
+
 end  # DATA_AVAILABLE
 
 end  # @testset


### PR DESCRIPTION
**Regression fix.** Adding `:nG` to `ScalesType002` (#116) inserted a field, changing the serialized struct layout 133→134. Mera-files store `ScalesType002` as a raw struct (no JLD2 `writeas`), so **every pre-existing mera file failed to `loaddata`**:

```
MethodError: Cannot convert JLD2.ReconstructedStatic{:ScalesType002, …, NTuple{133,Float64}} to ScalesType002
```

In-session JLD2 round-trip tests didn't catch it (they save+load with the current layout). `:nG` (nanogauss) is a non-essential convenience unit; backward-compatible archives matter far more, so revert it. The MHD quantities (`:bmag/:pmag/:beta/:v_alfven/:e_magnetic`) are unaffected (they use `:Gauss/:muG/:Tesla`).

Adds a **regression test** (test/27): loads a pre-existing old-schema mera file and checks the scale type is intact, so a future `ScalesType002` layout change can't silently break old files again.

Follow-up noted in the commit: the underlying fragility (no `writeas` → any field change breaks old files) is worth fixing properly so the type can evolve.

Full suite green (incl. the regression test loading the real old file).