### PR TITLE
getmovie: expose the full off-axis projection view

### DIFF
--- a/docs/src/movie.md
+++ b/docs/src/movie.md
@@ -32,17 +32,28 @@ want the individual images on disk, ask for them — `savemovie(...; save_frames
 each rendered frame as a PNG (see [Scratch frames](#Scratch-frames-—-keep-the-PNGs)) — and
 [`moviefromframes`](@ref) goes the other way, building a movie from images already on disk.
 
-## Orientation and region
+## Orientation: off-axis movies
 
-The view is whatever [`projection`](@ref) accepts, **fixed across frames**. Axis-aligned by
-default (`direction=:z`); for an oriented movie, pass a `los`/`up` from [`face_on`](@ref) or
-[`edge_on`](@ref) computed on a reference snapshot:
+`getmovie` uses the **full [`projection`](@ref) view**, held fixed across frames so the movie
+is steady. It's axis-aligned by default (`direction=:z`), but every off-axis control that
+`projection` offers works here too:
 
 ```julia
+# 1. a line of sight from the auto-frame (face-on / edge-on)
 ref = gethydro(getinfo(1, "/data/sim"))
 fr  = face_on(ref)
 m   = getmovie("/data/sim", :sd; los=fr.los, up=fr.up, center=fr.center, range_unit=fr.center_unit)
+
+# 2. by viewing angles (the off-axis camera)
+m = getmovie("/data/sim", :sd; inclination=60, azimuth=30)      # degrees by default
+m = getmovie("/data/sim", :sd; theta=45, phi=20, position_angle=15)
+
+# 3. auto face-on from the gas angular momentum, recomputed per frame
+m = getmovie("/data/sim", :sd; axis=:angmom)
 ```
+
+The view is the same for every frame (so the camera doesn't wander) — except `axis=:angmom`,
+which re-derives the face-on orientation from each snapshot's own angular momentum.
 
 `res`, `lmax`, and the `xrange`/`yrange`/`zrange` region keywords cut the cost (and memory)
 of each frame. `outputs` selects which snapshots (`:all`, a range, or a vector), and

--- a/src/functions/movie.jl
+++ b/src/functions/movie.jl
@@ -36,7 +36,9 @@ end
 
 """
     getmovie(path, quantity; unit=:standard, datatype=:hydro, outputs=:all, mera_files=false,
-             direction=:z, los=nothing, up=nothing, center=[:boxcenter], range_unit=:standard,
+             direction=:z, los=nothing, up=nothing, theta=nothing, phi=nothing,
+             inclination=nothing, azimuth=nothing, position_angle=nothing, axis=nothing,
+             angle_unit=:deg, center=[:boxcenter], range_unit=:standard,
              xrange=[missing,missing], yrange=[missing,missing], zrange=[missing,missing],
              res=nothing, lmax=nothing, weighting=[:mass, missing],
              time_unit=:Myr, verbose=true) -> MeraMovie
@@ -46,9 +48,11 @@ Project `quantity` for every output of a simulation and collect the maps into a
 loads **one snapshot at a time** (RAM-safe) and discovers outputs the same way (RAMSES or
 `mera_files`).
 
-The view is whatever [`projection`](@ref) accepts and is held **fixed** across frames so the
-movie is steady: axis-aligned by default (`direction=:z`), or pass a `los`/`up` from
-[`face_on`](@ref)/[`edge_on`](@ref) for an oriented view. `res`/`lmax` and the region
+The view is the **full [`projection`](@ref) view** and is held **fixed** across frames so the
+movie is steady. Axis-aligned by default (`direction=:z`); for an **off-axis** movie use any
+of projection's view controls — a `los`/`up` (e.g. from [`face_on`](@ref)/[`edge_on`](@ref)),
+the angles `inclination`/`azimuth` (or `theta`/`phi`, `position_angle`, with `angle_unit`),
+or `axis=:angmom` to auto-orient face-on. `res`/`lmax` and the region
 keywords cut cost per frame.
 
 ```julia
