### PR TITLE
timeseries: human-readable time (Myr) by default + redshift/aexp for cosmological runs

### DIFF
--- a/docs/src/examples/LoadFromExistingOutputs.md
+++ b/docs/src/examples/LoadFromExistingOutputs.md
@@ -83,3 +83,20 @@ gettime.(N.outputs, path, :Myr)
 1-element Vector{Float64}:
  445.8861174695
 ```
+
+## One call: `timeseries`
+
+The whole pattern above — discover the outputs, load each one, read its physical time,
+collect a quantity — is what [`timeseries`](@ref) automates into a single call. You give it
+a *reducer* (`data -> scalar | NamedTuple`); it loads one snapshot at a time (RAM-safe) and
+returns one table with an `output` column and a physical **`time` column in Myr** (the same
+`gettime(:Myr)` shown above), plus `redshift`/`aexp` columns for a cosmological run:
+
+```julia
+ts = timeseries(path, d -> (mass = msum(d, :Msol), rho_max = maximum(getvar(d, :rho))))
+# columns: output | time [Myr] | mass | rho_max   (one row per output)
+```
+
+Use the manual loop when you want full control per snapshot; reach for `timeseries` when
+you just want X(t) as a table. See **[Time Series](../timeseries.md)** for output selection,
+memory control, mera-file and cosmological runs, projections-over-time, and plotting.

--- a/docs/src/timeseries.md
+++ b/docs/src/timeseries.md
@@ -40,11 +40,12 @@ ts = timeseries("/data/Mera-Tests/timeseries_sedov3d", d -> (
         mass    = msum(d, :Msol),
         rho_max = maximum(getvar(d, :rho)),
         ncells  = length(d.data),
-     ))
+     ); time_unit = :standard)        # this Sedov fixture is dimensionless → code-unit time
 ```
 
 The result is an `IndexedTables` table — one row per output, with `output` and `time`
