### PR TITLE
provenance: human-readable time (Myr/Gyr) + redshift; document .info scope

### DIFF
--- a/docs/src/provenance.md
+++ b/docs/src/provenance.md
@@ -14,18 +14,45 @@ provenance(gas)
 #   Mera version : 1.8.0
 #   simulation   : /data/sim
 #   output       : 100  (RAMSES, written 2025-06-21T18:31:55.533)
-#   time (code)  : 9.9335
+#   time         : 148.08 Myr
 #   box / levels : L=100.0  ndim=3  levels 3–7
 #   scale type   : ScalesType003
 ```
 
-It works on anything that carries an `InfoType` — a data object, a [`projection`](@ref)
-map, a velocity cube — or on an `InfoType` directly:
+The time is **human-readable**: physical time in Myr/Gyr for a normal run, and **redshift**
+(plus expansion factor and age) for a cosmological one:
 
 ```julia
-provenance(projection(gas, :sd))   # the map's provenance
-provenance(gas.info)               # straight from the info
+#   time         : z=0.1426  (aexp=0.8752, age 11.925 Gyr)
 ```
+
+## Where it applies
+
+`provenance` works on **any object that carries an `InfoType`** — not just projections.
+That is every data object, projection map, and LOS/velocity cube, plus an `InfoType` itself:
+
+| make it with | type | provenance? |
+|--------------|------|-------------|
+| [`getinfo`](@ref) | `InfoType` | ✓ |
+| [`gethydro`](@ref) | `HydroDataType` | ✓ |
+| [`getparticles`](@ref) | `PartDataType` | ✓ |
+| [`getgravity`](@ref) | `GravDataType` | ✓ |
+| [`getclumps`](@ref) | `ClumpDataType` | ✓ |
+| [`getrt`](@ref) | `RtDataType` | ✓ |
+| [`projection`](@ref) | `AMRMapsType` (the map) | ✓ |
+| [`velocity_cube`](@ref) / [`los_cube`](@ref) | `LosCubeType` | ✓ |
+
+```julia
+provenance(getparticles(info))     # particles
+provenance(projection(gas, :sd))   # a projection map
+provenance(velocity_cube(gas))     # a LOS / velocity cube
+provenance(gas.info)               # the InfoType directly
+```
+
+A `NamedTuple`-style result that carries no `.info` — a [`pdf`](@ref), a [`timeseries`](@ref)
+table, a [`position_velocity`](@ref) diagram, a [`GalaxyFrame`](@ref) — cannot be stamped
+directly (you get a clear error saying so); take `provenance` of the **source data object**
+you computed it from.
 
 ## Stamping a figure or FITS header
 
@@ -34,7 +61,8 @@ a `COMMENT` card when you [`savefits`](@ref):
 
 ```julia
 provenance_string(gas)
-# "Mera v1.8.0 | sim/output_00100 | t=9.9335 code | L=100.0 ndim=3 lmin=3 lmax=7 | ScalesType003"
+# "Mera v1.8.0 | sim/output_00100 | 148.08 Myr | L=100.0 ndim=3 lmin=3 lmax=7 | ScalesType003"
+# cosmological run → "… | z=0.14256 | …"
 
 # e.g. as a caption
 text(0, 0, provenance_string(gas); fontsize=8)
@@ -46,7 +74,9 @@ text(0, 0, provenance_string(gas); fontsize=8)
 |-------|---------|
 | `mera_version` | the Mera version that read the data |
 | `path`, `output`, `simcode` | which simulation, output number, and code (RAMSES) |
-| `time` | snapshot time (code units) |
+| `cosmological` | whether the run is cosmological ([`iscosmological`](@ref)) |
+| `time_myr` | physical snapshot time in Myr (the age of the universe for a cosmological run) |
+| `redshift`, `aexp` | cosmological redshift `z = 1/aexp − 1` and expansion factor (`0` / `1` for a normal run) |
 | `boxlen`, `ndim`, `levelmin`, `levelmax` | box size, dimensionality, AMR level range |
 | `scale_type` | the serialized scale-type version (e.g. `:ScalesType003`) — relevant for reading older [mera files](07_multi_Mera_Files.md) |
 | `file_ctime` | when the snapshot was written on disk |

--- a/src/functions/provenance.jl
+++ b/src/functions/provenance.jl
@@ -5,24 +5,29 @@
 #   provenance_string(obj)  -> one-line String for figure captions / FITS headers / logs
 #
 # Answers "what produced this?" six months later: Mera version, simulation path + output,
