### PR TITLE
docs(off-axis): rewrite the two figures for a broad audience

### DIFF
--- a/docs/src/06_offaxis_Projection.md
+++ b/docs/src/06_offaxis_Projection.md
@@ -223,7 +223,7 @@ the geometric root of the conservation property. The four `binning` kernels diff
 shadow is spread across pixels — and every one is a *partition of unity* (the per-cell shares sum to 1),
 so the projected total equals the cell total at any angle and any pixel size.
 
-![How each AMR cell is treated in an off-axis projection: AMR grid → rotation by the camera basis → projected box-spline footprint, and the four deposit kernels (:ngp nearest-pixel, :cic 4-pixel bilinear, :overlap sub-point supersampling, :exact analytic chord integral)](assets/offaxis/offaxis_cell_treatment.svg)
+![How a tilted simulation becomes a flat image, one cube at a time: the simulation is a grid of cubes (smaller where the gas is denser); each cube is tilted to the viewing angle and casts a shadow on the pixel grid; then one of four methods shares the cube's gas among the pixels — :ngp drops it all in the nearest pixel, :cic smears it over the 4 nearest, :overlap fills the shadow with sample points (the default), :exact uses the cube's true shadow shape. All keep the total.](assets/offaxis/offaxis_cell_treatment.svg)
 
 * **`:ngp` / `:cic`** treat the cell as its *centre point* — one nearest pixel, or a 4-pixel bilinear
   stencil. Fast, but a coarse cell that should shadow many pixels collapses to a point (speckle/moiré).
