### PR TITLE
docs(off-axis): "How each AMR cell is treated" section + vector figure

### DIFF
--- a/docs/src/06_offaxis_Projection.md
+++ b/docs/src/06_offaxis_Projection.md
@@ -213,6 +213,29 @@ particle-mesh assignment (Hockney & Eastwood 1988); `:overlap`/`:exact` are foot
 The default `:overlap` (and `:exact`) are AMR-aligned and free of the cell-grid moiré that point
 deposits (`:cic`/`:ngp`) leave on coarse cells; use `:cic` only for a quick preview.
 
+### How each AMR cell is treated
+
+Each cell is an axis-aligned cube of side `s = boxlen / 2^ℓ`. The pipeline rotates the cube into the
+camera frame `(r̂, û, ŵ)` — `build_camera_basis` (`src/functions/projection/projection.jl`) — projects
+its centre to image coordinates `x_cam = r̂·r`, `y_cam = û·r`, then deposits its **projected shadow**
+onto the pixel grid. Because the camera basis is orthonormal the rotation preserves volume, which is
+the geometric root of the conservation property. The four `binning` kernels differ only in *how* the
+shadow is spread across pixels — and every one is a *partition of unity* (the per-cell shares sum to 1),
+so the projected total equals the cell total at any angle and any pixel size.
+
+![How each AMR cell is treated in an off-axis projection: AMR grid → rotation by the camera basis → projected box-spline footprint, and the four deposit kernels (:ngp nearest-pixel, :cic 4-pixel bilinear, :overlap sub-point supersampling, :exact analytic chord integral)](assets/offaxis/offaxis_cell_treatment.svg)
+
+* **`:ngp` / `:cic`** treat the cell as its *centre point* — one nearest pixel, or a 4-pixel bilinear
+  stencil. Fast, but a coarse cell that should shadow many pixels collapses to a point (speckle/moiré).
+  `deposit_rotated_cells_to_grid!`.
+* **`:overlap`** splits the cube into `n³` regularly-spaced sub-points (`n = ⌈cellsize/pixel⌉`, capped
+  at `nmax`), each CIC-deposited carrying `weight/n³`. As `n` grows it converges to the true cube
+  shadow; a finest-level cell (`n=1`) reduces to plain CIC. `deposit_rotated_cells_overlap!`.
+* **`:exact`** integrates the exact line-of-sight chord `L(x,y)` over each pixel analytically (the
+  box-spline footprint `M_Ξ`, coloured above by `L`): no sampling, no `nmax` cap. The cube shadow is
+  cut at its kink lines into convex pieces where `L` is affine and integrated in closed form.
+  `deposit_rotated_cells_exact!` (see the next subsection for the math).
+
 ```julia
 # fast preview (point deposit — may speckle on coarse AMR cells)
 preview = projection(gas, :sd, :Msol_pc2, los=[1, 1, 1], binning=:cic, center=[:bc])

--- a/docs/src/assets/offaxis/offaxis_cell_treatment.svg
+++ b/docs/src/assets/offaxis/offaxis_cell_treatment.svg
@@ -1,0 +1,202 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+     width="1180" height="772" viewBox="0 0 1180 772" font-family="Helvetica, Arial, sans-serif">
+  <defs>
+    <!-- arrowhead -->
+    <marker id="arr" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 z" fill="#94a3b8"/>
+    </marker>
+    <marker id="arrR" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 z" fill="#ef4444"/>
+    </marker>
+    <marker id="arrG" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 z" fill="#16a34a"/>
+    </marker>
+    <marker id="arrB" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 z" fill="#2563eb"/>
+    </marker>
+    <!-- chord-length field (viridis-like): long chord in the centre, short at the rim -->
+    <radialGradient id="chord" cx="50%" cy="50%" r="62%">
+      <stop offset="0%"  stop-color="#fde725"/>
+      <stop offset="38%" stop-color="#5ec962"/>
+      <stop offset="68%" stop-color="#21918c"/>
+      <stop offset="100%" stop-color="#3b528b"/>
+    </radialGradient>
+    <!-- 5x5 and 6x6 pixel grids (40 px tiles) -->
+    <g id="px5">
+      <rect x="0" y="0" width="200" height="200" fill="#f8fafc"/>
+      <g stroke="#dbe2ea" stroke-width="1">
+        <line x1="0" y1="0" x2="0" y2="200"/><line x1="40" y1="0" x2="40" y2="200"/>
+        <line x1="80" y1="0" x2="80" y2="200"/><line x1="120" y1="0" x2="120" y2="200"/>
+        <line x1="160" y1="0" x2="160" y2="200"/><line x1="200" y1="0" x2="200" y2="200"/>
+        <line x1="0" y1="0" x2="200" y2="0"/><line x1="0" y1="40" x2="200" y2="40"/>
+        <line x1="0" y1="80" x2="200" y2="80"/><line x1="0" y1="120" x2="200" y2="120"/>
+        <line x1="0" y1="160" x2="200" y2="160"/><line x1="0" y1="200" x2="200" y2="200"/>
+      </g>
+      <rect x="0" y="0" width="200" height="200" fill="none" stroke="#94a3b8" stroke-width="1.4"/>
+    </g>
+    <g id="px6">
+      <rect x="0" y="0" width="240" height="240" fill="#f8fafc"/>
+      <g stroke="#dbe2ea" stroke-width="1">
+        <line x1="0" y1="0" x2="0" y2="240"/><line x1="40" y1="0" x2="40" y2="240"/><line x1="80" y1="0" x2="80" y2="240"/>
+        <line x1="120" y1="0" x2="120" y2="240"/><line x1="160" y1="0" x2="160" y2="240"/><line x1="200" y1="0" x2="200" y2="240"/><line x1="240" y1="0" x2="240" y2="240"/>
+        <line x1="0" y1="0" x2="240" y2="0"/><line x1="0" y1="40" x2="240" y2="40"/><line x1="0" y1="80" x2="240" y2="80"/>
+        <line x1="0" y1="120" x2="240" y2="120"/><line x1="0" y1="160" x2="240" y2="160"/><line x1="0" y1="200" x2="240" y2="200"/><line x1="0" y1="240" x2="240" y2="240"/>
+      </g>
+      <rect x="0" y="0" width="240" height="240" fill="none" stroke="#94a3b8" stroke-width="1.4"/>
+    </g>
+    <!-- the rotated coarse-cell shadow (hexagon = cube zonotope), centred at (0,0) -->
+    <g id="hex"><polygon points="-66,-16 -20,-60 46,-44 66,16 20,60 -46,44" /></g>
+  </defs>
+
+  <rect width="1180" height="772" fill="#ffffff"/>
+  <text x="590" y="34" text-anchor="middle" font-size="22" font-weight="bold" fill="#1f2937">How each AMR cell is treated in an off-axis projection</text>
+  <text x="590" y="58" text-anchor="middle" font-size="13.5" fill="#64748b">A cell is an axis-aligned cube of side s = boxlen / 2&#8467;. Rotate it by the camera basis, then deposit its projected shadow onto the pixel grid.</text>
+
+  <!-- ============================ ROW 1: geometry ============================ -->
+  <!-- P1: AMR grid -->
+  <g transform="translate(115,86)">
+    <text x="125" y="-6" text-anchor="middle" font-size="14" font-weight="bold" fill="#334155">1 &#183; AMR grid</text>
+    <g transform="translate(0,4)">
+      <rect x="0" y="0" width="240" height="240" fill="none" stroke="#334155" stroke-width="2"/>
+      <!-- followed coarse cell (level l) -->
+      <rect x="0" y="0" width="120" height="120" fill="#fbbf24" fill-opacity="0.5" stroke="#d97706" stroke-width="2.2"/>
+      <rect x="120" y="0" width="120" height="120" fill="#e2e8f0" fill-opacity="0.55" stroke="#94a3b8" stroke-width="1.2"/>
+      <rect x="0" y="120" width="120" height="120" fill="#e2e8f0" fill-opacity="0.55" stroke="#94a3b8" stroke-width="1.2"/>
+      <!-- level l+1 (four 60-cells), bottom-right quadrant -->
+      <rect x="120" y="120" width="60" height="60" fill="#bae6fd" fill-opacity="0.65" stroke="#38bdf8" stroke-width="1.2"/>
+      <rect x="180" y="120" width="60" height="60" fill="#bae6fd" fill-opacity="0.65" stroke="#38bdf8" stroke-width="1.2"/>
+      <rect x="120" y="180" width="60" height="60" fill="#bae6fd" fill-opacity="0.65" stroke="#38bdf8" stroke-width="1.2"/>
+      <!-- level l+2 (four 30-cells) in the densest corner -->
+      <g stroke="#0ea5e9" stroke-width="1.1">
+        <rect x="180" y="180" width="30" height="30" fill="#7dd3fc" fill-opacity="0.8"/>
+        <rect x="210" y="180" width="30" height="30" fill="#7dd3fc" fill-opacity="0.8"/>
+        <rect x="180" y="210" width="30" height="30" fill="#7dd3fc" fill-opacity="0.8"/>
+        <rect x="210" y="210" width="30" height="30" fill="#7dd3fc" fill-opacity="0.8"/>
+      </g>
+      <text x="60"  y="66"  text-anchor="middle" font-size="15" fill="#92400e" font-style="italic">&#8467;</text>
+      <text x="150" y="155" text-anchor="middle" font-size="12" fill="#0369a1" font-style="italic">&#8467;+1</text>
+      <text x="225" y="172" text-anchor="middle" font-size="10" fill="#0369a1" font-style="italic">&#8467;+2</text>
+    </g>
+    <text x="125" y="266" text-anchor="middle" font-size="12" fill="#64748b">refinement follows density; we follow the amber cell</text>
+  </g>
+
+  <!-- arrow 1 -->
+  <line x1="372" y1="210" x2="452" y2="210" stroke="#94a3b8" stroke-width="2.4" marker-end="url(#arr)"/>
+  <text x="412" y="200" text-anchor="middle" font-size="11.5" fill="#64748b">rotate</text>
+
+  <!-- P2: cube + camera basis -->
+  <g transform="translate(465,86)">
+    <text x="125" y="-6" text-anchor="middle" font-size="14" font-weight="bold" fill="#334155">2 &#183; camera basis</text>
+    <g transform="translate(0,4)">
+      <!-- isometric cube (the amber cell as a 3-D cube) -->
+      <polygon points="70,108 160,108 200,72 110,72" fill="#fcd34d" fill-opacity="0.55" stroke="#d97706" stroke-width="1.8"/>
+      <polygon points="160,108 200,72 200,170 160,206" fill="#f59e0b" fill-opacity="0.45" stroke="#d97706" stroke-width="1.8"/>
+      <polygon points="70,108 160,108 160,206 70,206" fill="#fde68a" fill-opacity="0.7" stroke="#d97706" stroke-width="1.8"/>
+      <!-- camera basis arrows from cube centre -->
+      <g stroke-width="2.6" fill="none">
+        <line x1="120" y1="150" x2="205" y2="150" stroke="#ef4444" marker-end="url(#arrR)"/>
+        <line x1="120" y1="150" x2="120" y2="62"  stroke="#16a34a" marker-end="url(#arrG)"/>
+        <line x1="120" y1="150" x2="186" y2="206" stroke="#2563eb" marker-end="url(#arrB)"/>
+      </g>
+      <text x="212" y="153" font-size="13" fill="#ef4444" font-style="italic">r&#770;</text>
+      <text x="124" y="58"  font-size="13" fill="#16a34a" font-style="italic">u&#770;</text>
+      <text x="190" y="220" font-size="13" fill="#2563eb" font-style="italic">w&#770; (los)</text>
+    </g>
+    <text x="125" y="266" text-anchor="middle" font-size="12" fill="#64748b">x_cam = r&#770;&#183;r,  y_cam = u&#770;&#183;r  (orthonormal &#8658; volume-preserving)</text>
+  </g>
+
+  <!-- arrow 2 -->
+  <line x1="722" y1="210" x2="802" y2="210" stroke="#94a3b8" stroke-width="2.4" marker-end="url(#arr)"/>
+  <text x="762" y="200" text-anchor="middle" font-size="11.5" fill="#64748b">project</text>
+
+  <!-- P3: footprint over pixels -->
+  <g transform="translate(815,86)">
+    <text x="125" y="-6" text-anchor="middle" font-size="14" font-weight="bold" fill="#334155">3 &#183; projected footprint</text>
+    <g transform="translate(5,4)">
+      <use xlink:href="#px6"/>
+      <g transform="translate(120,120)">
+        <use xlink:href="#hex" fill="#7c3aed" fill-opacity="0.16" stroke="#7c3aed" stroke-width="2"/>
+      </g>
+    </g>
+    <text x="125" y="266" text-anchor="middle" font-size="12" fill="#64748b">shadow = box-spline M&#915; over the pixels,  &#8747;M&#915; = s&#179;</text>
+  </g>
+
+  <!-- divider -->
+  <line x1="60" y1="372" x2="1120" y2="372" stroke="#e2e8f0" stroke-width="1.4"/>
+  <text x="590" y="396" text-anchor="middle" font-size="16" font-weight="bold" fill="#1f2937">The four deposit kernels &#8212; same cell, different fidelity (all conserve mass: &#931; shares = 1)</text>
+
+  <!-- ============================ ROW 2: the four kernels ============================ -->
+  <!-- P4: :ngp -->
+  <g transform="translate(45,418)">
+    <text x="125" y="14" text-anchor="middle" font-size="14.5" font-weight="bold" fill="#0f766e">:ngp</text>
+    <g transform="translate(25,24)">
+      <use xlink:href="#px5"/>
+      <!-- nearest pixel -->
+      <rect x="80" y="80" width="40" height="40" fill="#0d9488" fill-opacity="0.85"/>
+      <circle cx="104" cy="98" r="3.2" fill="#0f172a"/>
+    </g>
+    <text x="125" y="246" text-anchor="middle" font-size="11.5" fill="#475569">centre &#8594; nearest pixel</text>
+    <text x="125" y="262" text-anchor="middle" font-size="11" fill="#94a3b8" font-style="italic">fastest &#183; preview (sharp)</text>
+  </g>
+
+  <!-- P5: :cic -->
+  <g transform="translate(325,418)">
+    <text x="125" y="14" text-anchor="middle" font-size="14.5" font-weight="bold" fill="#0f766e">:cic</text>
+    <g transform="translate(25,24)">
+      <use xlink:href="#px5"/>
+      <!-- bilinear 4-pixel stencil (opacity = weight) -->
+      <rect x="64" y="64" width="40" height="40" fill="#0d9488" fill-opacity="0.72"/>
+      <rect x="104" y="64" width="40" height="40" fill="#0d9488" fill-opacity="0.42"/>
+      <rect x="64" y="104" width="40" height="40" fill="#0d9488" fill-opacity="0.46"/>
+      <rect x="104" y="104" width="40" height="40" fill="#0d9488" fill-opacity="0.26"/>
+      <circle cx="98" cy="96" r="3.2" fill="#0f172a"/>
+    </g>
+    <text x="125" y="246" text-anchor="middle" font-size="11.5" fill="#475569">centre &#8594; 4-pixel bilinear</text>
+    <text x="125" y="262" text-anchor="middle" font-size="11" fill="#94a3b8" font-style="italic">fast &#183; preview (speckles on coarse cells)</text>
+  </g>
+
+  <!-- P6: :overlap -->
+  <g transform="translate(605,418)">
+    <text x="125" y="14" text-anchor="middle" font-size="14.5" font-weight="bold" fill="#0f766e">:overlap  <tspan font-size="11" font-weight="normal" fill="#94a3b8">(default)</tspan></text>
+    <g transform="translate(25,24)">
+      <use xlink:href="#px5"/>
+      <g transform="translate(100,100)">
+        <use xlink:href="#hex" fill="#0d9488" fill-opacity="0.14" stroke="#0f766e" stroke-width="1.8"/>
+        <!-- n x n sub-points filling the cube shadow (spacing fits inside the hexagon by construction) -->
+        <g fill="#0f766e">
+          <circle cx="-37.5" cy="-37.5" r="2.1"/><circle cx="-22.5" cy="-37.5" r="2.1"/><circle cx="-7.5" cy="-37.5" r="2.1"/><circle cx="7.5" cy="-37.5" r="2.1"/><circle cx="22.5" cy="-37.5" r="2.1"/><circle cx="37.5" cy="-37.5" r="2.1"/>
+          <circle cx="-37.5" cy="-22.5" r="2.1"/><circle cx="-22.5" cy="-22.5" r="2.1"/><circle cx="-7.5" cy="-22.5" r="2.1"/><circle cx="7.5" cy="-22.5" r="2.1"/><circle cx="22.5" cy="-22.5" r="2.1"/><circle cx="37.5" cy="-22.5" r="2.1"/>
+          <circle cx="-37.5" cy="-7.5" r="2.1"/><circle cx="-22.5" cy="-7.5" r="2.1"/><circle cx="-7.5" cy="-7.5" r="2.1"/><circle cx="7.5" cy="-7.5" r="2.1"/><circle cx="22.5" cy="-7.5" r="2.1"/><circle cx="37.5" cy="-7.5" r="2.1"/>
+          <circle cx="-37.5" cy="7.5" r="2.1"/><circle cx="-22.5" cy="7.5" r="2.1"/><circle cx="-7.5" cy="7.5" r="2.1"/><circle cx="7.5" cy="7.5" r="2.1"/><circle cx="22.5" cy="7.5" r="2.1"/><circle cx="37.5" cy="7.5" r="2.1"/>
+          <circle cx="-37.5" cy="22.5" r="2.1"/><circle cx="-22.5" cy="22.5" r="2.1"/><circle cx="-7.5" cy="22.5" r="2.1"/><circle cx="7.5" cy="22.5" r="2.1"/><circle cx="22.5" cy="22.5" r="2.1"/><circle cx="37.5" cy="22.5" r="2.1"/>
+          <circle cx="-37.5" cy="37.5" r="2.1"/><circle cx="-22.5" cy="37.5" r="2.1"/><circle cx="-7.5" cy="37.5" r="2.1"/><circle cx="7.5" cy="37.5" r="2.1"/><circle cx="22.5" cy="37.5" r="2.1"/><circle cx="37.5" cy="37.5" r="2.1"/>
+        </g>
+      </g>
+    </g>
+    <text x="125" y="246" text-anchor="middle" font-size="11.5" fill="#475569">n&#179; sub-points &#8594; CIC, weight/n&#179;</text>
+    <text x="125" y="262" text-anchor="middle" font-size="11" fill="#94a3b8" font-style="italic">accurate &#183; AMR-aligned &#183; n capped at nmax</text>
+  </g>
+
+  <!-- P7: :exact -->
+  <g transform="translate(885,418)">
+    <text x="125" y="14" text-anchor="middle" font-size="14.5" font-weight="bold" fill="#0f766e">:exact</text>
+    <g transform="translate(25,24)">
+      <use xlink:href="#px5"/>
+      <g transform="translate(100,100)">
+        <use xlink:href="#hex" fill="url(#chord)" fill-opacity="0.92" stroke="#3b528b" stroke-width="1.8"/>
+      </g>
+      <!-- pixel boundaries on top so the analytic per-pixel integration reads clearly -->
+      <g stroke="#475569" stroke-width="0.6" stroke-opacity="0.5" fill="none">
+        <line x1="40" y1="0" x2="40" y2="200"/><line x1="80" y1="0" x2="80" y2="200"/><line x1="120" y1="0" x2="120" y2="200"/><line x1="160" y1="0" x2="160" y2="200"/>
+        <line x1="0" y1="40" x2="200" y2="40"/><line x1="0" y1="80" x2="200" y2="80"/><line x1="0" y1="120" x2="200" y2="120"/><line x1="0" y1="160" x2="200" y2="160"/>
+      </g>
+    </g>
+    <text x="125" y="246" text-anchor="middle" font-size="11.5" fill="#475569">analytic &#8747;&#8747;&#8347;&#8339; L(x,y) dx dy per pixel</text>
+    <text x="125" y="262" text-anchor="middle" font-size="11" fill="#94a3b8" font-style="italic">exact &#183; colour = chord length L (the box spline)</text>
+  </g>
+
+  <!-- footer -->
+  <text x="590" y="720" text-anchor="middle" font-size="12" fill="#64748b">Every kernel is a partition of unity (per-cell shares sum to 1) &#8658; &#931;&#8202;pixels = &#931;&#8202;cells to machine precision, at any angle and any pixel size.</text>
+  <text x="590" y="740" text-anchor="middle" font-size="11" fill="#94a3b8">Mera.jl &#183; src/functions/projection/projection_hydro.jl: deposit_rotated_cells_{to_grid!, overlap!, exact!}</text>
+</svg>


### PR DESCRIPTION
Adds a hand-authored **SVG** (true vector graphics) and a new subsection to `06_offaxis_Projection.md` illustrating the off-axis per-cell pipeline: AMR grid → rotation by the camera basis `(r̂,û,ŵ)` → projected box-spline footprint, then the four deposit kernels side by side (`:ngp` nearest-pixel, `:cic` 4-pixel bilinear, `:overlap` n³ sub-points, `:exact` analytic chord integral coloured by `L`). Each panel labels its speed/fidelity and the kernel function (`deposit_rotated_cells_{to_grid!, overlap!, exact!}`), and the text notes the partition-of-unity conservation property. Complements the existing box-spline math subsection and the conservation proof. Docs build green; SVG validated.