-# snapshot time, box/levels, the serialized scale-type version, and when the output was
-# written. Read straight from the InfoType every result already carries.
+# snapshot time (human-readable Myr/Gyr, or redshift for cosmological runs), box/levels, the
+# serialized scale-type version, and when the output was written. Read straight from the
+# InfoType that every data object, projection map and LOS/velocity cube already carries.
 # ====================================================================================
 
 """
     Provenance
 
 Reproducibility record returned by [`provenance`](@ref): `mera_version`, simulation `path`,
-`output`, `simcode`, snapshot `time` (code units), `boxlen`, `ndim`, `levelmin`/`levelmax`,
-the serialized `scale_type` (e.g. `:ScalesType003`), and the output's `file_ctime`.
-Render a one-liner for a figure caption or FITS header with [`provenance_string`](@ref).
+`output`, `simcode`, `cosmological`, the snapshot `time_myr` (physical time in Myr; the age
+of the universe for a cosmological run), `redshift` and `aexp`, `boxlen`, `ndim`,
+`levelmin`/`levelmax`, the serialized `scale_type` (e.g. `:ScalesType003`), and the output's
+`file_ctime`. Render a one-liner with [`provenance_string`](@ref).
 """
 struct Provenance
     mera_version::VersionNumber
     path::String
     output::Int
     simcode::String
-    time::Float64
+    cosmological::Bool
+    time_myr::Float64
+    redshift::Float64
+    aexp::Float64
     boxlen::Float64
     ndim::Int
     levelmin::Int
@@ -34,33 +39,57 @@ end
 """
     provenance(x) -> Provenance
 
-Build a [`Provenance`](@ref) record from an `InfoType` or from any result that carries one
-(a data object, a [`projection`](@ref) map, a velocity cube, …). Deterministic — it reads
-only the snapshot's own metadata, so it is safe to compare across runs.
+Build a [`Provenance`](@ref) record from an `InfoType` or from any result that carries one —
+a **data object** (`gethydro`/`getparticles`/`getgravity`/`getclumps`/`getrt`), a
+[`projection`](@ref) map, or a [`velocity_cube`](@ref)/[`los_cube`](@ref). Deterministic: it
+reads only the snapshot's own metadata, so it is safe to compare across runs.
 
 ```julia
 gas = gethydro(getinfo(100, "/data/sim"))
-p   = provenance(gas)          # or provenance(projection(gas, :sd)), provenance(gas.info)
+provenance(gas)                      # data object
+provenance(projection(gas, :sd))     # projection map
+provenance(velocity_cube(gas))       # LOS / velocity cube
+provenance(gas.info)                 # the InfoType directly
 ```
-"""
-provenance(info::InfoType) = Provenance(
-    pkgversion(@__MODULE__), info.path, round(Int, info.output), String(info.simcode),
-    Float64(info.time), Float64(info.boxlen), Int(info.ndim),
-    Int(info.levelmin), Int(info.levelmax), nameof(typeof(info.scale)), info.ctime)
 
-provenance(dataobject) = provenance(dataobject.info)
+For a `NamedTuple`-style result that carries no `.info` (a [`pdf`](@ref), a
+[`timeseries`](@ref) table, a [`position_velocity`](@ref) diagram), take the provenance of
+the source data object you computed it from.
+"""
+function provenance(info::InfoType)
+    Provenance(pkgversion(@__MODULE__), info.path, round(Int, info.output), String(info.simcode),
+               iscosmological(info), Float64(gettime(info, :Myr)), redshift(info),
+               Float64(info.aexp), Float64(info.boxlen), Int(info.ndim),
+               Int(info.levelmin), Int(info.levelmax), nameof(typeof(info.scale)), info.ctime)
+end
+
+provenance(x) = hasproperty(x, :info) ? provenance(x.info) :
+    throw(ArgumentError(
+        "provenance: a $(typeof(x).name.name) carries no `.info`. Apply it to a data object " *
+        "(hydro/particles/gravity/clumps/RT), a projection map, a LOS/velocity cube, or an " *
+        "InfoType. For a NamedTuple result (pdf, timeseries, position_velocity), take " *
+        "provenance of the source data object."))
+
+# Human-readable snapshot time: redshift (+ age) for cosmological runs, else Myr/Gyr.
+function _prov_age(p::Provenance)
+    p.time_myr >= 1000 ? "$(round(p.time_myr / 1000, sigdigits=5)) Gyr" :
+                         "$(round(p.time_myr, sigdigits=5)) Myr"
+end
+_prov_time(p::Provenance) = p.cosmological ?
+    "z=$(round(p.redshift, sigdigits=4))  (aexp=$(round(p.aexp, sigdigits=4)), age $(_prov_age(p)))" :
+    _prov_age(p)
 
 """
     provenance_string(x) -> String
 