-columns added automatically:
+columns added automatically (see [Physical time](#Physical-time-and-cosmological-runs) — the
+default `time` is in **Myr**; the dimensionless Sedov sim is shown here in code units):
 
 ```text
 Table with 13 rows, 5 columns:
@@ -97,6 +98,24 @@ Laid side by side, the maps show the shell sweeping outward through the box:
 
 Return a scalar instead when you only need a number per snapshot — for example the peak
 column density over time, `d -> maximum(projection(d, :sd, verbose=false).maps[:sd])`.
+
+## Physical time and cosmological runs
+
+The `time` column is **physical** by default — Myr (from [`gettime`](@ref)), not code units —
+so a time-series plots against a meaningful axis straight away. Choose another unit with
+`time_unit` (`:Gyr`, `:yr`, …), or `time_unit = :standard` for code units (as the
+dimensionless Sedov fixture above).
+
+A **cosmological** run is detected automatically ([`iscosmological`](@ref)) and gets two extra
+columns — `redshift` (`z = 1/aexp − 1`) and `aexp` — so you can plot any quantity against
+redshift directly. The `time` column then holds the **age of the universe** in Myr:
+
+```julia
+ts = timeseries("/data/cosmo_run", d -> (sfr = …, mgas = msum(d, :Msol)))
+# columns: output | time [Myr, = age] | redshift | aexp | sfr | mgas
+using Mera.IndexedTables: columns
+lines(columns(ts).redshift, columns(ts).mgas)     # gas mass vs redshift
+```
 
 ## Selecting which outputs
 
@@ -201,7 +220,7 @@ timeseries(path, d -> maximum(getvar(d, :rho));
 | `loader` | `nothing` | custom `info -> data` (overrides `datatype`/ranges/`lmax`) |
 | `lmax` | `info.levelmax` | max AMR level to read (hydro/gravity) |
 | `xrange`,`yrange`,`zrange`,`center`,`range_unit` | full box | spatial selection → less RAM |
-| `time_unit` | `:standard` | unit of the `time` column (see [`gettime`](@ref)) |
+| `time_unit` | `:Myr` | unit of the `time` column — physical by default; `:standard` for code units (see [`gettime`](@ref)). Cosmological runs also get `redshift`/`aexp` columns |
 | `verbose` | `true` | per-snapshot progress |
 | `notify` | `false` | call [`notifyme`](@ref) when finished |
 

--- a/src/functions/timeseries.jl
+++ b/src/functions/timeseries.jl
@@ -15,8 +15,9 @@ table — one row per output, ordered by output number.
 
 `reducer` receives the loaded data object of one snapshot and returns either a scalar
 or a `NamedTuple`. The returned table always carries an `output` column and a `time`
-column (from [`gettime`](@ref)); a scalar reducer value lands in a `value` column, a
-`NamedTuple` is expanded into one column per field.
+column (physical time in **Myr** by default, from [`gettime`](@ref); a cosmological run
+additionally gets `redshift` and `aexp` columns). A scalar reducer value lands in a `value`
+column, a `NamedTuple` is expanded into one column per field.
 
 Snapshots are loaded **strictly one at a time** and released before the next, so memory
 stays bounded — suited to a laptop with limited RAM. Loading respects
@@ -38,7 +39,9 @@ stays bounded — suited to a laptop with limited RAM. Loading respects
 - `lmax = nothing` : max AMR level to read (hydro/gravity); `nothing` uses `info.levelmax`.
 - `xrange, yrange, zrange, center, range_unit` : spatial selection passed to the loader —
   cutting the region is the main lever to reduce RAM per snapshot.
-- `time_unit::Symbol = :standard` : unit for the `time` column (see [`gettime`](@ref)).
+- `time_unit::Symbol = :Myr` : unit for the `time` column — physical by default
+  (`:Myr`/`:Gyr`/…); pass `:standard` for code units (see [`gettime`](@ref)). A cosmological
+  run also gets `redshift` and `aexp` columns automatically.
 - `verbose::Bool = true` : print per-snapshot progress.
 - `notify::Bool = false` : call [`notifyme`](@ref) when finished (a no-op unless
   `~/email.txt` / `~/zulip.txt` is configured).
@@ -71,7 +74,7 @@ function timeseries(path::String, reducer;
                     center::Array{<:Any,1} = [0., 0., 0.],
                     range_unit::Symbol = :standard,
                     smallr::Real = 0.,
-                    time_unit::Symbol = :standard,
+                    time_unit::Symbol = :Myr,
                     verbose::Bool = true,
                     notify::Bool = false)
 
@@ -88,8 +91,11 @@ function timeseries(path::String, reducer;
                                 lmax=lmax, xrange=xrange, yrange=yrange, zrange=zrange,
                                 center=center, range_unit=range_unit, smallr=smallr)
         val  = reducer(data)
-        t    = gettime(data; unit=time_unit)          # from the loaded object's own info
-        push!(rows, merge((output = n, time = t), _astuple(val)))
+        t    = gettime(data; unit=time_unit)          # physical time (Myr by default)
+        base = iscosmological(data.info) ?            # cosmological run → add z and aexp
+               (output = n, time = t, redshift = redshift(data.info), aexp = data.info.aexp) :
+               (output = n, time = t)
+        push!(rows, merge(base, _astuple(val)))
 
         data = nothing            # release the snapshot before loading the next one
         GC.gc(false)              # keep peak memory bounded on RAM-limited machines

--- a/test/46_timeseries_tests.jl
+++ b/test/46_timeseries_tests.jl
@@ -45,6 +45,14 @@ if DATA_AVAILABLE && isdir(TS_RAMSES) && !isempty(checkoutputs(TS_RAMSES, verbos
         @test all(c.ncells .> 0)
     end
 
+    @testset "physical time (Myr) default + code-unit override" begin
+        cmyr  = _cols(timeseries(TS_RAMSES, d -> 1; verbose=false))                 # default :Myr
+        ccode = _cols(timeseries(TS_RAMSES, d -> 1; time_unit=:standard, verbose=false))
+        @test issorted(cmyr.time)                            # Myr column present + monotonic
+        @test ccode.time[end] ≈ 0.2 atol=0.05                # code-unit blast time of the Sedov fixture
+        @test :redshift ∉ propertynames(cmyr)                # a non-cosmological run has no z column
+    end
+
     @testset "output selection + scalar reducer" begin
         sub = timeseries(TS_RAMSES, d -> length(d.data); outputs=avail[1:3], verbose=false)
         @test length(sub) == 3
@@ -126,6 +134,20 @@ if DATA_AVAILABLE && isdir(RT_RAMSES) && !isempty(checkoutputs(RT_RAMSES, verbos
             tm = timeseries(RT_MERA, red; datatype=:rt, mera_files=true, verbose=false)
             @test _cols(tm).output == _cols(tr).output
             @test _cols(tm).np1 ≈ _cols(tr).np1 rtol=1e-9    # mera RT reproduces RAMSES RT
+        end
+    end
+end
+
+# cosmological run → automatic redshift / aexp columns, time as the age in Myr
+let cp = joinpath(SIMULATION_PATH, "yt_cosmo")
+    if DATA_AVAILABLE && isdir(cp)
+        @testset "cosmological run → redshift / aexp columns" begin
+            ic = getinfo(80, cp, verbose=false)
+            c  = _cols(timeseries(cp, d -> maximum(getvar(d, :rho)); outputs=[80], verbose=false))
+            @test :redshift in propertynames(c) && :aexp in propertynames(c)
+            @test c.redshift[1] ≈ (1/ic.aexp - 1) rtol=1e-6
+            @test c.aexp[1] ≈ ic.aexp rtol=1e-6
+            @test c.time[1] > 1000                 # age of the universe, in Myr (~11925)
         end
     end
 end


### PR DESCRIPTION
Mirrors the provenance human-readable-time fix, for the place you actually plot vs time.

## What
- The `time` column is now **physical** — `time_unit` defaults to `:Myr` (was code units), so a series plots against a meaningful axis immediately.
- A **cosmological** run (detected via `iscosmological`) automatically gains `redshift` (`z = 1/aexp − 1`) and `aexp` columns; `time` then holds the **age of the universe** in Myr. Plot `columns(ts).mgas` vs `columns(ts).redshift` directly.
- `time_unit = :standard` still gives code units.

## Ties into the example you flagged
`LoadFromExistingOutputs.md` shows the manual loop (`checkoutputs` → `getinfo`/`gethydro` → `gettime(:Myr)`) — exactly what `timeseries` automates, including that `:Myr` physical time. That page now has a **"One call: `timeseries`"** section pointing here.

## Tests — `test/46` (49)
Myr default + `time_unit=:standard` override on the (dimensionless) Sedov fixture; a real cosmological run (`yt_cosmo`) gets `redshift`/`aexp` columns with `z = 1/aexp − 1` and age-in-Myr time.

## Docs
`timeseries.md`: new **Physical time and cosmological runs** section; the Sedov example is marked code-unit (it's dimensionless, so Myr ≈ 0 there); options table updated. The evolution figure stays in code units (Sedov is dimensionless).