### PR TITLE
provenance: wire .info into derived results (pdf, position_velocity, GalaxyFrame)

### DIFF
--- a/docs/src/provenance.md
+++ b/docs/src/provenance.md
@@ -41,18 +41,27 @@ That is every data object, projection map, and LOS/velocity cube, plus an `InfoT
 | [`getrt`](@ref) | `RtDataType` | ✓ |
 | [`projection`](@ref) | `AMRMapsType` (the map) | ✓ |
 | [`velocity_cube`](@ref) / [`los_cube`](@ref) | `LosCubeType` | ✓ |
+| [`pdf`](@ref) (cell/particle or 2D-map form) | `NamedTuple` with `.info` | ✓ |
+| [`position_velocity`](@ref) | `NamedTuple` with `.info` | ✓ |
+| [`face_on`](@ref) / [`edge_on`](@ref) | [`GalaxyFrame`](@ref) | ✓ |
 
 ```julia
-provenance(getparticles(info))     # particles
-provenance(projection(gas, :sd))   # a projection map
-provenance(velocity_cube(gas))     # a LOS / velocity cube
-provenance(gas.info)               # the InfoType directly
+provenance(getparticles(info))         # particles
+provenance(projection(gas, :sd))       # a projection map
+provenance(velocity_cube(gas))         # a LOS / velocity cube
+provenance(pdf(gas, :rho))             # a PDF result
+provenance(face_on(gas))               # a galaxy frame
+provenance(gas.info)                   # the InfoType directly
 ```
 
-A `NamedTuple`-style result that carries no `.info` — a [`pdf`](@ref), a [`timeseries`](@ref)
-table, a [`position_velocity`](@ref) diagram, a [`GalaxyFrame`](@ref) — cannot be stamped
-directly (you get a clear error saying so); take `provenance` of the **source data object**
-you computed it from.
+These derived results carry an `.info` field, so the same `provenance` call works on them.
+The exceptions, which keep no source snapshot, raise a clear error (pointing you to
+`provenance` of the source data):
+
+- the **raw-matrix** form `pdf(map2d)` (a bare 2D array has no snapshot);
+- a [`timeseries`](@ref) table — it spans *many* outputs, so a single provenance does not
+  describe it; inside the reducer you have the full data object, so e.g.
+  `timeseries(path, d -> (prov = provenance_string(d), …))` records per-snapshot provenance.
 
 ## Stamping a figure or FITS header
 

--- a/src/functions/galaxy_frame.jl
+++ b/src/functions/galaxy_frame.jl
@@ -22,7 +22,8 @@ projection(gas, :sd; los=fr.los, up=fr.up, center=fr.center, range_unit=fr.cente
 
 Fields: `center` (in `center_unit`), `los` (unit vector the camera looks along),
 `up` (unit vector for the camera's up direction), `angmom` (the net angular-momentum
-vector the frame was derived from).
+vector the frame was derived from), and `info` (the source snapshot — so `provenance(frame)`
+works).
 """
 struct GalaxyFrame
     center::Vector{Float64}
@@ -30,6 +31,7 @@ struct GalaxyFrame
     los::Vector{Float64}
     up::Vector{Float64}
     angmom::Vector{Float64}
+    info::InfoType        # source snapshot — carries provenance (see `provenance`)
 end
 
 function Base.show(io::IO, f::GalaxyFrame)
@@ -114,7 +116,7 @@ function _galaxy_frame(dataobject; center=:com, aperture=nothing,
     else
         los, up = spin, _vunit(_vcross(spin, inplane))   # look along spin; up in-plane
     end
-    return GalaxyFrame(cen, range_unit, los, up, L)
+    return GalaxyFrame(cen, range_unit, los, up, L, dataobject.info)
 end
 
 """

--- a/src/functions/projection/projection.jl
+++ b/src/functions/projection/projection.jl
@@ -458,7 +458,8 @@ function position_velocity(dataobject; los=nothing, theta=nothing, phi=nothing,
     end
     return (offset = collect(range(ext[1], ext[2], length=no+1)),
             velocity = collect(range(ext[3], ext[4], length=nv+1)),
-            pv = grid, offset_unit = offset_unit, v_unit = v_unit, los = collect(w))
+            pv = grid, offset_unit = offset_unit, v_unit = v_unit, los = collect(w),
+            info = dataobject.info)        # carries provenance (see `provenance`)
 end
 
 

--- a/src/functions/statistics.jl
+++ b/src/functions/statistics.jl
@@ -99,7 +99,8 @@ function pdf(dataobject, quantity::Symbol; weight::Symbol=:mass, norm::Symbol=:d
         Float64.(getvar(dataobject, weight, mask=mask))
     r = _weighted_pdf(x, w; bins=bins, valrange=valrange, logbins=logbins, norm=norm)
     return (centers = r.centers, edges = r.edges, pdf = r.pdf, logbins = r.logbins,
-            norm = r.norm, quantity = quantity, unit = unit, weight = weight)
+            norm = r.norm, quantity = quantity, unit = unit, weight = weight,
+            info = dataobject.info)        # carries provenance (see `provenance`)
 end
 
 """
@@ -129,7 +130,7 @@ function pdf(m::DataMapsType, var::Symbol; weight=:area, norm::Symbol=:density,
         end
     r = _weighted_pdf(vals, w; bins=bins, valrange=valrange, logbins=logbins, norm=norm)
     return (centers = r.centers, edges = r.edges, pdf = r.pdf, logbins = r.logbins,
-            norm = r.norm, quantity = var, weight = weight)
+            norm = r.norm, quantity = var, weight = weight, info = m.info)   # provenance
 end
 
 """

--- a/test/47_galaxyframe_tests.jl
+++ b/test/47_galaxyframe_tests.jl
@@ -44,6 +44,13 @@ if DATA_AVAILABLE && isdir(GF_PATH)
         @test all(abs.(seed.center .- glob.center) .< 0.05)  # re-centred back to the disk
     end
 
+    @testset "frame: struct, show, carries provenance" begin
+        fr = face_on(g)
+        @test fr.center_unit == :standard
+        @test occursin("GalaxyFrame", sprint(show, fr))
+        @test provenance(fr).output == 100        # the frame carries its source snapshot
+    end
+
     @testset "frame feeds projection" begin
         fo = face_on(g)
         pr = projection(g, :sd; los=fo.los, up=fo.up, center=fo.center,
@@ -57,16 +64,11 @@ else
 end
 
 # ------------------------------------------------------------------ PART B
-@testset "vector helpers + GalaxyFrame (data-free)" begin
+@testset "vector helpers (data-free)" begin
     @test Mera._vnorm([3.0, 4.0, 0.0]) == 5.0
     @test Mera._vunit([0.0, 0.0, 2.0]) == [0.0, 0.0, 1.0]
     @test Mera._vcross([1.0, 0, 0], [0.0, 1, 0]) == [0.0, 0.0, 1.0]
     @test Mera._vcross([1.0, 0, 0], [1.0, 0, 0]) == [0.0, 0.0, 0.0]   # parallel → 0
-
-    fr = GalaxyFrame([0.5, 0.5, 0.5], :standard, [0.0, 0, 1], [1.0, 0, 0], [0.0, 0, 10])
-    @test fr.center_unit == :standard
-    @test fr.los == [0.0, 0, 1]
-    @test occursin("GalaxyFrame", sprint(show, fr))
 end
 
 end

--- a/test/50_provenance_tests.jl
+++ b/test/50_provenance_tests.jl
@@ -62,8 +62,16 @@ if DATA_AVAILABLE && isdir(PV_PATH)
         for o in objs
             @test provenance(o).output == 100
         end
-        # a result with no .info → clear ArgumentError, not a MethodError
-        @test_throws ArgumentError provenance(face_on(g))
+    end
+
+    @testset "wired into derived results (pdf / PV / GalaxyFrame)" begin
+        @test provenance(pdf(g, :rho)).output == 100
+        @test provenance(pdf(projection(g, :sd, verbose=false, show_progress=false), :sd)).output == 100
+        @test provenance(position_velocity(g; nbins=16, verbose=false)).output == 100
+        @test provenance(face_on(g)).output == 100
+        # a result with genuinely no .info (raw matrix pdf, a plain NamedTuple) → clear error
+        @test_throws ArgumentError provenance(pdf(projection(g, :sd, verbose=false, show_progress=false).maps[:sd]))
+        @test_throws ArgumentError provenance((a = 1, b = 2))
     end
 else
     @testset "provenance data-backed (skipped: spiral_clumps unavailable)" begin


### PR DESCRIPTION
Follow-up to #133 — provenance now travels **on** the derived results, not just data objects.

Each result gains an `.info` field, so the generic `provenance(x) = provenance(x.info)` works on it directly:

| result | how |
|---|---|
| `pdf(data, …)` / `pdf(projection, …)` | NamedTuple gains `.info` |
| `position_velocity(…)` | NamedTuple gains `.info` |
| `face_on`/`edge_on` → `GalaxyFrame` | struct gains an `info::InfoType` field |



**Still info-less, by nature** (clear error, pointing to the source):
- the raw-matrix form `pdf(map2d)` — a bare array has no snapshot;
- a `timeseries` table — it spans *many* outputs, so one provenance can't describe it. The reducer has the full data object, so `timeseries(path, d -> (prov = provenance_string(d), …))` records per-snapshot provenance (documented).

## Tests / docs
- `test/50`: provenance over the wired results + matrix-pdf / bare-NamedTuple still error. `GalaxyFrame` struct/show/provenance moved to the data-backed block (the struct now needs an `InfoType`).
- All affected suites pass: 47 (22), 48 (14), 49 (29), 50 (31), and off-axis 36.
- Docs: the "Where it applies" table now includes `pdf`/`position_velocity`/`GalaxyFrame`, with the info-less exceptions spelled out.