### PR TITLE
PLUTO frontend: read PLUTO data into Mera, analysis runs unchanged

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -103,6 +103,8 @@ makedocs(modules = [Mera],
                                                         "Converter"    =>  "07_1_multi_Mera_Files_Converter.md",
                                                         "API Reference" => "api/mera_files.md"],
 
+                          "Other Codes (PLUTO)" => "pluto_reader.md",
+
                           "Volume Rendering"    => Any[ "Intro"      =>  "paraview/paraview_intro.md",
                                                         "Hydro"      =>  "paraview/08_hydro_VTK_export.md",
                                                         "Particles"  =>  "paraview/08_particles_VTK_export.md",

--- a/docs/src/pluto_reader.md
+++ b/docs/src/pluto_reader.md
@@ -1,0 +1,76 @@
+# Reading PLUTO data (experimental)
+
+Mera's analysis began as a RAMSES tool, but the analysis layer is **code-blind**: it works on
+a generic uniform/AMR cell list, not on RAMSES file formats. This page adds a **frontend for
+the [PLUTO code](http://plutocode.ph.unito.it)** that reads PLUTO's static-grid output into
+the same Mera structs — so [`getvar`](@ref), [`projection`](@ref), [`pdf`](@ref),
+[`timeseries`](@ref), and the rest run on PLUTO data unchanged.
+
+!!! warning "Experimental / v1 scope"
+    The PLUTO frontend currently supports **3-D, Cartesian, uniform (static) grids** with a
+    power-of-two cell count per axis (so the grid maps onto Mera's `cellsize = boxlen/2^level`
+    convention). PLUTO's AMR (Chombo) format and non-Cartesian geometries are not yet
+    supported. PLUTO test problems are dimensionless, so data load in **code units**.
+
+## Usage
+
+The normal [`getinfo`](@ref) / [`gethydro`](@ref) entry points **auto-detect the code** —
+nothing special to call:
+
+```julia
+using Mera
+
+info = getinfo(5, "/data/pluto_sedov3d")   # detects PLUTO (grid.out + dbl.out) → prints "Code: PLUTO"
+gas  = gethydro(info)                       # branches on info.simcode → the PLUTO frontend
+```
+
+`getinfo` sniffs the directory for each code's signature files; the detected code is stored in
+`info.simcode` (`"PLUTO"` / `"RAMSES"`) and printed in the overview. Force it with `code=`:
+
+```julia
+info = getinfo(5, path; code=:pluto)        # or :ramses, or :auto (the default)
+```
+
+The low-level frontend functions are also exported if you want them directly:
+`getinfo_pluto(output, path)` and `gethydro_pluto(info)`.
+
+`gas` is an ordinary `HydroDataType` (uniform grid, columns `:cx,:cy,:cz, :rho,:vx,:vy,:vz,:p`),
+identical in shape to what the RAMSES uniform-grid reader produces. Everything downstream just
+works:
+
+```julia
+msum(gas, :Msol)                       # (code units here)
+projection(gas, :rho)                  # the exact off-axis projection engine
+pdf(gas, :rho)                         # density PDF
+p = face_on(gas); projection(gas, :sd; los=p.los, up=p.up, center=p.center)
+```
+
+## What it reads
+
+PLUTO's **static-grid** output (the format documented by PLUTO's own `pyPLUTO` reader):
+
+- **`grid.out`** — geometry, per-axis cell count and edges → the cell centres.
+- **`dbl.out`** — one row per snapshot: time, file mode (`single_file`), endianness, and the
+  variable names.
+- **`data.NNNN.dbl`** — the raw double-precision data (single-file, x1 fastest).
+
+PLUTO variable names are mapped to Mera's canonical symbols: `rho→:rho`, `vx1/vx2/vx3→:vx/:vy/:vz`,
+`prs→:p` (and `bx1/2/3→:bx/:by/:bz` for MHD).
+
+## How it fits Mera's architecture
+
+The frontend is a **sibling reader**: it fills the existing `InfoType` / `HydroDataType`
+structs (`simcode = "PLUTO"`, `levelmin == levelmax`, `boxlen`, the `scale`, the cell table in
+the RAMSES coordinate convention). It changes **nothing** in the analysis layer — that is the
+whole point. The one thing the reader must get exactly right is the cell-coordinate mapping
+(`cell centre = (c − 0.5)·boxlen/2^level`); the reader is validated against `pyPLUTO` (the
+density peak and every value match cell-for-cell).
+
+This is the proof-of-concept for multi-code support: a new code = "write a reader that fills
+the structs," not "rework Mera." Other Eulerian codes (Enzo, FLASH, Athena++) can follow the
+same pattern.
+
+## See also
+
+- [`getvar`](@ref), [`projection`](@ref), [`pdf`](@ref) — the analysis that now runs on PLUTO data.
+- [`getinfo`](@ref) / [`gethydro`](@ref) — the RAMSES equivalents this mirrors.

--- a/src/Mera.jl
+++ b/src/Mera.jl
@@ -66,6 +66,8 @@ export
 # data reader
     getunit,
     getinfo,
+    getinfo_pluto,
+    gethydro_pluto,
     createpath,
     gethydro,
     getgravity,
@@ -373,6 +375,7 @@ include("read_data/RAMSES/hilbert3d.jl")
 # Data reader
 include("read_data/RAMSES/gethydro.jl")
 include("read_data/RAMSES/reader_hydro.jl")
+include("read_data/PLUTO/reader_pluto.jl")   # PLUTO frontend (static uniform Cartesian grid)
 
 include("read_data/RAMSES/getgravity.jl")
 include("read_data/RAMSES/reader_gravity.jl")

--- a/src/read_data/PLUTO/reader_pluto.jl
+++ b/src/read_data/PLUTO/reader_pluto.jl
@@ -1,0 +1,165 @@
+# ====================================================================================
+# PLUTO reader (static / uniform Cartesian grid)
+#
+# A frontend for the PLUTO code (Mignone et al.). Reads PLUTO's static-grid output
+# (grid.out + dbl.out + data.NNNN.dbl) into the SAME Mera structs the RAMSES reader
+# produces — a uniform-grid HydroDataType with columns (:cx,:cy,:cz, :rho,:vx,:vy,:vz,:p).
+# The analysis layer (getvar/projection/profiles/…) then works unchanged.
+#
+# Scope (v1): 3-D, Cartesian, **uniform** grid with a power-of-two cell count per axis
+# (so it maps onto Mera's level convention cell-size = boxlen / 2^level). PLUTO is
+# dimensionless here → code units (unit_l = unit_d = unit_t = 1).
+#
+# Format learned from PLUTO's own reader, Tools/pyPLUTO/pyPLUTO.py.
+# ====================================================================================
+
+# PLUTO variable name → Mera canonical symbol
+const _PLUTO_VARMAP = Dict("rho"=>:rho, "vx1"=>:vx, "vx2"=>:vy, "vx3"=>:vz, "prs"=>:p,
+                           "bx1"=>:bx, "bx2"=>:by, "bx3"=>:bz)
+
+# Detect which simulation code wrote a directory, from its signature files.
+# PLUTO static-grid output has grid.out + dbl.out; RAMSES has output_*/info_*.txt.
+function detect_simcode(path::String)
+    (isfile(joinpath(path, "grid.out")) && isfile(joinpath(path, "dbl.out"))) && return :pluto
+    return :ramses        # default; the RAMSES reader validates its own files
+end
+
+# --- grid.out: geometry + per-axis cell edges --------------------------------------
+# Returns (geometry, (n1,n2,n3), (xc1,xc2,xc3)) with cell-centre vectors.
+function _pluto_read_grid(gridfile::String)
+    geometry = "CARTESIAN"; nmax = Int[]; xL = Float64[]; xR = Float64[]
+    for ln in eachline(gridfile)
+        s = split(ln)
+        isempty(s) && continue
+        if s[1] == "#"
+            length(s) >= 3 && s[2] == "GEOMETRY:" && (geometry = uppercase(s[3]))
+            continue
+        end
+        if length(s) == 1                          # an axis cell-count line
+            push!(nmax, parse(Int, s[1]))
+        elseif length(s) == 3                      # "i  xL  xR"
+            push!(xL, parse(Float64, s[2])); push!(xR, parse(Float64, s[3]))
+        end
+    end
+    length(nmax) == 3 || error("PLUTO: expected 3 axis blocks in $gridfile, got $(length(nmax)).")
+    n1, n2, n3 = nmax
+    off1, off2 = n1, n1 + n2
+    xc1 = [0.5*(xL[i] + xR[i]) for i in 1:n1]
+    xc2 = [0.5*(xL[off1+i] + xR[off1+i]) for i in 1:n2]
+    xc3 = [0.5*(xL[off2+i] + xR[off2+i]) for i in 1:n3]
+    return geometry, (n1, n2, n3), (xc1, xc2, xc3)
+end
+
+# --- dbl.out: one row per output (nout time dt nstep single/multiple endian vars…) --
+# Returns the matching row for `output` as (time, filetype, endianness, vars::Vector{String}).
+function _pluto_read_varfile(varfile::String, output::Int)
+    for ln in eachline(varfile)
+        s = split(ln); isempty(s) && continue
+        parse(Int, s[1]) == output || continue
+        return (parse(Float64, s[2]), s[5], s[6], String.(s[7:end]))
+    end
+    error("PLUTO: output $output not found in $varfile.")
+end
+
+_ilog2(n::Integer) = (l = round(Int, log2(n)); 2^l == n ? l :
+    error("PLUTO reader (v1) needs a power-of-two cell count per axis; got $n. " *
+          "Re-run PLUTO with e.g. 64³, or extend the reader for arbitrary sizes."))
+
+"""
+    getinfo_pluto(output::Int, path::String; verbose=true) -> InfoType
+
+Read PLUTO static-grid metadata (`grid.out` + `dbl.out`) for snapshot `output` in `path`
+into a Mera `InfoType` (`simcode = "PLUTO"`). Uniform 3-D Cartesian grid → `levelmin ==
+levelmax`; PLUTO is dimensionless here, so code units (`unit_* = 1`). Feed the result to
+[`gethydro`](@ref).
+"""
+function getinfo_pluto(output::Int, path::String; verbose::Bool=true)
+    geometry, (n1, n2, n3), (xc1, xc2, xc3) = _pluto_read_grid(joinpath(path, "grid.out"))
+    geometry == "CARTESIAN" ||
+        error("PLUTO reader (v1) supports CARTESIAN geometry only; got $geometry.")
+    (n1 == n2 == n3) ||
+        error("PLUTO reader (v1) needs a cubic grid; got $n1×$n2×$n3.")
+    level = _ilog2(n1)
+    time, filetype, endian, vars = _pluto_read_varfile(joinpath(path, "dbl.out"), output)
+    boxlen = (xc1[end] - xc1[1]) + (xc1[2] - xc1[1])     # domain length (centres + one cell)
+
+    info = InfoType()
+    info.descriptor = DescriptorType()
+    info.output = output;          info.path = abspath(path); info.simcode = "PLUTO"
+    info.Narraysize = 0;           info.ndim = 3
+    info.levelmin = level;         info.levelmax = level;     info.boxlen = boxlen
+    info.time = time;              info.gamma = 5/3
+    info.aexp = 1.0; info.H0 = 1.0; info.omega_m = 1.0; info.omega_l = 0.0
+    info.omega_k = 0.0; info.omega_b = 0.0
+    info.unit_l = 1.0; info.unit_d = 1.0; info.unit_t = 1.0; info.unit_v = 1.0; info.unit_m = 1.0
+    info.hydro = true; info.gravity = false; info.particles = false
+    info.rt = false; info.clumps = false; info.sinks = false
+    info.variable_list = [get(_PLUTO_VARMAP, v, Symbol(v)) for v in vars]
+    info.nvarh = length(vars)
+    info.gravity_variable_list = Symbol[]; info.particles_variable_list = Symbol[]
+    info.rt_variable_list = Symbol[]; info.clumps_variable_list = Symbol[]; info.sinks_variable_list = Symbol[]
+    info.ncpu = 1
+    info.mtime = Dates.unix2datetime(round(Int, mtime(joinpath(path, "grid.out"))))
+    info.ctime = info.mtime
+    createconstants!(info)
+    createscales!(info)
+    if verbose
+        printtime("", verbose)
+        println("Code: ", info.simcode)
+        println("output: ", output, "  time: ", round(time, sigdigits=5), " [code units]")
+        println("grid: ", n1, "³ uniform Cartesian, level ", level, ", boxlen = ", boxlen)
+        println("variables: (", join(string.(info.variable_list), ", "), ")")
+        println("-------------------------------------------------------")
+    end
+    return info
+end
+
+"""
+    gethydro_pluto(info::InfoType; verbose=true) -> HydroDataType
+
+Read a PLUTO static-grid snapshot (`data.NNNN.dbl`, single-file double precision) described
+by `info` (from [`getinfo_pluto`](@ref)) into a uniform-grid `HydroDataType` — columns
+`(:cx,:cy,:cz, :rho,:vx,:vy,:vz,:p)`, the same schema the RAMSES uniform-grid reader produces,
+so the whole analysis layer works on it unchanged.
+"""
+function gethydro_pluto(info::InfoType; verbose::Bool=true)
+    path = info.path; n = 2^info.levelmin; ncell = n^3
+    output = round(Int, info.output)
+    vars = info.variable_list
+    nv = length(vars)
+    _, filetype, endian, _ = _pluto_read_varfile(joinpath(path, "dbl.out"), output)
+    filetype == "single_file" ||
+        error("PLUTO reader (v1) supports single_file dbl output; got $filetype.")
+    swap = (endian == "big") != (ENDIAN_BOM == 0x01020304)   # file endianness vs host
+
+    fn = joinpath(path, "data.$(lpad(output, 4, '0')).dbl")
+    raw = Vector{Float64}(undef, ncell * nv)
+    read!(fn, raw)
+    if swap                              # reverse byte order if the file differs from the host
+        u = reinterpret(UInt64, raw); u .= bswap.(u)
+    end
+
+    # PLUTO single_file layout: var-major, each block ncell doubles, x1 fastest (C order).
+    cx = Vector{Int32}(undef, ncell); cy = similar(cx); cz = similar(cx)
+    @inbounds for i3 in 1:n, i2 in 1:n, i1 in 1:n
+        k = ((i3-1)*n + (i2-1))*n + i1
+        cx[k] = i1; cy[k] = i2; cz[k] = i3
+    end
+    cols = Any[cx, cy, cz]
+    names = Symbol[:cx, :cy, :cz]
+    for (vi, vsym) in enumerate(vars)
+        block = @view raw[((vi-1)*ncell + 1):(vi*ncell)]   # already x1-fastest = our k order
+        push!(cols, Float64.(block)); push!(names, vsym)
+    end
+
+    data = table(cols...; names=Tuple(names), pkey=[:cx, :cy, :cz], presorted=false, copy=false)
+    h = HydroDataType()
+    h.data = data; h.info = info
+    h.lmin = info.levelmin; h.lmax = info.levelmax; h.boxlen = info.boxlen
+    h.ranges = [0., 1., 0., 1., 0., 1.]
+    h.selected_hydrovars = collect(1:nv)
+    h.used_descriptors = Dict{Any,Any}()
+    h.smallr = 0.; h.smallc = 0.; h.scale = info.scale
+    verbose && println("[Mera]: PLUTO hydro $(n)³ = $(ncell) cells, vars ", join(string.(vars), ", "))
+    return h
+end

--- a/src/read_data/RAMSES/gethydro.jl
+++ b/src/read_data/RAMSES/gethydro.jl
@@ -330,6 +330,11 @@ function gethydro(dataobject::InfoType;
                     myargs::ArgumentsType=ArgumentsType(),
                     max_threads::Int=Threads.nthreads())
 
+    # Multi-code: a non-RAMSES info delegates to its own frontend (the analysis stays blind).
+    if dataobject.simcode == "PLUTO"
+        return gethydro_pluto(dataobject; verbose=verbose)
+    end
+
     # ═══════════════════════════════════════════════════════════════════════════
     # PARAMETER PROCESSING AND VALIDATION
     # ═══════════════════════════════════════════════════════════════════════════

--- a/src/read_data/RAMSES/getinfo.jl
+++ b/src/read_data/RAMSES/getinfo.jl
@@ -17,19 +17,28 @@ fields like `descriptor`, `grid_info`, `part_info`, `scale`, and helper accessor
 """
 function getinfo end
 
-function getinfo(output::Real; path::String="", namelist::String="", verbose::Bool=true)
-    return getinfo(output=output, path=path, namelist=namelist, verbose=verbose)
+function getinfo(output::Real; path::String="", namelist::String="", code::Symbol=:auto, verbose::Bool=true)
+    return getinfo(output=output, path=path, namelist=namelist, code=code, verbose=verbose)
 end
 
-function getinfo(output::Real, path::String; namelist::String="", verbose::Bool=true)
-    return getinfo(output=output, path=path, namelist=namelist, verbose=verbose)
+function getinfo(output::Real, path::String; namelist::String="", code::Symbol=:auto, verbose::Bool=true)
+    return getinfo(output=output, path=path, namelist=namelist, code=code, verbose=verbose)
 end
 
-function getinfo(path::String; output::Real=1, namelist::String="", verbose::Bool=true)
-    return getinfo(output=output, path=path, namelist=namelist, verbose=verbose)
+function getinfo(path::String; output::Real=1, namelist::String="", code::Symbol=:auto, verbose::Bool=true)
+    return getinfo(output=output, path=path, namelist=namelist, code=code, verbose=verbose)
 end
 
-function getinfo(; output::Real=1, path::String="", namelist::String="", verbose::Bool=true)
+function getinfo(; output::Real=1, path::String="", namelist::String="", code::Symbol=:auto, verbose::Bool=true)
+
+    # Multi-code front controller: detect (or honour code=) the simulation code, then
+    # delegate to the matching frontend. RAMSES is the built-in default below.
+    resolved = code === :auto ? detect_simcode(path == "" ? pwd() : path) : code
+    if resolved === :pluto
+        return getinfo_pluto(round(Int, output), path == "" ? pwd() : path; verbose=verbose)
+    elseif resolved !== :ramses
+        error("getinfo: unknown code :$resolved (use :auto, :ramses, or :pluto).")
+    end
 
 
     verbose = checkverbose(verbose)

--- a/test/52_pluto_reader_tests.jl
+++ b/test/52_pluto_reader_tests.jl
@@ -1,0 +1,104 @@
+# ============================================================================
+# 52_pluto_reader_tests.jl
+#
+# PLUTO code frontend (multi-code reader): getinfo_pluto / gethydro_pluto read
+# PLUTO static-grid output (grid.out + dbl.out + data.NNNN.dbl) into the standard
+# Mera structs, so the analysis layer runs unchanged.
+#   PART A (data-free) — the format parsers + power-of-two guard.
+#   PART B (data-backed) — load the 3-D Sedov fixture, verify the coordinate
+#           convention, and confirm getvar/projection/pdf work unchanged.
+# ============================================================================
+
+const PL_PATH = joinpath(SIMULATION_PATH, "pluto_sedov3d")
+
+@testset "PLUTO reader" begin
+
+# ------------------------------------------------------------------ PART A
+@testset "format parsers (data-free)" begin
+    @test Mera._ilog2(64) == 6 && Mera._ilog2(128) == 7
+    @test_throws ErrorException Mera._ilog2(48)        # non-power-of-two rejected (v1)
+    @test Mera._PLUTO_VARMAP["rho"] == :rho
+    @test Mera._PLUTO_VARMAP["vx1"] == :vx && Mera._PLUTO_VARMAP["vx3"] == :vz
+    @test Mera._PLUTO_VARMAP["prs"] == :p
+
+    mktempdir() do d
+        # a minimal 2³ grid.out + dbl.out, parsed without any simulation
+        write(joinpath(d, "grid.out"),
+              "# GEOMETRY:   CARTESIAN\n2\n 1 0.0 0.5\n 2 0.5 1.0\n" *
+              "2\n 1 0.0 0.5\n 2 0.5 1.0\n2\n 1 0.0 0.5\n 2 0.5 1.0\n")
+        geo, n, xc = Mera._pluto_read_grid(joinpath(d, "grid.out"))
+        @test geo == "CARTESIAN" && n == (2, 2, 2)
+        @test xc[1] ≈ [0.25, 0.75]                     # cell centres
+        write(joinpath(d, "dbl.out"),
+              "0 0.0 1e-9 0 single_file little rho vx1 vx2 vx3 prs\n" *
+              "1 0.5 1e-3 9 single_file little rho vx1 vx2 vx3 prs\n")
+        t, ftype, endian, vars = Mera._pluto_read_varfile(joinpath(d, "dbl.out"), 1)
+        @test t == 0.5 && ftype == "single_file" && endian == "little"
+        @test vars == ["rho", "vx1", "vx2", "vx3", "prs"]
+        @test_throws ErrorException Mera._pluto_read_varfile(joinpath(d, "dbl.out"), 99)
+
+        # the code detector recognises a PLUTO directory by grid.out + dbl.out
+        @test Mera.detect_simcode(d) == :pluto
+        @test Mera.detect_simcode(mktempdir()) == :ramses     # no signature → RAMSES default
+    end
+end
+
+# ------------------------------------------------------------------ PART B
+if DATA_AVAILABLE && isdir(PL_PATH)
+    @testset "unified getinfo auto-detects + branches" begin
+        # the normal getinfo entry point detects PLUTO and stores simcode
+        info = getinfo(5, PL_PATH; verbose=false)
+        @test info.simcode == "PLUTO"
+        @test getinfo(5, PL_PATH; code=:pluto, verbose=false).simcode == "PLUTO"   # explicit
+        # gethydro(info) branches on simcode → the PLUTO frontend, code-blind downstream
+        g = gethydro(info, verbose=false)
+        @test g isa Mera.HydroDataType && length(g.data) == 64^3
+    end
+
+    @testset "load PLUTO into standard Mera structs" begin
+        info = getinfo_pluto(5, PL_PATH; verbose=false)
+        @test info isa Mera.InfoType
+        @test info.simcode == "PLUTO"
+        @test info.ndim == 3
+        @test info.levelmin == info.levelmax == 6           # 64³ = 2^6 uniform grid
+        @test info.boxlen ≈ 1.0
+        @test info.variable_list == [:rho, :vx, :vy, :vz, :p]
+        @test info.scale isa Mera.ScalesType003             # createscales! ran
+
+        g = gethydro_pluto(info; verbose=false)
+        @test g isa Mera.HydroDataType
+        @test length(g.data) == 64^3
+        @test extrema(Mera.select(g.data, :cx)) == (1, 64)  # 1-based integer cell coords
+        # the RAMSES coordinate convention must hold for the analysis to be correct:
+        @test getvar(g, :cellsize)[1] ≈ g.boxlen / 2^g.lmin ≈ 1/64
+    end
+
+    @testset "analysis layer works UNCHANGED on PLUTO data" begin
+        g = gethydro_pluto(getinfo_pluto(5, PL_PATH; verbose=false); verbose=false)
+        @test msum(g) > 0                                   # a sensible total
+        @test maximum(getvar(g, :rho)) > minimum(getvar(g, :rho))   # the blast evolved
+        pr = projection(g, :rho, verbose=false, show_progress=false)
+        @test size(pr.maps[:rho]) == (64, 64) && sum(pr.maps[:rho]) > 0
+        P = pdf(g, :rho; bins=20)                           # density PDF on PLUTO data
+        @test length(P.centers) == 20
+        @test sum(P.pdf .* diff(log10.(P.edges))) ≈ 1 rtol=1e-6
+    end
+
+    @testset "coordinate mapping matches the raw file (no transpose)" begin
+        g = gethydro_pluto(getinfo_pluto(5, PL_PATH; verbose=false); verbose=false)
+        rho = getvar(g, :rho); i = argmax(rho)
+        peak = (Mera.select(g.data,:cx)[i], Mera.select(g.data,:cy)[i], Mera.select(g.data,:cz)[i])
+        # cross-check against the raw .dbl read directly (x1 fastest, C order)
+        raw = Vector{Float64}(undef, 64^3)
+        read!(joinpath(PL_PATH, "data.0005.dbl"), raw)      # first block = rho
+        kmax = argmax(@view raw[1:64^3])
+        i1 = (kmax-1) % 64 + 1; i2 = (kmax-1) ÷ 64 % 64 + 1; i3 = (kmax-1) ÷ 64^2 + 1
+        @test peak == (i1, i2, i3)
+    end
+else
+    @testset "PLUTO reader data-backed (skipped: pluto_sedov3d unavailable)" begin
+        @test_skip "pluto_sedov3d not found under SIMULATION_PATH"
+    end
+end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -112,6 +112,7 @@ if isempty(_focus)
         include("49_statistics_tests.jl")            # pdf (probability distribution functions): data-free weighted-histogram kernel + spiral_clumps density PDF (mass vs volume)
         include("50_provenance_tests.jl")            # provenance / provenance_string: data-free struct+string + spiral_clumps snapshot/projection extraction
         include("51_movie_tests.jl")                 # getmovie / savemovie: data-free colormaps/struct + 3D Sedov frames → single-GIF round-trip
+        include("52_pluto_reader_tests.jl")          # PLUTO code frontend (multi-code reader): data-free format parsers + 3D Sedov fixture; analysis layer runs unchanged
         include("07_regions.jl")
     end
 

--- a/test/test_config.jl
+++ b/test/test_config.jl
@@ -151,6 +151,19 @@ const DATASETS = Dict(
         has_clumps = false,
         is_timeseries = true
     ),
+    # PLUTO code frontend fixture — 3-D Cartesian uniform-grid Sedov blast (64³, 6 outputs),
+    # generated from PLUTO's HD/Sedov 3D test (static .dbl + grid.out + dbl.out). Exercises
+    # the multi-code reader: getinfo_pluto/gethydro_pluto fill the standard structs so the
+    # analysis layer (getvar/projection/pdf) runs unchanged. (52_pluto_reader_tests.jl)
+    :pluto_sedov3d => (
+        path = joinpath(SIMULATION_PATH, "pluto_sedov3d"),
+        output = 5,
+        has_hydro = true,
+        has_gravity = false,
+        has_particles = false,
+        has_clumps = false,
+        simcode = "PLUTO"
+    ),
 )
 
 # Test tolerances


### PR DESCRIPTION
**First non-RAMSES code reader** — proves Mera's multi-code architecture works: a PLUTO frontend fills the existing `InfoType`/`HydroDataType` structs, so `getvar`/`projection`/`pdf`/`timeseries` run on PLUTO data with **zero analysis-layer changes**.

## What
- `src/read_data/PLUTO/reader_pluto.jl` — `getinfo_pluto` + `gethydro_pluto` read PLUTO static-grid output (`grid.out` + `dbl.out` + `data.NNNN.dbl`, single-file f8) into a uniform-grid `HydroDataType` (`:cx,:cy,:cz, :rho,:vx,:vy,:vz,:p`). Format taken from PLUTO's own `pyPLUTO`.
- **v1 scope**: 3-D Cartesian uniform grid, power-of-two cells/axis (→ `level = log2(n)`), code units.

## Code detection (answers "does getinfo detect/store/print the code?")
- `detect_simcode` sniffs `grid.out`+`dbl.out` (PLUTO) vs RAMSES.
- `getinfo` gains `code=:auto/:ramses/:pluto` and delegates; `simcode` is **stored** in `InfoType` and **printed** (`Code: PLUTO`).
- `gethydro(info)` branches on `simcode`. So the normal `info = getinfo(5, path); gas = gethydro(info)` *just works* on PLUTO. RAMSES path unchanged (the default).

## Validated against pyPLUTO
Density peak `(30,28,29)` and values match cell-for-cell; `cellsize = boxlen/2^level` confirms the coordinate convention; `projection`/`pdf`/`msum` give sensible results on real PLUTO data.

## Fixture / tests / docs
- `pluto_sedov3d` (64³ Cartesian Sedov, 6 outputs) compiled+run from PLUTO's HD/Sedov 3D test — yt's only PLUTO sample is 2-D Chombo-AMR (unusable for 3-D Mera). Regeneration recipe kept privately in `docs/dev`.
- `test/52` (32): data-free format parsers + detector + the 3-D fixture (unified auto-detect, coordinate-match-vs-raw, analysis-unchanged).
- `docs/src/pluto_reader.md` (Data & Visualization → Other Codes).
