### PR TITLE
types: forward-compatible loading for InfoType + data containers + sub-structs

### DIFF
--- a/src/functions/data/data_info.jl
+++ b/src/functions/data/data_info.jl
@@ -157,10 +157,22 @@ function infodata(output::Int;
         "Mera.ScalesType001" => JLD2.Upgrade(ScalesType003),
         "Mera.ScalesType002" => JLD2.Upgrade(ScalesType003),
         "Mera.ScalesType003" => ScalesType003,
-        
-        # Map old InfoType versions (if they exist)
-        "Mera.InfoType" => InfoType,
-        "Mera.InfoType001" => InfoType,
+
+        # Forward-compatible loading of the container / metadata structs: route them through Upgrade
+        # so a future field addition to any of them does not break already-saved mera files. The
+        # generic _mera_rconvert (src/types.jl) copies present fields and zero-fills new Number fields.
+        "Mera.InfoType" => JLD2.Upgrade(InfoType),
+        "Mera.InfoType001" => JLD2.Upgrade(InfoType),
+        "Mera.FileNamesType" => JLD2.Upgrade(FileNamesType),
+        "Mera.GridInfoType" => JLD2.Upgrade(GridInfoType),
+        "Mera.PartInfoType" => JLD2.Upgrade(PartInfoType),
+        "Mera.CompilationInfoType" => JLD2.Upgrade(CompilationInfoType),
+        "Mera.DescriptorType" => JLD2.Upgrade(DescriptorType),
+        "Mera.HydroDataType" => JLD2.Upgrade(HydroDataType),
+        "Mera.GravDataType" => JLD2.Upgrade(GravDataType),
+        "Mera.RtDataType" => JLD2.Upgrade(RtDataType),
+        "Mera.PartDataType" => JLD2.Upgrade(PartDataType),
+        "Mera.ClumpDataType" => JLD2.Upgrade(ClumpDataType),
     )
     
     dataobject = JLD2.load(fpath, inflink, typemap=typemap)

--- a/src/functions/data/data_load.jl
+++ b/src/functions/data/data_load.jl
@@ -181,10 +181,22 @@ function loaddata(output::Int; path::String="./",
         "Mera.ScalesType001" => JLD2.Upgrade(ScalesType003),
         "Mera.ScalesType002" => JLD2.Upgrade(ScalesType003),
         "Mera.ScalesType003" => ScalesType003,
-        
-        # Map old InfoType versions (if they exist)
-        "Mera.InfoType" => InfoType,
-        "Mera.InfoType001" => InfoType,
+
+        # Forward-compatible loading of the container / metadata structs: route them through Upgrade
+        # so a future field addition to any of them does not break already-saved mera files. The
+        # generic _mera_rconvert (src/types.jl) copies present fields and zero-fills new Number fields.
+        "Mera.InfoType" => JLD2.Upgrade(InfoType),
+        "Mera.InfoType001" => JLD2.Upgrade(InfoType),
+        "Mera.FileNamesType" => JLD2.Upgrade(FileNamesType),
+        "Mera.GridInfoType" => JLD2.Upgrade(GridInfoType),
+        "Mera.PartInfoType" => JLD2.Upgrade(PartInfoType),
+        "Mera.CompilationInfoType" => JLD2.Upgrade(CompilationInfoType),
+        "Mera.DescriptorType" => JLD2.Upgrade(DescriptorType),
+        "Mera.HydroDataType" => JLD2.Upgrade(HydroDataType),
+        "Mera.GravDataType" => JLD2.Upgrade(GravDataType),
+        "Mera.RtDataType" => JLD2.Upgrade(RtDataType),
+        "Mera.PartDataType" => JLD2.Upgrade(PartDataType),
+        "Mera.ClumpDataType" => JLD2.Upgrade(ClumpDataType),
     )
     
     dataobject = JLD2.load(fpath, dlink, typemap=typemap)

--- a/src/types.jl
+++ b/src/types.jl
@@ -1498,6 +1498,37 @@ function JLD2.rconvert(::Type{PhysicalUnitsType002}, nt::NamedTuple)
             setfield!(units, field, 1.0)  # Default fallback
         end
     end
-    
+
     return units
