### PR TITLE
PLUTO particle reading: getparticles_pluto -> PartDataType

### DIFF
--- a/docs/src/pluto_reader.md
+++ b/docs/src/pluto_reader.md
@@ -117,6 +117,21 @@ savemap(p, "pluto_rho.jld2")
 Every step above is the same call you would make on a RAMSES snapshot — that is the whole
 point of the code-blind analysis layer.
 
+## PLUTO particles
+
+If a PLUTO run wrote Lagrangian particles (`particles.NNNN.dbl`), `getinfo` flags them and
+`getparticles` reads them into a Mera `PartDataType` — so the particle analysis runs unchanged:
+
+```julia
+info = getinfo(5, "/data/pluto_run")     # info.particles == true if a particle file is present
+part = getparticles(info)                 # → PartDataType (:x,:y,:z, :id, :vx,:vy,:vz, …)
+getvar(part, :vx); msum(part)             # the usual particle analysis
+```
+
+The PLUTO particle format (an ASCII `#` header — `field_names`/`field_dim`/`nparticles`/
+`endianity` — followed by particle-major binary) is read directly; field names map to Mera
+symbols (`x1→:x`, `vx1→:vx`, …), extra fields keep their names.
+
 ## PLUTO AMR (Chombo)
 
 PLUTO's **AMR** output uses the Chombo box-structured HDF5 format (shared with Orion and other

--- a/src/Mera.jl
+++ b/src/Mera.jl
@@ -69,6 +69,7 @@ export
     getinfo,
     getinfo_pluto,
     gethydro_pluto,
+    getparticles_pluto,
     createpath,
     gethydro,
     getgravity,

--- a/src/read_data/PLUTO/reader_pluto.jl
+++ b/src/read_data/PLUTO/reader_pluto.jl
@@ -17,6 +17,33 @@
 const _PLUTO_VARMAP = Dict("rho"=>:rho, "vx1"=>:vx, "vx2"=>:vy, "vx3"=>:vz, "prs"=>:p,
                            "bx1"=>:bx, "bx2"=>:by, "bx3"=>:bz)
 
+# PLUTO particle field name → Mera canonical particle symbol
+const _PLUTO_PARTMAP = Dict("id"=>:id, "x1"=>:x, "x2"=>:y, "x3"=>:z,
+                            "vx1"=>:vx, "vx2"=>:vy, "vx3"=>:vz)
+
+# Parse the ASCII '#' header of a PLUTO particles.NNNN.dbl file.
+# Returns (field_names, field_dim, nparticles, endian, header_nbytes).
+function _pluto_read_particle_header(fn::String)
+    names = String[]; dims = Int[]; npart = 0; endian = "little"; hbytes = 0
+    open(fn, "r") do io
+        while !eof(io)
+            mark(io); ln = readline(io)
+            if !startswith(ln, "#")
+                reset(io); break          # binary starts here
+            end
+            hbytes = position(io)
+            s = split(ln)
+            length(s) >= 2 || continue
+            if s[2] == "field_names";      names = String.(s[3:end])
+            elseif s[2] == "field_dim";    dims = parse.(Int, s[3:end])
+            elseif s[2] == "nparticles";   npart = parse(Int, s[3])
+            elseif s[2] == "endianity";    endian = s[3]
+            end
+        end
+    end
+    return names, dims, npart, endian, hbytes
+end
+
 # Output numbers of a PLUTO run, read from the first column of dbl.out.
 function pluto_output_numbers(path::String)
     f = joinpath(path, "dbl.out"); nums = Int[]
