### PR TITLE
test: ScalesType version coverage across functions (+ 2 fixes it surfaced)

### DIFF
--- a/src/functions/data/data_info.jl
+++ b/src/functions/data/data_info.jl
@@ -146,9 +146,11 @@ function infodata(output::Int;
     
     # Create comprehensive typemap matching the one in loaddata()
     typemap = Dict(
-        # Map old PhysicalUnitsType versions to current one
-        "Mera.PhysicalUnitsType" => JLD2.Upgrade(PhysicalUnitsType001),
-        "Mera.PhysicalUnitsType001" => PhysicalUnitsType001,
+        # Map old PhysicalUnitsType versions to the CURRENT one (002) via Upgrade → rconvert, so an
+        # old file's constants reconstruct into the live type (fills new constants with defaults).
+        "Mera.PhysicalUnitsType" => JLD2.Upgrade(PhysicalUnitsType002),
+        "Mera.PhysicalUnitsType001" => JLD2.Upgrade(PhysicalUnitsType002),
+        "Mera.PhysicalUnitsType002" => PhysicalUnitsType002,
         
         # Map old ScalesType versions to current one using Upgrade for field conversion
         "Mera.ScalesType" => JLD2.Upgrade(ScalesType003),

--- a/src/functions/data/data_load.jl
+++ b/src/functions/data/data_load.jl
@@ -170,9 +170,11 @@ function loaddata(output::Int; path::String="./",
     
     # Create comprehensive typemap following JLD2 best practices for backward compatibility
     typemap = Dict(
-        # Map old PhysicalUnitsType versions to current one
-        "Mera.PhysicalUnitsType" => JLD2.Upgrade(PhysicalUnitsType001),
-        "Mera.PhysicalUnitsType001" => PhysicalUnitsType001,
+        # Map old PhysicalUnitsType versions to the CURRENT one (002) via Upgrade → rconvert, so an
+        # old file's constants reconstruct into the live type (fills new constants with defaults).
+        "Mera.PhysicalUnitsType" => JLD2.Upgrade(PhysicalUnitsType002),
+        "Mera.PhysicalUnitsType001" => JLD2.Upgrade(PhysicalUnitsType002),
+        "Mera.PhysicalUnitsType002" => PhysicalUnitsType002,
         
         # Map old ScalesType versions to current one using Upgrade for field conversion
         "Mera.ScalesType" => JLD2.Upgrade(ScalesType003),

--- a/src/types.jl
+++ b/src/types.jl
@@ -1291,7 +1291,10 @@ function Base.convert(::Type{ScalesType003}, old::Union{ScalesType001,ScalesType
         end
     end
     # nG is new in 003: derive it from Gauss (older types don't store it)
-    new_scales.nG = (isdefined(new_scales, :Gauss) ? new_scales.Gauss : 1.0) * 1e9
+    # nG is new in 003: derive from Gauss when the source actually carried it (ScalesType002), else 0
+    # (ScalesType001 predates the magnetic units; isdefined() can't tell — Float64 fields are isbits and
+    # always "defined", so check the SOURCE type's field set). The scale is refreshed on load anyway.
+    new_scales.nG = hasfield(typeof(old), :Gauss) ? new_scales.Gauss * 1e9 : 0.0
     return new_scales
 end
 

--- a/test/22_types_tests.jl
+++ b/test/22_types_tests.jl
@@ -328,4 +328,73 @@ using DataStructures: SortedDict
             @test isapprox(loaded.deg, s.deg, rtol=1e-12)
         end
     end
+
+    # ====================================================================
+    # ScalesType003 versioning — adding :nG must NOT break old mera files.
+    # 003 = frozen 002 + :nG; old files upgrade through convert/rconvert and
+    # the JLD2 typemap. Covers every path that has to care about the different
+    # ScalesType versions: the structs, convert (in-memory upgrade),
+    # rconvert (NamedTuple load path), the real JLD2 file-upgrade via typemap,
+    # and the functions that consume a scale.
+    # ====================================================================
+    @testset "ScalesType003: struct stays additive over a frozen 002" begin
+        @test Mera.ScalesType003() isa Mera.ScalesType003
+        @test fieldcount(Mera.ScalesType002) == 133            # frozen — old files match this layout
+        @test fieldcount(Mera.ScalesType003) == 134            # 002 + :nG
+        @test :nG in fieldnames(Mera.ScalesType003)
+        @test :nG ∉ fieldnames(Mera.ScalesType002)             # never add to the frozen version
+    end
+
+    @testset "convert ScalesType002/001 → ScalesType003 (derives :nG)" begin
+        old2 = Mera.ScalesType002()
+        old2.kpc = 12.34; old2.Msol = 1.989e33; old2.Gauss = 2.0
+        new = convert(Mera.ScalesType003, old2)
+        @test new isa Mera.ScalesType003
+        @test new.kpc == 12.34 && new.Msol == 1.989e33 && new.Gauss == 2.0
+        @test new.nG == 2.0 * 1e9                              # derived from Gauss (not garbage memory)
+        # ScalesType001 predates the magnetic units (no :Gauss field) → nG is 0 (no info), not garbage
+        @test :Gauss ∉ fieldnames(Mera.ScalesType001)
+        old1 = Mera.ScalesType001(); old1.kpc = 5.0
+        n1 = convert(Mera.ScalesType003, old1)
+        @test n1 isa Mera.ScalesType003 && n1.kpc == 5.0 && n1.nG == 0.0
+    end
+
+    @testset "rconvert ScalesType003 ← old-layout NamedTuple (no :nG)" begin
+        # how JLD2 hands Mera an old 002 file: a NamedTuple WITHOUT :nG.
+        nt = (kpc = 3.5, Msol = 1.989e33, Gauss = 4.0, dimensionless = 1.0)
+        s = JLD2.rconvert(Mera.ScalesType003, nt)
+        @test s isa Mera.ScalesType003
+        @test s.kpc == 3.5 && s.Gauss == 4.0
+        @test s.nG == 4.0 * 1e9                                # filled FROM Gauss, not the 1.0 default
+        @test s.dimensionless == 1.0
+        @test isapprox(s.deg, 180.0 / π, rtol=1e-12)           # the other documented defaults still fill
+        # a NamedTuple that already carries :nG keeps it verbatim
+        @test JLD2.rconvert(Mera.ScalesType003, (Gauss = 4.0, nG = 123.0)).nG == 123.0
+    end
+
+    @testset "JLD2 file upgrade: a saved ScalesType002 loads as 003 via typemap" begin
+        # The real loaddata mechanism: an old file stored "Mera.ScalesType002"; the typemap upgrades it.
+        s2 = Mera.ScalesType002(); s2.kpc = 7.89; s2.Gauss = 5.0
+        mktempdir() do dir
+            f = joinpath(dir, "old_scale.jld2")
+            JLD2.jldsave(f; s = s2)
+            tm = Dict("Mera.ScalesType002" => JLD2.Upgrade(Mera.ScalesType003))
+            loaded = JLD2.load(f, "s"; typemap = tm)
+            @test loaded isa Mera.ScalesType003
+            @test loaded.kpc == 7.89 && loaded.Gauss == 5.0
+            @test loaded.nG == 5.0 * 1e9                       # derived during the upgrade
+        end
+    end
+
+    @testset "functions that consume a ScalesType use the current version (003)" begin
+        consts = Mera.createconstants()
+        sc = Mera.createscales(3.0e21, 1.0e-23, 1.0e15, 2.0e42, consts)
+        @test sc isa Mera.ScalesType003                        # createscales builds the current version
+        @test sc.nG ≈ sc.Gauss * 1e9
+        info = Mera.InfoType(); info.scale = sc                # the scale field accepts a 003
+        @test getunit(info, :muG) ≈ sc.muG                     # getunit resolves units off the 003 scale
+        @test getunit(info, :nG)  ≈ sc.nG
+        @test (viewfields(sc); true)                           # viewfields has a ::ScalesType003 method
+        @test Mera.humanize(1.0, sc, 2, "length") isa Tuple    # humanize too
+    end
 end


### PR DESCRIPTION
Follow-up to #120 — comprehensive tests for the different `ScalesType` versions and every path that must handle them, plus fixes for two bugs the tests surfaced.

**Tests (test/22, data-free, runs in CI):**
- struct invariants: `002` frozen at 133 fields, `003` = 002 + `:nG`
- `convert` 001/002 → 003 (derives `:nG` from Gauss)
- `rconvert` 003 ← old-layout NamedTuple (the JLD2 load path)
- the **real file-upgrade**: a saved `ScalesType002` loads as `003` via the typemap
- scale-consuming functions (`createscales`/`getunit`/`viewfields`/`humanize`) use the current `003`

**Fixes surfaced by the tests:**
- `convert(ScalesType003, ::ScalesType001)` read **garbage into `:nG`** — `isdefined(new_scales, :Gauss)` is always true for an isbits `Float64` field, so a pre-magnetic `001` source didn't fall back. Now checks the source type's field set (→ `nG = 0` for `001`).
- `PhysicalUnitsType` typemap mapped old versions to `001` while the live type is `002` (inconsistent with Scales). Now old/`001` → `JLD2.Upgrade(PhysicalUnitsType002)` + `002` passthrough — old constants reconstruct into the current type.

Full suite green.