@@ -275,7 +275,7 @@ when `ŵ` is a box axis (then two columns of `Ξ` are axis-aligned and the hexag
 cell's square). `:overlap` is a convergent `n³` sampling of this same footprint; `:exact` is its
 limit. Cost is `O(covered pixels)` per cell.
 
-![Inside :exact — the box-spline footprint is piecewise-linear (its kink lines, where the entering/exiting cube face switches, cut it into convex pieces on which the chord length L is affine), so the integral of L over each pixel is computed in closed form as the sum over convex pieces of area·L(centroid)](assets/offaxis/offaxis_exact_integration.svg)
+![Why :exact is exact: a tilted cube's shadow is brightest through the middle, where the line of sight crosses more of the cube; for each pixel, :exact measures exactly how much of that shadow falls inside it and gives the pixel that share — no sampling, so the result never loses gas and barely changes with pixel size.](assets/offaxis/offaxis_exact_integration.svg)
 
 Concretely (`_oa_pixel_integral!`): the pixel∩footprint polygon is Sutherland–Hodgman-clipped
 (`_oa_clip!`) and split by the kink lines into convex pieces; on each, the entering face (argmax `tmin`)

--- a/docs/src/assets/offaxis/offaxis_cell_treatment.svg
+++ b/docs/src/assets/offaxis/offaxis_cell_treatment.svg
@@ -50,13 +50,13 @@
   </defs>
 
   <rect width="1180" height="772" fill="#ffffff"/>
-  <text x="590" y="34" text-anchor="middle" font-size="22" font-weight="bold" fill="#1f2937">How each AMR cell is treated in an off-axis projection</text>
-  <text x="590" y="58" text-anchor="middle" font-size="13.5" fill="#64748b">A cell is an axis-aligned cube of side s = boxlen / 2&#8467;. Rotate it by the camera basis, then deposit its projected shadow onto the pixel grid.</text>
+  <text x="590" y="34" text-anchor="middle" font-size="22" font-weight="bold" fill="#1f2937">How a tilted simulation becomes a flat image &#8212; one cube at a time</text>
+  <text x="590" y="58" text-anchor="middle" font-size="13.5" fill="#64748b">A simulation is built from cubes of gas. To picture it from any viewing angle, tilt each cube and spread its gas onto the image&#8217;s pixels.</text>
 
   <!-- ============================ ROW 1: geometry ============================ -->
   <!-- P1: AMR grid -->
   <g transform="translate(115,86)">
-    <text x="125" y="-6" text-anchor="middle" font-size="14" font-weight="bold" fill="#334155">1 &#183; AMR grid</text>
+    <text x="125" y="-6" text-anchor="middle" font-size="14" font-weight="bold" fill="#334155">1 &#183; a grid of cubes</text>
     <g transform="translate(0,4)">
       <rect x="0" y="0" width="240" height="240" fill="none" stroke="#334155" stroke-width="2"/>
       <!-- followed coarse cell (level l) -->
@@ -74,11 +74,11 @@
         <rect x="180" y="210" width="30" height="30" fill="#7dd3fc" fill-opacity="0.8"/>
         <rect x="210" y="210" width="30" height="30" fill="#7dd3fc" fill-opacity="0.8"/>
       </g>
-      <text x="60"  y="66"  text-anchor="middle" font-size="15" fill="#92400e" font-style="italic">&#8467;</text>
-      <text x="150" y="155" text-anchor="middle" font-size="12" fill="#0369a1" font-style="italic">&#8467;+1</text>
-      <text x="225" y="172" text-anchor="middle" font-size="10" fill="#0369a1" font-style="italic">&#8467;+2</text>
+      <text x="60"  y="64"  text-anchor="middle" font-size="13" fill="#92400e">big cell</text>
+      <text x="150" y="154" text-anchor="middle" font-size="10.5" fill="#0369a1">small</text>
+      <text x="225" y="172" text-anchor="middle" font-size="9" fill="#0369a1">tiny</text>
     </g>
-    <text x="125" y="266" text-anchor="middle" font-size="12" fill="#64748b">refinement follows density; we follow the amber cell</text>
+    <text x="125" y="266" text-anchor="middle" font-size="12" fill="#64748b">smaller cubes where gas is denser</text>
   </g>
 
   <!-- arrow 1 -->
@@ -87,7 +87,7 @@
 
   <!-- P2: cube + camera basis -->
   <g transform="translate(465,86)">
-    <text x="125" y="-6" text-anchor="middle" font-size="14" font-weight="bold" fill="#334155">2 &#183; camera basis</text>
+    <text x="125" y="-6" text-anchor="middle" font-size="14" font-weight="bold" fill="#334155">2 &#183; tilt to the view</text>
     <g transform="translate(0,4)">
       <!-- isometric cube (the amber cell as a 3-D cube) -->
       <polygon points="70,108 160,108 200,72 110,72" fill="#fcd34d" fill-opacity="0.55" stroke="#d97706" stroke-width="1.8"/>
@@ -99,11 +99,11 @@
         <line x1="120" y1="150" x2="120" y2="62"  stroke="#16a34a" marker-end="url(#arrG)"/>
         <line x1="120" y1="150" x2="186" y2="206" stroke="#2563eb" marker-end="url(#arrB)"/>
       </g>
-      <text x="212" y="153" font-size="13" fill="#ef4444" font-style="italic">r&#770;</text>
-      <text x="124" y="58"  font-size="13" fill="#16a34a" font-style="italic">u&#770;</text>
-      <text x="190" y="220" font-size="13" fill="#2563eb" font-style="italic">w&#770; (los)</text>
+      <text x="210" y="153" font-size="12.5" fill="#ef4444">image &#8594;</text>
+      <text x="124" y="58"  font-size="12.5" fill="#16a34a">image &#8593;</text>
+      <text x="190" y="221" font-size="12.5" fill="#2563eb">line of sight</text>
     </g>
-    <text x="125" y="266" text-anchor="middle" font-size="12" fill="#64748b">x_cam = r&#770;&#183;r,  y_cam = u&#770;&#183;r  (orthonormal &#8658; volume-preserving)</text>
+    <text x="125" y="266" text-anchor="middle" font-size="12" fill="#64748b">rotate it to face the camera (no squashing)</text>
   </g>
 
   <!-- arrow 2 -->
@@ -112,19 +112,19 @@
 
   <!-- P3: footprint over pixels -->
   <g transform="translate(815,86)">
-    <text x="125" y="-6" text-anchor="middle" font-size="14" font-weight="bold" fill="#334155">3 &#183; projected footprint</text>
+    <text x="125" y="-6" text-anchor="middle" font-size="14" font-weight="bold" fill="#334155">3 &#183; the cube&#8217;s shadow</text>
     <g transform="translate(5,4)">
       <use xlink:href="#px6"/>
       <g transform="translate(120,120)">
         <use xlink:href="#hex" fill="#7c3aed" fill-opacity="0.16" stroke="#7c3aed" stroke-width="2"/>
       </g>
     </g>
-    <text x="125" y="266" text-anchor="middle" font-size="12" fill="#64748b">shadow = box-spline M&#915; over the pixels,  &#8747;M&#915; = s&#179;</text>
+    <text x="125" y="266" text-anchor="middle" font-size="12" fill="#64748b">one tilted cube can cover many pixels</text>
   </g>
 
   <!-- divider -->
   <line x1="60" y1="372" x2="1120" y2="372" stroke="#e2e8f0" stroke-width="1.4"/>
-  <text x="590" y="396" text-anchor="middle" font-size="16" font-weight="bold" fill="#1f2937">The four deposit kernels &#8212; same cell, different fidelity (all conserve mass: &#931; shares = 1)</text>
+  <text x="590" y="396" text-anchor="middle" font-size="16" font-weight="bold" fill="#1f2937">Four ways to share one cube&#8217;s gas among the pixels &#8212; fast to most accurate (all keep the total)</text>
 
   <!-- ============================ ROW 2: the four kernels ============================ -->
   <!-- P4: :ngp -->
@@ -136,8 +136,8 @@
       <rect x="80" y="80" width="40" height="40" fill="#0d9488" fill-opacity="0.85"/>
       <circle cx="104" cy="98" r="3.2" fill="#0f172a"/>
     </g>
-    <text x="125" y="246" text-anchor="middle" font-size="11.5" fill="#475569">centre &#8594; nearest pixel</text>
-    <text x="125" y="262" text-anchor="middle" font-size="11" fill="#94a3b8" font-style="italic">fastest &#183; preview (sharp)</text>
+    <text x="125" y="246" text-anchor="middle" font-size="11.5" fill="#475569">put all the gas in the nearest pixel</text>
+    <text x="125" y="262" text-anchor="middle" font-size="11" fill="#94a3b8" font-style="italic">fastest &#183; blocky</text>
   </g>
 
   <!-- P5: :cic -->
@@ -152,8 +152,8 @@
       <rect x="104" y="104" width="40" height="40" fill="#0d9488" fill-opacity="0.26"/>
       <circle cx="98" cy="96" r="3.2" fill="#0f172a"/>
     </g>
-    <text x="125" y="246" text-anchor="middle" font-size="11.5" fill="#475569">centre &#8594; 4-pixel bilinear</text>
-    <text x="125" y="262" text-anchor="middle" font-size="11" fill="#94a3b8" font-style="italic">fast &#183; preview (speckles on coarse cells)</text>
+    <text x="125" y="246" text-anchor="middle" font-size="11.5" fill="#475569">smear over the 4 nearest pixels</text>
+    <text x="125" y="262" text-anchor="middle" font-size="11" fill="#94a3b8" font-style="italic">fast &#183; smoother preview</text>
   </g>
 
   <!-- P6: :overlap -->
@@ -174,8 +174,8 @@
         </g>
       </g>
     </g>
-    <text x="125" y="246" text-anchor="middle" font-size="11.5" fill="#475569">n&#179; sub-points &#8594; CIC, weight/n&#179;</text>
-    <text x="125" y="262" text-anchor="middle" font-size="11" fill="#94a3b8" font-style="italic">accurate &#183; AMR-aligned &#183; n capped at nmax</text>
+    <text x="125" y="246" text-anchor="middle" font-size="11.5" fill="#475569">fill the shadow with sample points</text>
+    <text x="125" y="262" text-anchor="middle" font-size="11" fill="#94a3b8" font-style="italic">accurate &#183; the default choice</text>
   </g>
 
   <!-- P7: :exact -->
@@ -192,11 +192,11 @@
         <line x1="0" y1="40" x2="200" y2="40"/><line x1="0" y1="80" x2="200" y2="80"/><line x1="0" y1="120" x2="200" y2="120"/><line x1="0" y1="160" x2="200" y2="160"/>
       </g>
     </g>
-    <text x="125" y="246" text-anchor="middle" font-size="11.5" fill="#475569">analytic &#8747;&#8747;&#8347;&#8339; L(x,y) dx dy per pixel</text>
-    <text x="125" y="262" text-anchor="middle" font-size="11" fill="#94a3b8" font-style="italic">exact &#183; colour = chord length L (the box spline)</text>
+    <text x="125" y="246" text-anchor="middle" font-size="11.5" fill="#475569">use the cube&#8217;s true shadow shape</text>
+    <text x="125" y="262" text-anchor="middle" font-size="11" fill="#94a3b8" font-style="italic">most accurate &#183; colour = depth through the cube</text>
   </g>
 
   <!-- footer -->
-  <text x="590" y="720" text-anchor="middle" font-size="12" fill="#64748b">Every kernel is a partition of unity (per-cell shares sum to 1) &#8658; &#931;&#8202;pixels = &#931;&#8202;cells to machine precision, at any angle and any pixel size.</text>
-  <text x="590" y="740" text-anchor="middle" font-size="11" fill="#94a3b8">Mera.jl &#183; src/functions/projection/projection_hydro.jl: deposit_rotated_cells_{to_grid!, overlap!, exact!}</text>
+  <text x="590" y="720" text-anchor="middle" font-size="12.5" fill="#1f2937">Whichever method, a cube always gives <tspan font-weight="bold">all</tspan> its gas to the image &#8212; the picture adds up to the simulation&#8217;s true total, at any angle and any zoom.</text>
+  <text x="590" y="740" text-anchor="middle" font-size="10.5" fill="#94a3b8">technical: every kernel is a partition of unity (&#931; shares = 1) &#183; Mera.jl projection_hydro.jl: deposit_rotated_cells_{to_grid!, overlap!, exact!}</text>
 </svg>

--- a/docs/src/assets/offaxis/offaxis_exact_integration.svg
+++ b/docs/src/assets/offaxis/offaxis_exact_integration.svg
@@ -13,12 +13,12 @@
   </defs>
 
   <rect width="1000" height="520" fill="#ffffff"/>
-  <text x="500" y="32" text-anchor="middle" font-size="20" font-weight="bold" fill="#1f2937">Inside `:exact` &#8212; analytic per-pixel integration of the box-spline footprint</text>
-  <text x="500" y="55" text-anchor="middle" font-size="13" fill="#64748b">L(x,y) = min&#8202;<tspan font-style="italic">k</tspan> tmax&#8202;<tspan font-style="italic">k</tspan> &#8722; max&#8202;<tspan font-style="italic">k</tspan> tmin&#8202;<tspan font-style="italic">k</tspan>   (slab method over the 3 cube axes) &#8212; piecewise-linear, integrating to s&#179;</text>
+  <text x="500" y="32" text-anchor="middle" font-size="20" font-weight="bold" fill="#1f2937">Why `:exact` is exact &#8212; it measures the true shadow in every pixel</text>
+  <text x="500" y="55" text-anchor="middle" font-size="13" fill="#64748b">Nothing is sampled or guessed: each pixel receives exactly the amount of the cube&#8217;s shadow that falls inside it.</text>
 
   <!-- ===================== Panel A: piecewise-linear footprint ===================== -->
   <g transform="translate(70,90)">
-    <text x="190" y="6" text-anchor="middle" font-size="14.5" font-weight="bold" fill="#334155">1 &#183; the footprint is piecewise-linear</text>
+    <text x="190" y="6" text-anchor="middle" font-size="14.5" font-weight="bold" fill="#334155">1 &#183; the shadow is darkest through the middle</text>
     <g transform="translate(190,150)">
       <!-- the chord field as a coloured tent (bright centre = long chord, dark rim = 0) -->
       <use xlink:href="#hexO" fill="url(#mesa)" fill-opacity="0.9" stroke="#3b528b" stroke-width="1.6"/>
@@ -29,14 +29,9 @@
         <line x1="-36" y1="21" x2="-82" y2="47"/><line x1="-36" y1="-21" x2="-82" y2="-47"/>
       </g>
       <use xlink:href="#hexI" fill="none" stroke="#b45309" stroke-width="1.6" stroke-dasharray="5 4"/>
-      <!-- centroids: on a piece the entering/exiting face is fixed, so L is affine -->
-      <circle cx="0" cy="0" r="3" fill="#0f172a"/>
-      <circle cx="0" cy="-66" r="3" fill="#0f172a"/>
-      <text x="8" y="4" font-size="11" fill="#0f172a">c</text>
-      <text x="8" y="-62" font-size="11" fill="#0f172a">c'</text>
     </g>
-    <text x="190" y="276" text-anchor="middle" font-size="11.5" fill="#475569">kink lines (orange) = where the entering / exiting cube face switches</text>
-    <text x="190" y="293" text-anchor="middle" font-size="11.5" fill="#475569">&#8658; L is <tspan font-style="italic">affine</tspan> on each convex piece</text>
+    <text x="190" y="276" text-anchor="middle" font-size="12" fill="#475569">brighter where the line of sight crosses more of the cube</text>
+    <text x="190" y="293" text-anchor="middle" font-size="10.5" fill="#94a3b8">technical: the brightness is built from flat ramps meeting at the orange fold lines</text>
 
     <!-- 1-D cross-section: the mesa profile -->
     <g transform="translate(40,330)">
@@ -46,15 +41,15 @@
       <g stroke="#b45309" stroke-width="1" stroke-dasharray="3 3">
         <line x1="110" y1="6" x2="110" y2="60"/><line x1="190" y1="6" x2="190" y2="60"/>
       </g>
-      <text x="-6" y="2" text-anchor="end" font-size="11" fill="#475569" font-style="italic">L</text>
+      <text x="-6" y="2" text-anchor="end" font-size="10" fill="#475569">bright</text>
       <text x="300" y="74" text-anchor="end" font-size="11" fill="#475569">position across the shadow</text>
-      <text x="150" y="-2" text-anchor="middle" font-size="10.5" fill="#0f766e">plateau (full body chord)</text>
+      <text x="150" y="-2" text-anchor="middle" font-size="10.5" fill="#0f766e">deepest crossing</text>
     </g>
   </g>
 
   <!-- ===================== Panel B: exact per-pixel integral ===================== -->
   <g transform="translate(560,90)">
-    <text x="190" y="6" text-anchor="middle" font-size="14.5" font-weight="bold" fill="#334155">2 &#183; each pixel integral is exact</text>
+    <text x="190" y="6" text-anchor="middle" font-size="14.5" font-weight="bold" fill="#334155">2 &#183; each pixel gets its exact share</text>
     <g transform="translate(0,24)">
       <!-- 4x4 pixel grid (52 px) -->
       <g stroke="#cbd5e1" stroke-width="1" fill="#f8fafc">
@@ -75,17 +70,13 @@
       </g>
       <!-- highlighted pixel (straddles a kink line) -->
       <rect x="196" y="52" width="52" height="52" fill="#2563eb" fill-opacity="0.08" stroke="#2563eb" stroke-width="2"/>
-      <!-- pixel ∩ footprint, split by the kink line into two convex pieces -->
-      <!-- piece 1 (inside plateau side) -->
-      <polygon points="196,86 232,73 248,84 248,104 196,104" fill="#16a34a" fill-opacity="0.35" stroke="#15803d" stroke-width="1.2"/>
-      <!-- piece 2 (ramp side) -->
-      <polygon points="196,86 232,73 248,68 248,84" fill="#3b82f6" fill-opacity="0.30" stroke="#1d4ed8" stroke-width="1.2"/>
-      <circle cx="222" cy="92" r="2.6" fill="#0f172a"/><text x="226" y="97" font-size="10.5" fill="#0f172a">c1</text>
-      <circle cx="228" cy="79" r="2.6" fill="#0f172a"/><text x="232" y="76" font-size="10.5" fill="#0f172a">c2</text>
+      <!-- pixel ∩ shadow: the exact piece of shadow this pixel receives -->
+      <polygon points="196,86 232,73 248,68 248,104 196,104" fill="#0d9488" fill-opacity="0.5" stroke="#0f766e" stroke-width="1.7"/>
+      <text x="223" y="132" text-anchor="middle" font-size="10.5" fill="#0f766e">overlap</text>
     </g>
-    <text x="190" y="266" text-anchor="middle" font-size="13.5" fill="#1f2937">&#8747;&#8747;<tspan font-size="9" dy="3">pixel</tspan><tspan dy="-3"> </tspan>L = &#931; A&#8202;<tspan font-style="italic">k</tspan>&#183;L(c&#8202;<tspan font-style="italic">k</tspan>)   <tspan fill="#16a34a">exact</tspan></text>
-    <text x="190" y="287" text-anchor="middle" font-size="11.5" fill="#475569">clip pixel&#8745;footprint (Sutherland&#8211;Hodgman), split by kink lines,</text>
-    <text x="190" y="303" text-anchor="middle" font-size="11.5" fill="#475569">integrate area&#183;L(centroid) per convex piece &#183; &#8804;6 splits/cube</text>
+    <text x="190" y="262" text-anchor="middle" font-size="13.5" fill="#1f2937">the pixel gets <tspan font-weight="bold">exactly</tspan> that overlap &#8212; no sampling</text>
+    <text x="190" y="284" text-anchor="middle" font-size="11.5" fill="#475569">so the result never loses gas and barely changes with pixel size</text>
+    <text x="190" y="303" text-anchor="middle" font-size="10.5" fill="#94a3b8">technical: &#8747;&#8747; of the brightness over each pixel, in closed form (&#8804;6 polygon pieces/cube)</text>
   </g>
 
   <text x="500" y="506" text-anchor="middle" font-size="11" fill="#94a3b8">Mera.jl &#183; projection_hydro.jl: _oa_pixel_integral!, _oa_clip!, _oa_chord, _oa_affine_integral &#183; cost O(covered pixels), no nmax cap, per-cell renorm &#8658; &#931; f = 1</text>


### PR DESCRIPTION
Follow-up to #123/#124. Rewrites both off-axis cell-treatment SVGs (and their alt-text) to be intuition-first and understandable without numerical-methods background, while keeping the precise terms as small muted `technical:` notes for experts. Geometry unchanged.

- **Figure 1** ("How a tilted simulation becomes a flat image — one cube at a time"): grid of cubes → tilt to the view (`image →/↑`, `line of sight`) → the cubes shadow; the four kernels as plain actions with fast→most-accurate tradeoffs.
- **Figure 2** ("Why :exact is exact"): brightness = depth through the cube; one highlighted `pixel∩shadow` overlap with "the pixel gets exactly that overlap — no sampling".

Docs build green; both SVGs validated.