### PR TITLE
docs(off-axis): vector figure for the :exact per-pixel integration

### DIFF
--- a/docs/src/06_offaxis_Projection.md
+++ b/docs/src/06_offaxis_Projection.md
@@ -275,6 +275,15 @@ when `ŵ` is a box axis (then two columns of `Ξ` are axis-aligned and the hexag
 cell's square). `:overlap` is a convergent `n³` sampling of this same footprint; `:exact` is its
 limit. Cost is `O(covered pixels)` per cell.
 
+![Inside :exact — the box-spline footprint is piecewise-linear (its kink lines, where the entering/exiting cube face switches, cut it into convex pieces on which the chord length L is affine), so the integral of L over each pixel is computed in closed form as the sum over convex pieces of area·L(centroid)](assets/offaxis/offaxis_exact_integration.svg)
+
+Concretely (`_oa_pixel_integral!`): the pixel∩footprint polygon is Sutherland–Hodgman-clipped
+(`_oa_clip!`) and split by the kink lines into convex pieces; on each, the entering face (argmax `tmin`)
+and exiting face (argmin `tmax`) are fixed, so `L` is affine and `∫∫ = area · L(centroid)`
+(`_oa_affine_integral`) is exact — at most 6 splits for a cube, `O(covered pixels)` per cell, no `nmax`
+cap. A per-cell renormalisation makes the shares a partition of unity, so the total is conserved to
+machine precision.
+
 References: de Boor, Höllig & Riemenschneider, *Box Splines* (Springer 1993); Westover, *Footprint
 Evaluation for Volume Rendering* (SIGGRAPH 1990). Among **AMR** tools an analytic off-axis cell
 footprint is, to our knowledge, uncommon — yt ray-casts and most others resample to a uniform

--- a/docs/src/assets/offaxis/offaxis_exact_integration.svg
+++ b/docs/src/assets/offaxis/offaxis_exact_integration.svg
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+     width="1000" height="520" viewBox="0 0 1000 520" font-family="Helvetica, Arial, sans-serif">
+  <defs>
+    <radialGradient id="mesa" cx="50%" cy="50%" r="60%">
+      <stop offset="0%" stop-color="#fde725"/><stop offset="45%" stop-color="#5ec962"/>
+      <stop offset="78%" stop-color="#21918c"/><stop offset="100%" stop-color="#3b528b"/>
+    </radialGradient>
+    <!-- outer hexagon (cube shadow) centred at (0,0) -->
+    <g id="hexO"><polygon points="0,-95 82,-47 82,47 0,95 -82,47 -82,-47"/></g>
+    <!-- inner hexagon (plateau: longest chords through the cube body) -->
+    <g id="hexI"><polygon points="0,-42 36,-21 36,21 0,42 -36,21 -36,-21"/></g>
+  </defs>
+
+  <rect width="1000" height="520" fill="#ffffff"/>
+  <text x="500" y="32" text-anchor="middle" font-size="20" font-weight="bold" fill="#1f2937">Inside `:exact` &#8212; analytic per-pixel integration of the box-spline footprint</text>
+  <text x="500" y="55" text-anchor="middle" font-size="13" fill="#64748b">L(x,y) = min&#8202;<tspan font-style="italic">k</tspan> tmax&#8202;<tspan font-style="italic">k</tspan> &#8722; max&#8202;<tspan font-style="italic">k</tspan> tmin&#8202;<tspan font-style="italic">k</tspan>   (slab method over the 3 cube axes) &#8212; piecewise-linear, integrating to s&#179;</text>
+
+  <!-- ===================== Panel A: piecewise-linear footprint ===================== -->
+  <g transform="translate(70,90)">
+    <text x="190" y="6" text-anchor="middle" font-size="14.5" font-weight="bold" fill="#334155">1 &#183; the footprint is piecewise-linear</text>
+    <g transform="translate(190,150)">
+      <!-- the chord field as a coloured tent (bright centre = long chord, dark rim = 0) -->
+      <use xlink:href="#hexO" fill="url(#mesa)" fill-opacity="0.9" stroke="#3b528b" stroke-width="1.6"/>
+      <!-- kink lines: plateau boundary + the radial face-switch lines (dashed) -->
+      <g stroke="#b45309" stroke-width="1.5" stroke-dasharray="5 4" fill="none">
+        <line x1="0" y1="-42" x2="0" y2="-95"/><line x1="36" y1="-21" x2="82" y2="-47"/>
+        <line x1="36" y1="21" x2="82" y2="47"/><line x1="0" y1="42" x2="0" y2="95"/>
+        <line x1="-36" y1="21" x2="-82" y2="47"/><line x1="-36" y1="-21" x2="-82" y2="-47"/>
+      </g>
+      <use xlink:href="#hexI" fill="none" stroke="#b45309" stroke-width="1.6" stroke-dasharray="5 4"/>
+      <!-- centroids: on a piece the entering/exiting face is fixed, so L is affine -->
+      <circle cx="0" cy="0" r="3" fill="#0f172a"/>
+      <circle cx="0" cy="-66" r="3" fill="#0f172a"/>
+      <text x="8" y="4" font-size="11" fill="#0f172a">c</text>
+      <text x="8" y="-62" font-size="11" fill="#0f172a">c'</text>
+    </g>
+    <text x="190" y="276" text-anchor="middle" font-size="11.5" fill="#475569">kink lines (orange) = where the entering / exiting cube face switches</text>
+    <text x="190" y="293" text-anchor="middle" font-size="11.5" fill="#475569">&#8658; L is <tspan font-style="italic">affine</tspan> on each convex piece</text>
+
+    <!-- 1-D cross-section: the mesa profile -->
+    <g transform="translate(40,330)">
+      <line x1="0" y1="60" x2="300" y2="60" stroke="#94a3b8" stroke-width="1.2"/>
+      <line x1="0" y1="60" x2="0" y2="-6" stroke="#94a3b8" stroke-width="1.2"/>
+      <polyline points="20,60 110,6 190,6 280,60" fill="none" stroke="#0f766e" stroke-width="2.4"/>
+      <g stroke="#b45309" stroke-width="1" stroke-dasharray="3 3">
+        <line x1="110" y1="6" x2="110" y2="60"/><line x1="190" y1="6" x2="190" y2="60"/>
+      </g>
+      <text x="-6" y="2" text-anchor="end" font-size="11" fill="#475569" font-style="italic">L</text>
+      <text x="300" y="74" text-anchor="end" font-size="11" fill="#475569">position across the shadow</text>
+      <text x="150" y="-2" text-anchor="middle" font-size="10.5" fill="#0f766e">plateau (full body chord)</text>
+    </g>
+  </g>
+
+  <!-- ===================== Panel B: exact per-pixel integral ===================== -->
+  <g transform="translate(560,90)">
+    <text x="190" y="6" text-anchor="middle" font-size="14.5" font-weight="bold" fill="#334155">2 &#183; each pixel integral is exact</text>
+    <g transform="translate(0,24)">
+      <!-- 4x4 pixel grid (52 px) -->
+      <g stroke="#cbd5e1" stroke-width="1" fill="#f8fafc">
+        <rect x="40" y="0" width="208" height="208"/>
+      </g>
+      <g stroke="#cbd5e1" stroke-width="1">
+        <line x1="92" y1="0" x2="92" y2="208"/><line x1="144" y1="0" x2="144" y2="208"/><line x1="196" y1="0" x2="196" y2="208"/>
+        <line x1="40" y1="52" x2="248" y2="52"/><line x1="40" y1="104" x2="248" y2="104"/><line x1="40" y1="156" x2="248" y2="156"/>
+      </g>
+      <rect x="40" y="0" width="208" height="208" fill="none" stroke="#94a3b8" stroke-width="1.3"/>
+      <!-- the footprint -->
+      <g transform="translate(150,108)">
+        <use xlink:href="#hexO" fill="#5eead4" fill-opacity="0.18" stroke="#0f766e" stroke-width="1.5"/>
+        <use xlink:href="#hexI" fill="none" stroke="#b45309" stroke-width="1.3" stroke-dasharray="5 4"/>
+        <g stroke="#b45309" stroke-width="1.2" stroke-dasharray="5 4" fill="none">
+          <line x1="36" y1="-21" x2="82" y2="-47"/><line x1="36" y1="21" x2="82" y2="47"/>
+        </g>
+      </g>
+      <!-- highlighted pixel (straddles a kink line) -->
+      <rect x="196" y="52" width="52" height="52" fill="#2563eb" fill-opacity="0.08" stroke="#2563eb" stroke-width="2"/>
+      <!-- pixel ∩ footprint, split by the kink line into two convex pieces -->
+      <!-- piece 1 (inside plateau side) -->
+      <polygon points="196,86 232,73 248,84 248,104 196,104" fill="#16a34a" fill-opacity="0.35" stroke="#15803d" stroke-width="1.2"/>
+      <!-- piece 2 (ramp side) -->
+      <polygon points="196,86 232,73 248,68 248,84" fill="#3b82f6" fill-opacity="0.30" stroke="#1d4ed8" stroke-width="1.2"/>
+      <circle cx="222" cy="92" r="2.6" fill="#0f172a"/><text x="226" y="97" font-size="10.5" fill="#0f172a">c1</text>
+      <circle cx="228" cy="79" r="2.6" fill="#0f172a"/><text x="232" y="76" font-size="10.5" fill="#0f172a">c2</text>
+    </g>
+    <text x="190" y="266" text-anchor="middle" font-size="13.5" fill="#1f2937">&#8747;&#8747;<tspan font-size="9" dy="3">pixel</tspan><tspan dy="-3"> </tspan>L = &#931; A&#8202;<tspan font-style="italic">k</tspan>&#183;L(c&#8202;<tspan font-style="italic">k</tspan>)   <tspan fill="#16a34a">exact</tspan></text>
+    <text x="190" y="287" text-anchor="middle" font-size="11.5" fill="#475569">clip pixel&#8745;footprint (Sutherland&#8211;Hodgman), split by kink lines,</text>
+    <text x="190" y="303" text-anchor="middle" font-size="11.5" fill="#475569">integrate area&#183;L(centroid) per convex piece &#183; &#8804;6 splits/cube</text>
+  </g>
+
+  <text x="500" y="506" text-anchor="middle" font-size="11" fill="#94a3b8">Mera.jl &#183; projection_hydro.jl: _oa_pixel_integral!, _oa_clip!, _oa_chord, _oa_affine_integral &#183; cost O(covered pixels), no nmax cap, per-cell renorm &#8658; &#931; f = 1</text>
+</svg>


### PR DESCRIPTION
Follow-up to #123. Adds a second hand-authored **SVG** to the `:exact` box-spline subsection of `06_offaxis_Projection.md`, illustrating the analytic core: (1) the footprint as a piecewise-linear chord field with its kink lines cutting it into affine convex pieces (+ a 1-D mesa cross-section), and (2) a pixel straddling a kink line whose `pixel∩footprint` polygon is clipped and split into convex pieces, each integrated as `area·L(centroid)` so `∫∫ = Σ A_k·L(c_k)` is exact. Mapped in prose to `_oa_pixel_integral!`/`_oa_clip!`/`_oa_chord`/`_oa_affine_integral`. Pure SVG, docs build green.