@@ -65,6 +69,8 @@ function getmovie(path::String, quantity::Symbol;
                   unit::Symbol=:standard,
                   datatype::Symbol=:hydro, outputs=:all, mera_files::Bool=false,
                   direction::Symbol=:z, los=nothing, up=nothing,
+                  theta=nothing, phi=nothing, inclination=nothing, azimuth=nothing,
+                  position_angle=nothing, axis=nothing, angle_unit::Symbol=:deg,
                   center=[:boxcenter], range_unit::Symbol=:standard,
                   xrange=[missing, missing], yrange=[missing, missing], zrange=[missing, missing],
                   res=nothing, lmax=nothing, weighting=[:mass, missing],
@@ -82,6 +88,8 @@ function getmovie(path::String, quantity::Symbol;
                                 lmax=lmax, xrange=xrange, yrange=yrange, zrange=zrange,
                                 center=center, range_unit=range_unit, smallr=0.)
         pr = _movie_project(data, quantity, unit; direction=direction, los=los, up=up,
+                            theta=theta, phi=phi, inclination=inclination, azimuth=azimuth,
+                            position_angle=position_angle, axis=axis, angle_unit=angle_unit,
                             center=center, range_unit=range_unit,
                             xrange=xrange, yrange=yrange, zrange=zrange, res=res,
                             lmax=lmax, weighting=weighting)
@@ -94,17 +102,24 @@ function getmovie(path::String, quantity::Symbol;
     return MeraMovie(frames, outs, times, extent, quantity, unit, time_unit)
 end
 
-# Forward only the projection kwargs that are set (res/lmax default to projection's own).
-function _movie_project(data, quantity, unit; direction, los, up, center, range_unit,
+# Forward the projection view/region kwargs that are set — including the full off-axis set
+# (los/up, theta/phi, inclination/azimuth, position_angle, axis) — so getmovie can make an
+# off-axis movie exactly as `projection` would (res/lmax default to projection's own).
+function _movie_project(data, quantity, unit; direction, los, up, theta, phi, inclination,
+                        azimuth, position_angle, axis, angle_unit, center, range_unit,
                         xrange, yrange, zrange, res, lmax, weighting)
     kw = Dict{Symbol,Any}(:verbose => false, :show_progress => false,
                           :center => center, :range_unit => range_unit,
                           :xrange => xrange, :yrange => yrange, :zrange => zrange,
-                          :weighting => weighting)
-    los === nothing ? (kw[:direction] = direction) : (kw[:los] = los)
-    up === nothing || (kw[:up] = up)
-    res === nothing || (kw[:res] = res)
-    lmax === nothing || (kw[:lmax] = lmax)
+                          :weighting => weighting, :angle_unit => angle_unit)
+    # the line of sight: an explicit los/up, or angle-based off-axis, else an axis direction
+    any(!isnothing, (los, theta, phi, inclination, azimuth, axis)) || (kw[:direction] = direction)
+    for (name, val) in (:los => los, :up => up, :theta => theta, :phi => phi,
+                        :inclination => inclination, :azimuth => azimuth,
+                        :position_angle => position_angle, :axis => axis,
+                        :res => res, :lmax => lmax)
+        val === nothing || (kw[name] = val)
+    end
     return projection(data, quantity, unit; kw...)
 end
 

--- a/test/51_movie_tests.jl
+++ b/test/51_movie_tests.jl
@@ -90,6 +90,17 @@ if DATA_AVAILABLE && isdir(MV_PATH)
         @test length(ms) == 3
     end
 
+    @testset "off-axis frames (full projection view set)" begin
+        o = avail[end:end]
+        za  = getmovie(MV_PATH, :sd; outputs=o, res=48, verbose=false).frames[1]          # axis-aligned z
+        inc = getmovie(MV_PATH, :sd; outputs=o, res=48, inclination=45, azimuth=30, verbose=false).frames[1]
+        @test ndims(inc) == 2
+        @test inc != za                                              # angle-based off-axis tilts the frame
+        # an explicit line of sight also works (e.g. from face_on/edge_on)
+        l = getmovie(MV_PATH, :sd; outputs=o, res=48, los=[1.0,0.0,0.0], up=[0.0,0.0,1.0], verbose=false)
+        @test length(l) == 1 && ndims(l.frames[1]) == 2
+    end
+
     @testset "savemovie writes one GIF (no intermediate files)" begin
         m = getmovie(MV_PATH, :sd; outputs=avail[1:4], res=32, time_unit=:standard, verbose=false)
         mktempdir() do d


### PR DESCRIPTION
Answers "does the movie make use of off-axis projection?" — it did via `los`/`up`, but not the angle-based controls. This forwards the **complete** `projection` view so `getmovie` is a full off-axis movie maker.

## What
`getmovie` now accepts and forwards every off-axis view control `projection` offers:
- `los`/`up` (e.g. from `face_on`/`edge_on`) — already worked;
- viewing angles `inclination`/`azimuth` (or `theta`/`phi`, `position_angle`, with `angle_unit`) — new;
- `axis=:angmom` to auto-orient face-on from each snapshot's angular momentum — new.

`_movie_project` picks the line of sight as: an explicit `los`, or any angle/axis spec, else the axis-aligned `direction`. The view is held fixed across frames (steady camera), except `axis=:angmom`, which re-derives face-on per snapshot.

```
getmovie("/data/sim", :sd; inclination=60, azimuth=30)   # off-axis by angle
getmovie("/data/sim", :sd; axis=:angmom)                 # auto face-on per frame
getmovie("/data/sim", :sd; los=fr.los, up=fr.up)         # from the auto-frame
```

## Tests / docs
- test/51 (55): angle-based off-axis tilts the frame vs the z view; explicit los/up works.
- docs/src/movie.md: new "Orientation: off-axis movies" section (los/up, viewing angles, axis=:angmom). Build clean.
