### PR TITLE
docs(myargs): compare with native NamedTuple splatting; when to use which

### DIFF
--- a/docs/src/bundled_arguments.md
+++ b/docs/src/bundled_arguments.md
@@ -78,6 +78,57 @@ part = getparticles(info, myargs=quiet)
 For silencing **all** Mera calls at once (without threading a bundle through each), use the
 global switch instead — see [Verbose & progress switches](verbose_progress_switches.md).
 
+## Other ways to bundle — and when `myargs` is the right one
+
+Julia itself has a first-class way to bundle keyword arguments: a `NamedTuple` **splatted**
+with `;`. It works directly with Mera functions, no special type needed:
+
+```julia
+opts = (; xrange=[-10.,10.], yrange=[-10.,10.], center=[:boxcenter], range_unit=:kpc)
+
+gas = gethydro(info; opts...)                 # splat the bundle as keywords
+p   = projection(gas, :sd; opts...)
+
+gethydro(info; opts..., lmax=6)               # an explicit keyword overrides the bundle
+gethydro(info; merge(opts, (; lmax=6))...)    # …or merge first, then splat
+```
+
+This is the idiomatic choice for a bundle of options shared by **one** function, or by
+functions that all accept the **same** keywords.
+
+There is one important difference. A splatted `NamedTuple` passes *every* key as a keyword,
+so a key the target function does **not** accept is an error:
+
+```julia
+opts2 = (; xrange=[-10.,10.], los=[0.,0.,1.])   # los is a projection-only argument
+gethydro(info; opts2...)                         # ERROR: gethydro has no `los` keyword
+```
+
+[`ArgumentsType`](@ref) (`myargs`) is built exactly for this case: it is a **tolerant,
+heterogeneous** bundle. Each function reads only the fields it knows and ignores the rest, so
+**one** bundle can carry arguments for several functions with *different* signatures:
+
+```julia
+ma = ArgumentsType()
+ma.xrange = [-10.,10.]; ma.center = [:boxcenter]; ma.range_unit = :kpc
+ma.los = [0.,0.,1.]                  # only projection uses this
+
+gethydro(info, myargs=ma)            # ignores `los`, uses the region
+projection(gas, :sd, myargs=ma)      # uses `los` and the region
+```
+
+Rule of thumb:
+
+| you want | use |
+|----------|-----|
+| share options across calls of the **same** function (or same keywords) | a `NamedTuple` + `; opts...` (native Julia) |
+| override a shared bundle for one call | `; opts..., key=val` or `merge(opts, (; key=val))...` |
+| **one** bundle spanning functions with **different** signatures | `myargs=ArgumentsType()` (tolerant) |
+| a preconfigured shorthand function | a closure, `myhydro(info; kw...) = gethydro(info; opts..., kw...)` |
+
+You can also combine them — pass a `myargs` bundle *and* splat a `NamedTuple` of extra
+keywords in the same call.
+
 ## See also
 
 - [Verbose & progress switches](verbose_progress_switches.md) — global master switch for messages and progress bars.


### PR DESCRIPTION
Answers *'would there be other/better ways to bundle arguments — maybe already shipped by Julia itself?'*

Adds an **Other ways to bundle** section to the `myargs` page, documenting the idiomatic Julia mechanism alongside `ArgumentsType`, with the trade-off spelled out (all examples verified against Mera functions):

- **Native NamedTuple splat** — `opts = (; xrange=…, center=…); gethydro(info; opts...)`; override with `; opts..., lmax=6` or `merge(opts, (; lmax=6))...`. Best for one function / shared keywords.
- **The catch** — a splatted NamedTuple passes *every* key, so a key the function doesn't accept errors (`los` into `gethydro` → `MethodError`). 
- **Why `myargs` exists** — `ArgumentsType` is a *tolerant, heterogeneous* bundle: each function reads only the fields it knows, so **one** bundle spans functions with different signatures (`gethydro` ignores `los`, `projection` uses it).
- A rule-of-thumb table (same-function splat / override / cross-function `myargs` / closure shorthand) and a note that `myargs=` and splatted keywords combine in one call.

Docs-only; build verified clean.