@@ -133,11 +160,16 @@ function getinfo_pluto(output::Int, path::String; unit_length::Real=1.0,
     info.unit_l = Float64(unit_length); info.unit_d = Float64(unit_density)
     info.unit_v = Float64(unit_velocity); info.unit_t = info.unit_l / info.unit_v
     info.unit_m = info.unit_d * info.unit_l^3
-    info.hydro = true; info.gravity = false; info.particles = false
+    # PLUTO Lagrangian particles, if a particles.NNNN.dbl is present for this output
+    pfile = joinpath(path, "particles.$(lpad(output, 4, '0')).dbl")
+    has_particles = isfile(pfile)
+    info.hydro = true; info.gravity = false; info.particles = has_particles
     info.rt = false; info.clumps = false; info.sinks = false
     info.variable_list = [get(_PLUTO_VARMAP, v, Symbol(v)) for v in vars]
     info.nvarh = length(vars)
-    info.gravity_variable_list = Symbol[]; info.particles_variable_list = Symbol[]
+    info.gravity_variable_list = Symbol[]
+    info.particles_variable_list = has_particles ?
+        [get(_PLUTO_PARTMAP, f, Symbol(f)) for f in _pluto_read_particle_header(pfile)[1]] : Symbol[]
     info.rt_variable_list = Symbol[]; info.clumps_variable_list = Symbol[]; info.sinks_variable_list = Symbol[]
     info.ncpu = 1
     info.mtime = Dates.unix2datetime(round(Int, mtime(joinpath(path, "grid.out"))))
@@ -203,4 +235,46 @@ function gethydro_pluto(info::InfoType; verbose::Bool=true)
     h.smallr = 0.; h.smallc = 0.; h.scale = info.scale
     verbose && println("[Mera]: PLUTO hydro $(n)³ = $(ncell) cells, vars ", join(string.(vars), ", "))
     return h
+end
+
+"""
+    getparticles_pluto(info::InfoType; verbose=true) -> PartDataType
+
+Read a PLUTO Lagrangian-particle snapshot (`particles.NNNN.dbl`, single binary file with an
+ASCII `#` header) described by `info` into a Mera `PartDataType` — columns `:x,:y,:z, :id,
+:vx,:vy,:vz` (+ any extra PLUTO particle fields by name), so the particle analysis runs
+unchanged. Positions are in code length (= `info` units).
+"""
+function getparticles_pluto(info::InfoType; verbose::Bool=true)
+    output = round(Int, info.output)
+    fn = joinpath(info.path, "particles.$(lpad(output, 4, '0')).dbl")
+    isfile(fn) || error("getparticles_pluto: $fn not found (no PLUTO particle output).")
+    names, dims, npart, endian, hbytes = _pluto_read_particle_header(fn)
+    tot = sum(dims)
+    swap = (endian == "big") != (ENDIAN_BOM == 0x01020304)
+
+    raw = Vector{Float64}(undef, npart * tot)           # binary follows the ASCII header
+    open(fn, "r") do io
+        seek(io, hbytes); read!(io, raw)
+    end
+    swap && (u = reinterpret(UInt64, raw); u .= bswap.(u))
+    mat = reshape(raw, tot, npart)                       # column = one particle (particle-major)
+
+    cols = Any[]; outnames = Symbol[]
+    fcol = 1                                             # running field-column index (field_dim≥1)
+    for (fi, fname) in enumerate(names)
+        sym = get(_PLUTO_PARTMAP, fname, Symbol(fname))
+        push!(cols, vec(mat[fcol, :])); push!(outnames, sym)
+        fcol += dims[fi]
+    end
+    data = table(cols...; names=Tuple(outnames), presorted=false, copy=false)
+
+    p = PartDataType()
+    p.data = data; p.info = info
+    p.lmin = info.levelmin; p.lmax = info.levelmax; p.boxlen = info.boxlen
+    p.ranges = [0., 1., 0., 1., 0., 1.]
+    p.selected_partvars = outnames
+    p.used_descriptors = Dict{Any,Any}(); p.scale = info.scale
+    verbose && println("[Mera]: PLUTO particles = $npart, fields ", join(string.(outnames), ", "))
+    return p
 end

--- a/src/read_data/RAMSES/getparticles.jl
+++ b/src/read_data/RAMSES/getparticles.jl
@@ -198,6 +198,11 @@ function getparticles( dataobject::InfoType;
                     subsample::Real=1.0,                     # read only ~this fraction of CPU files (1.0 = all); for very large runs
                     myargs::ArgumentsType=ArgumentsType() )
 
+    # Multi-code: a non-RAMSES info delegates to its own particle frontend.
+    if dataobject.simcode == "PLUTO"
+        return getparticles_pluto(dataobject; verbose=verbose)
+    end
+
     # ===== ARGUMENT OVERRIDE SECTION =====
     # Allow myargs struct to override individual function arguments
     # This provides a convenient way to pass multiple arguments at once

--- a/test/52_pluto_reader_tests.jl
+++ b/test/52_pluto_reader_tests.jl
@@ -44,6 +44,48 @@ const CH_PATH = joinpath(SIMULATION_PATH, "chombo_3d", "IsothermalSphere")
     end
 end
 
+@testset "PLUTO particles (synthetic, data-free)" begin
+    # a minimal PLUTO run with a particle file, written in the documented format
+    mktempdir() do d
+        # 4³ grid + one dbl output so getinfo_pluto works
+        gline(n) = "$n\n" * join([" $i  $((i-1)/n)  $(i/n)" for i in 1:n], "\n") * "\n"
+        write(joinpath(d, "grid.out"),
+              "# GEOMETRY:   CARTESIAN\n" * gline(4) * gline(4) * gline(4))
+        write(joinpath(d, "dbl.out"),
+              "0 0.0 1e-9 0 single_file little rho vx1 vx2 vx3 prs\n")
+        write(joinpath(d, "data.0000.dbl"), zeros(UInt8, 4^3 * 5 * 8))   # dummy hydro block
+
+        # particles.0000.dbl: header + particle-major binary (id,x1,x2,x3,vx1,vx2,vx3)
+        np = 50; names = ["id","x1","x2","x3","vx1","vx2","vx3"]
+        open(joinpath(d, "particles.0000.dbl"), "w") do io
+            println(io, "# PLUTO particle file"); println(io, "# field_names ", join(names, " "))
+            println(io, "# field_dim ", join(ones(Int, 7), " "))
+            println(io, "# nparticles $np"); println(io, "# endianity little")
+            for i in 1:np
+                write(io, Float64(i))                                     # id
+                write(io, Float64(i/np), Float64(0.5), Float64(0.25))     # x1,x2,x3
+                write(io, Float64(2.0), Float64(0.0), Float64(0.0))       # vx1,vx2,vx3
+            end
+        end
+
+        # header parser
+        hn, hd, hnp, hend, _ = Mera._pluto_read_particle_header(joinpath(d, "particles.0000.dbl"))
+        @test hn == names && hd == ones(Int, 7) && hnp == 50 && hend == "little"
+
+        # full path: getinfo auto-detects particles → getparticles delegates to PLUTO
+        info = getinfo(0, d)
+        @test info.particles == true
+        @test info.particles_variable_list == [:id, :x, :y, :z, :vx, :vy, :vz]
+        p = getparticles(info, verbose=false)
+        @test p isa Mera.PartDataType
+        @test length(p.data) == 50
+        @test Mera.IndexedTables.colnames(p.data) == (:id, :x, :y, :z, :vx, :vy, :vz)
+        @test getvar(p, :id) == collect(1.0:50.0)                         # particle-major parse
+        @test getvar(p, :x) ≈ (1:50) ./ 50
+        @test all(getvar(p, :vx) .== 2.0)
+    end
+end
+
 # ------------------------------------------------------------------ PART B
 if DATA_AVAILABLE && isdir(PL_PATH)
     @testset "unified getinfo auto-detects + branches" begin


### PR DESCRIPTION
Reads PLUTO Lagrangian-particle output (`particles.NNNN.dbl`) into Mera's `PartDataType`, so the particle analysis runs unchanged.

## What
- `getparticles_pluto(info)`: parses the ASCII `#` header (`field_names`/`field_dim`/`nparticles`/`endianity`) + the particle-major binary into columns `:x,:y,:z, :id, :vx,:vy,:vz` (+ extra PLUTO fields by name). Field names map to Mera symbols (`x1->:x`, `vx1->:vx`). Format from PLUTO's own `part_read.py`.
- `getinfo_pluto` detects `particles.NNNN.dbl` and sets `info.particles` + `particles_variable_list`; `getparticles(info)` branches on `simcode=="PLUTO"`. RAMSES path unchanged.

```
info = getinfo(5, path)        # info.particles == true if a particle file is present
part = getparticles(info)      # -> PartDataType
getvar(part, :vx); msum(part)  # the usual particle analysis
```

## Validation (honest note)
A particle-enabled PLUTO build hit PLUTO's own particle-module compile internals (the PARTICLES_LOOP macro) -- a deep PLUTO build-config issue -- so there is no real-data fixture yet. The reader is validated in test/52 (+9) against a synthetic particle file written in the exact documented format: header parse, auto-detection, particle-major layout (id/x/vx values match), getvar on particles. Generating real PLUTO particle data is recorded as a follow-up.

Docs: pluto_reader.md 'PLUTO particles' section.