-A compact one-line provenance string — drop it into a figure caption, a FITS/`savefits`
-header `COMMENT`, or a log. Accepts the same inputs as [`provenance`](@ref) (or a
-`Provenance`).
+A compact one-line provenance string — drop it into a figure caption, a `COMMENT` card when
+you [`savefits`](@ref), or a log. Accepts the same inputs as [`provenance`](@ref) (or a
+`Provenance`). The time is shown as `z=…` for a cosmological run, otherwise in Myr/Gyr.
 """
 provenance_string(p::Provenance) =
     "Mera v$(p.mera_version) | $(basename(rstrip(p.path, '/')))/output_$(lpad(p.output, 5, '0')) " *
-    "| t=$(round(p.time, sigdigits=5)) code | L=$(p.boxlen) ndim=$(p.ndim) " *
-    "lmin=$(p.levelmin) lmax=$(p.levelmax) | $(p.scale_type)"
+    "| $(p.cosmological ? "z=$(round(p.redshift, sigdigits=5))" : _prov_age(p)) " *
+    "| L=$(p.boxlen) ndim=$(p.ndim) lmin=$(p.levelmin) lmax=$(p.levelmax) | $(p.scale_type)"
 provenance_string(x) = provenance_string(provenance(x))
 
 function Base.show(io::IO, p::Provenance)
@@ -68,7 +97,7 @@ function Base.show(io::IO, p::Provenance)
     println(io, "  Mera version : ", p.mera_version)
     println(io, "  simulation   : ", p.path)
     println(io, "  output       : ", p.output, "  (", p.simcode, ", written ", p.file_ctime, ")")
-    println(io, "  time (code)  : ", p.time)
+    println(io, "  time         : ", _prov_time(p))
     println(io, "  box / levels : L=", p.boxlen, "  ndim=", p.ndim, "  levels ",
             p.levelmin, "–", p.levelmax)
     print(io,   "  scale type   : ", p.scale_type)

--- a/test/50_provenance_tests.jl
+++ b/test/50_provenance_tests.jl
@@ -2,8 +2,9 @@
 # 50_provenance_tests.jl
 #
 # provenance / provenance_string — a reproducible record of where a result came from.
-#   PART A (data-free) — Provenance struct, string formatting, show.
-#   PART B (data-backed) — extraction from a real snapshot + a projection map.
+#   PART A (data-free) — Provenance struct, human-readable time / redshift, show.
+#   PART B (data-backed) — extraction from snapshots (non-cosmo Myr + cosmological z),
+#           the full set of .info-carrying objects, and the no-info error.
 # ============================================================================
 
 using Dates
@@ -14,16 +15,24 @@ const PV_PATH = joinpath(SIMULATION_PATH, "spiral_clumps")
 
 # ------------------------------------------------------------------ PART A
 @testset "Provenance struct / string / show (data-free)" begin
+    # non-cosmological → time in Myr
     p = Mera.Provenance(v"1.8.0", "/data/sim/spiral_clumps", 100, "RAMSES",
-                        9.9335, 100.0, 3, 3, 7, :ScalesType003,
+                        false, 148.08, 0.0, 1.0, 100.0, 3, 3, 7, :ScalesType003,
                         DateTime(2025, 6, 21, 18, 31, 55))
     s = provenance_string(p)
     @test occursin("Mera v1.8.0", s)
-    @test occursin("spiral_clumps/output_00100", s)   # trailing path component + zero-padded output
-    @test occursin("ndim=3", s) && occursin("lmin=3", s) && occursin("lmax=7", s)
+    @test occursin("spiral_clumps/output_00100", s)
+    @test occursin("148.08 Myr", s)                       # human-readable, not code units
     @test occursin("ScalesType003", s)
-    out = sprint(show, p)
-    @test occursin("Provenance", out) && occursin("RAMSES", out)
+    @test occursin("Myr", sprint(show, p)) && occursin("RAMSES", sprint(show, p))
+
+    # cosmological → redshift (and Gyr age in the long form)
+    pc = Mera.Provenance(v"1.8.0", "/data/sim/cosmo", 80, "RAMSES",
+                         true, 11925.0, 0.1426, 0.8752, 1.0, 3, 6, 16, :ScalesType003,
+                         DateTime(2026, 6, 1))
+    sc = provenance_string(pc)
+    @test occursin("z=0.1426", sc) && !occursin("Myr", sc)
+    @test occursin("z=0.1426", sprint(show, pc)) && occursin("Gyr", sprint(show, pc))
 end
 
 # ------------------------------------------------------------------ PART B
@@ -31,28 +40,48 @@ if DATA_AVAILABLE && isdir(PV_PATH)
     info = getinfo(100, PV_PATH, verbose=false)
     g    = gethydro(info, verbose=false, show_progress=false)
 
-    @testset "extraction from a snapshot" begin
+    @testset "extraction from a (non-cosmological) snapshot" begin
         p = provenance(g)
         @test p isa Mera.Provenance
-        @test p.output == 100
-        @test p.ndim == info.ndim
-        @test p.boxlen == info.boxlen
+        @test p.output == 100 && p.ndim == info.ndim && p.boxlen == info.boxlen
         @test p.levelmin == info.levelmin && p.levelmax == info.levelmax
         @test p.scale_type == nameof(typeof(info.scale))
         @test p.mera_version == pkgversion(Mera)
-        @test provenance(info) == p                         # InfoType and data object agree
-        @test provenance(g.info) == p
+        @test p.cosmological == false && p.redshift == 0.0
+        @test 100 < p.time_myr < 200                       # ~148 Myr, human-readable
+        @test provenance(info) == p && provenance(g.info) == p
+        @test occursin("Myr", provenance_string(g))
     end
 
-    @testset "works on a projection result + string" begin
-        pr = projection(g, :sd, verbose=false, show_progress=false)
-        @test provenance(pr).output == 100                  # a map carries provenance too
-        s = provenance_string(g)
-        @test occursin("Mera v", s) && occursin("output_00100", s) && occursin("ndim=3", s)
+    @testset "applies to every .info-carrying object" begin
+        objs = Any[g,
+                   getgravity(info, verbose=false, show_progress=false),
+                   getclumps(info, verbose=false),
+                   projection(g, :sd, verbose=false, show_progress=false),
+                   velocity_cube(g; nv=8, verbose=false)]
+        for o in objs
+            @test provenance(o).output == 100
+        end
+        # a result with no .info → clear ArgumentError, not a MethodError
+        @test_throws ArgumentError provenance(face_on(g))
     end
 else
     @testset "provenance data-backed (skipped: spiral_clumps unavailable)" begin
         @test_skip "spiral_clumps not found under SIMULATION_PATH"
+    end
+end
+
+# cosmological snapshot → redshift comes through
+let cp = joinpath(SIMULATION_PATH, "yt_cosmo")
+    if DATA_AVAILABLE && isdir(cp)
+        @testset "cosmological snapshot → redshift" begin
+            ic = getinfo(80, cp, verbose=false)
+            pc = provenance(gethydro(ic, verbose=false, show_progress=false))
+            @test pc.cosmological == true
+            @test pc.redshift ≈ (1/ic.aexp - 1) rtol=1e-6
+            @test pc.redshift > 0
+            @test occursin("z=", provenance_string(ic))
+        end
     end
 end
 


### PR DESCRIPTION
Follow-up to #132, addressing two requests.

## Human-readable time (instead of code units)
The snapshot time is now physical: **Myr/Gyr** for a normal run, and **redshift** for a cosmological one (detected via `iscosmological`), e.g.

```
time : 148.08 Myr                              # non-cosmological
time : z=0.1426  (aexp=0.8752, age 11.925 Gyr) # cosmological
```

New `Provenance` fields: `cosmological`, `time_myr`, `redshift`, `aexp` (replacing the code-unit `time`).

## Where provenance applies (documented)
`provenance` works on **any object carrying `.info`** — not just projections. The docs now list them explicitly:

| make it with | type |
|---|---|
| `getinfo` | `InfoType` |
| `gethydro`/`getparticles`/`getgravity`/`getclumps`/`getrt` | the data objects |
| `projection` | `AMRMapsType` |
| `velocity_cube`/`los_cube` | `LosCubeType` |

Objects with no `.info` (a `pdf`/`timeseries`/`position_velocity` NamedTuple, a `GalaxyFrame`) now raise a **clear `ArgumentError`** pointing to `provenance(source_data)` instead of a `MethodError`.

## Tests — 26
Non-cosmo Myr extraction; cosmological redshift (`yt_cosmo`); every `.info`-carrying object type; the no-info error; data-free struct/string/show for both regimes.