### PR TITLE
docs: dedicated docstrings for loadcube and verbose

### DIFF
--- a/src/functions/checks.jl
+++ b/src/functions/checks.jl
@@ -52,6 +52,22 @@ function checkverbose(verbose::Bool)
     return verbose
 end
 
+"""
+    verbose(mode::Union{Bool,Nothing})
+    verbose()
+
+Set or show the global verbose mode for all subsequent Mera operations. `verbose(false)`
+silences Mera's text messages, `verbose(true)` forces them on (the per-function `verbose=`
+argument is then ignored), and `verbose(nothing)` reverts to each function's own argument
+(the neutral default). `verbose()` with no argument prints the current state. See also
+[`showprogress`](@ref) and the combined master switch [`output_mode`](@ref).
+
+```julia
+verbose(false)    # quiet
+verbose()         # prints "verbose_mode: false"
+verbose(nothing)  # back to per-function control
+```
+"""
 function verbose(mode::Union{Bool,Nothing})
         global verbose_mode = mode
         @eval(Mera, verbose_mode)

--- a/src/functions/projection/projection.jl
+++ b/src/functions/projection/projection.jl
@@ -1104,6 +1104,14 @@ function savecube(c::LosCubeType, filename::AbstractString; verbose::Bool=true)
     verbose && println("Saved LOS cube $(size(c.cube)) → ", fn)
     return fn
 end
+
+"""
+    loadcube(filename; verbose=true) -> LosCubeType
+
+Load a LOS / velocity cube saved with [`savecube`](@ref) from a JLD2 file (the `.jld2`
+extension is added if missing). The cube, its axes, the binned quantity/units, the camera
+basis and the simulation `info` all round-trip, and the reconstructed cube is validated.
+"""
 function loadcube(filename::AbstractString; verbose::Bool=true)
     fn = endswith(filename, ".jld2") ? filename : filename * ".jld2"
     c = JLD2.load(fn, "loscube")


### PR DESCRIPTION
`loadcube` and `verbose` had no directly-attached docstrings (their text lived in `savecube`'s combined docstring / the switches page), so Documenter's `@autodocs` warned 'No docstring found in doc for binding' (10 warnings). 

Adds a docstring to `loadcube` (mirroring the `loadmap` fix) and to `verbose` (covering the setter + the no-arg query, cross-referencing `showprogress`/`output_mode`). All 10 remaining no-docstring autodoc warnings are now cleared; the full docs build is clean.