### PR TITLE
provenance: reproducible record of where a result came from (roadmap #5)

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -70,6 +70,8 @@ makedocs(modules = [Mera],
 
                           "Statistics (PDFs)"    => "statistics.md",
 
+                          "Provenance"           => "provenance.md",
+
                           "Mask/Filter/Meta"    => Any[ "Tutorial"    => "05_multi_Masking_Filtering.md",
                                                         "API Reference" => "api/masking_filtering.md"],
 

--- a/docs/src/provenance.md
+++ b/docs/src/provenance.md
@@ -1,0 +1,62 @@
+# Provenance (reproducibility)
+
+Six months after you make a figure, the question is always the same: *which snapshot, which
+Mera version, what units produced this?* [`provenance`](@ref) answers it. It reads the
+metadata every Mera result already carries (its `InfoType`) and returns a compact,
+deterministic record you can print, compare, or stamp onto a figure or a FITS header.
+
+```julia
+using Mera
+gas = gethydro(getinfo(100, "/data/sim"))
+
+provenance(gas)
+# Provenance:
+#   Mera version : 1.8.0
+#   simulation   : /data/sim
+#   output       : 100  (RAMSES, written 2025-06-21T18:31:55.533)
+#   time (code)  : 9.9335
+#   box / levels : L=100.0  ndim=3  levels 3–7
+#   scale type   : ScalesType003
+```
+
+It works on anything that carries an `InfoType` — a data object, a [`projection`](@ref)
+map, a velocity cube — or on an `InfoType` directly:
+
+```julia
+provenance(projection(gas, :sd))   # the map's provenance
+provenance(gas.info)               # straight from the info
+```
+
+## Stamping a figure or FITS header
+
+[`provenance_string`](@ref) renders a one-liner — drop it into a figure caption, a log, or
+a `COMMENT` card when you [`savefits`](@ref):
+
+```julia
+provenance_string(gas)
+# "Mera v1.8.0 | sim/output_00100 | t=9.9335 code | L=100.0 ndim=3 lmin=3 lmax=7 | ScalesType003"
+
+# e.g. as a caption
+text(0, 0, provenance_string(gas); fontsize=8)
+```
+
+## What it records
+
+| field | meaning |
+|-------|---------|
+| `mera_version` | the Mera version that read the data |
+| `path`, `output`, `simcode` | which simulation, output number, and code (RAMSES) |
+| `time` | snapshot time (code units) |
+| `boxlen`, `ndim`, `levelmin`, `levelmax` | box size, dimensionality, AMR level range |
+| `scale_type` | the serialized scale-type version (e.g. `:ScalesType003`) — relevant for reading older [mera files](07_multi_Mera_Files.md) |
+| `file_ctime` | when the snapshot was written on disk |
+
+The record is **deterministic** — it depends only on the snapshot's own metadata, never on
+the wall clock — so two runs over the same output produce identical provenance, and it is
+safe to use in tests and comparisons.
+
+## See also
+
+- [`getinfo`](@ref) — the `InfoType` provenance is read from.
+- [`savefits`](@ref) — export a map/cube to FITS, where the provenance string makes a good header comment.
+- [MERA-Files](07_multi_Mera_Files.md) — the `scale_type` version matters when loading older files.

--- a/src/Mera.jl
+++ b/src/Mera.jl
@@ -102,6 +102,9 @@ export
     edge_on,
     GalaxyFrame,
     pdf,
+    provenance,
+    provenance_string,
+    Provenance,
 
 # basic calcs
     msum,
@@ -424,6 +427,7 @@ include("functions/clumpfind.jl")
 include("functions/timeseries.jl")
 include("functions/galaxy_frame.jl")
 include("functions/statistics.jl")
+include("functions/provenance.jl")
 # ============================================
 
 

--- a/src/functions/provenance.jl
+++ b/src/functions/provenance.jl
@@ -1,0 +1,75 @@
+# ====================================================================================
+# Provenance: a compact, reproducible record of where a result came from
+#
+#   provenance(obj)         -> Provenance   (from any object carrying `.info`, or an InfoType)
+#   provenance_string(obj)  -> one-line String for figure captions / FITS headers / logs
+#
+# Answers "what produced this?" six months later: Mera version, simulation path + output,
+# snapshot time, box/levels, the serialized scale-type version, and when the output was
+# written. Read straight from the InfoType every result already carries.
+# ====================================================================================
+
+"""
+    Provenance
+
+Reproducibility record returned by [`provenance`](@ref): `mera_version`, simulation `path`,
+`output`, `simcode`, snapshot `time` (code units), `boxlen`, `ndim`, `levelmin`/`levelmax`,
+the serialized `scale_type` (e.g. `:ScalesType003`), and the output's `file_ctime`.
+Render a one-liner for a figure caption or FITS header with [`provenance_string`](@ref).
+"""
+struct Provenance
+    mera_version::VersionNumber
+    path::String
+    output::Int
+    simcode::String
+    time::Float64
+    boxlen::Float64
+    ndim::Int
+    levelmin::Int
+    levelmax::Int
+    scale_type::Symbol
+    file_ctime::DateTime
+end
+
+"""
+    provenance(x) -> Provenance
+
+Build a [`Provenance`](@ref) record from an `InfoType` or from any result that carries one
+(a data object, a [`projection`](@ref) map, a velocity cube, …). Deterministic — it reads
+only the snapshot's own metadata, so it is safe to compare across runs.
+
+```julia
+gas = gethydro(getinfo(100, "/data/sim"))
+p   = provenance(gas)          # or provenance(projection(gas, :sd)), provenance(gas.info)
+```
+"""
+provenance(info::InfoType) = Provenance(
+    pkgversion(@__MODULE__), info.path, round(Int, info.output), String(info.simcode),
+    Float64(info.time), Float64(info.boxlen), Int(info.ndim),
+    Int(info.levelmin), Int(info.levelmax), nameof(typeof(info.scale)), info.ctime)
+
+provenance(dataobject) = provenance(dataobject.info)
+
+"""
+    provenance_string(x) -> String
+
+A compact one-line provenance string — drop it into a figure caption, a FITS/`savefits`
+header `COMMENT`, or a log. Accepts the same inputs as [`provenance`](@ref) (or a
+`Provenance`).
+"""
+provenance_string(p::Provenance) =
+    "Mera v$(p.mera_version) | $(basename(rstrip(p.path, '/')))/output_$(lpad(p.output, 5, '0')) " *
+    "| t=$(round(p.time, sigdigits=5)) code | L=$(p.boxlen) ndim=$(p.ndim) " *
+    "lmin=$(p.levelmin) lmax=$(p.levelmax) | $(p.scale_type)"
+provenance_string(x) = provenance_string(provenance(x))
+
+function Base.show(io::IO, p::Provenance)
+    println(io, "Provenance:")
+    println(io, "  Mera version : ", p.mera_version)
+    println(io, "  simulation   : ", p.path)
+    println(io, "  output       : ", p.output, "  (", p.simcode, ", written ", p.file_ctime, ")")
+    println(io, "  time (code)  : ", p.time)
+    println(io, "  box / levels : L=", p.boxlen, "  ndim=", p.ndim, "  levels ",
+            p.levelmin, "–", p.levelmax)
+    print(io,   "  scale type   : ", p.scale_type)
+end

--- a/test/50_provenance_tests.jl
+++ b/test/50_provenance_tests.jl
@@ -1,0 +1,59 @@
+# ============================================================================
+# 50_provenance_tests.jl
+#
+# provenance / provenance_string — a reproducible record of where a result came from.
+#   PART A (data-free) — Provenance struct, string formatting, show.
+#   PART B (data-backed) — extraction from a real snapshot + a projection map.
+# ============================================================================
+
+using Dates
+
+const PV_PATH = joinpath(SIMULATION_PATH, "spiral_clumps")
+
+@testset "provenance" begin
+
+# ------------------------------------------------------------------ PART A
+@testset "Provenance struct / string / show (data-free)" begin
+    p = Mera.Provenance(v"1.8.0", "/data/sim/spiral_clumps", 100, "RAMSES",
+                        9.9335, 100.0, 3, 3, 7, :ScalesType003,
+                        DateTime(2025, 6, 21, 18, 31, 55))
+    s = provenance_string(p)
+    @test occursin("Mera v1.8.0", s)
+    @test occursin("spiral_clumps/output_00100", s)   # trailing path component + zero-padded output
+    @test occursin("ndim=3", s) && occursin("lmin=3", s) && occursin("lmax=7", s)
+    @test occursin("ScalesType003", s)
+    out = sprint(show, p)
+    @test occursin("Provenance", out) && occursin("RAMSES", out)
+end
+
+# ------------------------------------------------------------------ PART B
+if DATA_AVAILABLE && isdir(PV_PATH)
+    info = getinfo(100, PV_PATH, verbose=false)
+    g    = gethydro(info, verbose=false, show_progress=false)
+
+    @testset "extraction from a snapshot" begin
+        p = provenance(g)
+        @test p isa Mera.Provenance
+        @test p.output == 100
+        @test p.ndim == info.ndim
+        @test p.boxlen == info.boxlen
+        @test p.levelmin == info.levelmin && p.levelmax == info.levelmax
+        @test p.scale_type == nameof(typeof(info.scale))
+        @test p.mera_version == pkgversion(Mera)
+        @test provenance(info) == p                         # InfoType and data object agree
+        @test provenance(g.info) == p
+    end
+
+    @testset "works on a projection result + string" begin
+        pr = projection(g, :sd, verbose=false, show_progress=false)
+        @test provenance(pr).output == 100                  # a map carries provenance too
+        s = provenance_string(g)
+        @test occursin("Mera v", s) && occursin("output_00100", s) && occursin("ndim=3", s)
+    end
+else
+    @testset "provenance data-backed (skipped: spiral_clumps unavailable)" begin
+        @test_skip "spiral_clumps not found under SIMULATION_PATH"
+    end
+end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -110,6 +110,7 @@ if isempty(_focus)
         include("47_galaxyframe_tests.jl")           # auto-frame (center_of/face_on/edge_on): vector helpers data-free + spiral_clumps angular-momentum orientation
         include("48_mockobs_tests.jl")               # mock-observation pipeline (auto-frame → mock_observe/velocity_moments/position_velocity): data-free beam+noise + spiral_clumps kinematics
         include("49_statistics_tests.jl")            # pdf (probability distribution functions): data-free weighted-histogram kernel + spiral_clumps density PDF (mass vs volume)
+        include("50_provenance_tests.jl")            # provenance / provenance_string: data-free struct+string + spiral_clumps snapshot/projection extraction
         include("07_regions.jl")
     end
 


### PR DESCRIPTION
Roadmap #5 — answer *"which snapshot, which Mera version, what units produced this?"* months later.

## API
- `provenance(x)` → `Provenance`, read from the `InfoType` every result carries (a data object, a `projection` map, a velocity cube, or an `InfoType` directly). Records: Mera version, simulation path/output/simcode, snapshot time, `boxlen`/`ndim`/`levelmin`/`levelmax`, the serialized `scale_type` (e.g. `:ScalesType003`), and the output's `file_ctime`.
- `provenance_string(x)` → a one-liner for a figure caption, a log, or a `savefits` FITS header `COMMENT`.
- **Deterministic** — depends only on snapshot metadata, never the wall clock, so two runs over the same output agree (and it's safe in tests/comparisons).

## Tests — `test/50_provenance_tests.jl` (16)
Data-free struct/string/show; `spiral_clumps` snapshot & projection extraction (fields, `InfoType`/object agreement, version, scale type).

## Docs — `docs/src/provenance.md`
Usage, stamping a figure/FITS header, the field table, and the determinism note.