+end
+
+
+# ─────────────────────────────────────────────────────────────────────────────────────────────────
+# Forward-compatible loading of the container / metadata structs.
+# A mera (JLD2) file stores these by their struct layout, so if a future Mera release ADDS a field to
+# any of them an already-saved file would otherwise fail to reconstruct (the same break that adding
+# :nG to ScalesType caused). Routing each through `JLD2.Upgrade` in the loaddata / info typemaps hands
+# the on-disk object to this generic rconvert as a NamedTuple: present fields are copied verbatim; a
+# field that is NEW in the current layout is zero-filled when it is a `Number` (a sane default) and
+# otherwise left unset (a missing Array/Dict/String is better left undefined than silently fabricated).
+# Nested Mera fields (scale, constants, descriptor, grid_info, …) are upgraded via their own typemap
+# entries before they reach here. Adding a field to any of these structs therefore needs no extra code.
+function _mera_rconvert(::Type{T}, nt::NamedTuple) where {T}
+    obj = T()
+    for (i, f) in enumerate(fieldnames(T))
+        if haskey(nt, f)
+            setfield!(obj, f, getfield(nt, f))
+        else
+            FT = fieldtype(T, i)
+            # zero-fill a NEW field only when it is a CONCRETE Number (zero(Real) etc. would throw on an
+            # abstract type); abstract-Number and ref fields are left unset rather than fabricated.
+            (FT <: Number && isconcretetype(FT)) && setfield!(obj, f, zero(FT))
+        end
+    end
+    return obj
+end
+
+for T in (FileNamesType, GridInfoType, PartInfoType, CompilationInfoType, DescriptorType, InfoType,
+          HydroDataType, GravDataType, RtDataType, PartDataType, ClumpDataType)
+    @eval JLD2.rconvert(::Type{$T}, nt::NamedTuple) = _mera_rconvert($T, nt)
 end

--- a/test/22_types_tests.jl
+++ b/test/22_types_tests.jl
@@ -397,4 +397,35 @@ using DataStructures: SortedDict
         @test (viewfields(sc); true)                           # viewfields has a ::ScalesType003 method
         @test Mera.humanize(1.0, sc, 2, "length") isa Tuple    # humanize too
     end
+
+    # ====================================================================
+    # Forward-compatible loading of the CONTAINER / metadata structs
+    # (InfoType, the data containers, and their sub-structs). The loaddata
+    # typemap routes each through JLD2.Upgrade → _mera_rconvert, so a future
+    # field ADDITION to any of them won't break already-saved mera files.
+    # Simulated here by feeding rconvert a NamedTuple with only a SUBSET of
+    # the current fields (i.e. an "old layout"). Data-free.
+    # ====================================================================
+    @testset "container rconvert: present copied, new Number zero-filled, refs left unset" begin
+        gi = JLD2.rconvert(Mera.GridInfoType, (ngridmax = 100, nx = 4, ny = 4, nz = 4))
+        @test gi isa Mera.GridInfoType
+        @test gi.ngridmax == 100 && gi.nx == 4                 # present fields copied
+        @test gi.ngrid_current == 0 && gi.nlevelmax == 0       # absent Int fields → 0, not garbage
+        @test !isdefined(gi, :bound_key)                       # absent ref (Array) field → left unset
+
+        # InfoType: keeps present fields incl. an already-upgraded nested Mera type (scale)
+        sc = Mera.createscales(3.0e21, 1.0e-23, 1.0e15, 2.0e42, Mera.createconstants())
+        info = JLD2.rconvert(Mera.InfoType, (ndim = 3, boxlen = 100.0, scale = sc))
+        @test info isa Mera.InfoType
+        @test info.ndim == 3 && info.boxlen == 100.0
+        @test info.scale === sc && info.scale isa Mera.ScalesType003
+        @test info.ncpu == 0                                   # absent Int field → 0
+
+        # a top-level data container too (this is the object a mera file stores)
+        hd = JLD2.rconvert(Mera.HydroDataType, (lmin = 3, lmax = 7, boxlen = 48.0))
+        @test hd isa HydroDataType
+        @test hd.lmin == 3 && hd.lmax == 7 && hd.boxlen == 48.0
+        @test hd.smallr == 0.0                                 # absent Float64 field → 0.0
+        @test !isdefined(hd, :data)                            # absent table (ref) → left unset
+    end
 end


### PR DESCRIPTION
Extends the `ScalesType003` versioning robustness (#120/#121) to **every container/metadata struct stored in a mera file**, so a future field ADDITION to any of them won't break already-saved files.

- **types.jl**: generic `_mera_rconvert(T, nt)` — fresh `T()`, copies on-disk fields, zero-fills a NEW *concrete* `Number` field (guarded so abstract `Real`/ref fields aren't fabricated), leaves new ref fields unset. Registered as `JLD2.rconvert` for `InfoType`, `FileNamesType`, `GridInfoType`, `PartInfoType`, `CompilationInfoType`, `DescriptorType`, and the data containers `HydroDataType`/`GravDataType`/`RtDataType`/`PartDataType`/`ClumpDataType`.
- **typemaps** (data_load.jl / data_info.jl): route all of the above through `JLD2.Upgrade(T)` (InfoType was direct; the rest unmapped). Nested Mera fields upgrade via their own entries first.

**Tests** (test/22, data-free): container rconvert copies present fields, zero-fills absent Number fields, leaves absent refs unset, preserves a nested `ScalesType003`. Verified separately: a real `savedata→loaddata` round-trip through the new path reproduces the container identically, and the pre-existing old mera file still loads. Full suite green.

With this, the whole mera-file object graph is forward-compatible — adding a field to any of these structs is now a no-op for old archives.