### PR TITLE
feat: variable (per-cell) opacity in absorption_map + dust_opacity(λ) helper

### DIFF
--- a/docs/src/overlay_absorption.md
+++ b/docs/src/overlay_absorption.md
@@ -45,9 +45,42 @@ a = absorption_map(gas; kappa=50.0)         # κ = 50 cm²/g (grey/dust-like opa
 a = absorption_map(gas; kappa=50.0, los=fr.los, up=fr.up, center=fr.center)   # off-axis
 ```
 
-`kappa` is a constant (grey) opacity in units inverse to `sd_unit` (default `:g_cm2`, so `κ`
-is in cm²/g and `τ` is dimensionless). All [`projection`](@ref) view/region keywords pass
-through. Returns `(tau, transmission, absorbed, sd, extent, los, up, center, pixsize, info)`.
+`kappa` is in units inverse to `sd_unit` (default `:g_cm2`, so `κ` is in cm²/g and `τ` is
+dimensionless). All [`projection`](@ref) view/region keywords pass through. Returns
+`(tau, transmission, absorbed, sd, kappa_eff, extent, los, up, center, pixsize, info)` (`kappa_eff`
+is the column-effective opacity `τ/Σ`).
+
+### Variable opacity — `κ` that depends on physics
+
+The opacity is rarely truly grey. `kappa` may instead be **per-cell**, so it can depend on
+wavelength, metallicity, gas phase, temperature or ionization. The optical depth is then the exact
+`τ = ∫κρ dl = ⟨κ⟩_mass·Σ`:
+
+* a **`Real`** → grey (above);
+* a **`Symbol`** → a per-cell opacity *field* — any [`getvar`](@ref) field, an [`add_field`](@ref)-
+  registered field, or a raw data column (e.g. a stored metallicity);
+* an **`AbstractVector`** → a per-cell opacity (one value per cell), in `kappa_unit` (default cm²/g).
+
+```julia
+# wavelength: a Milky-Way dust opacity per gram of gas (see dust_opacity)
+a = absorption_map(gas; kappa = dust_opacity(0.55))             # V band ≈ 210 cm²/g
+
+# metallicity-dependent dust, per cell, with a hot-gas (dust-sublimation) cutoff
+κcell = dust_opacity(0.44) .* getvar(gas,:metals)./0.0134 .* (getvar(gas,:T,:K) .< 1500)
+a = absorption_map(gas; kappa = κcell, los=fr.los, up=fr.up, center=fr.center)
+
+# phase-specific: only one phase absorbs (a registered field or a raw column)
+a = absorption_map(gas; kappa = :my_kappa_field)
+```
+
+[`dust_opacity(λ_μm; kappa_V=210, Z_over_Zsun=1, beta=1.8)`](@ref) returns an approximate MW
+(R_V≈3.1) dust opacity per gram of *gas* at wavelength `λ`, scaling linearly with metallicity — a
+convenient way to pick a grey `κ` per band, or to build a per-cell `κ` (multiply by a metallicity
+field). It is approximate (one scaled MW curve), not a dust radiative-transfer code.
+
+What `κ` *physically* is — dust extinction (∝ metallicity/dust-to-gas, strongly λ-dependent),
+electron (Thomson) scattering (≈0.4 cm²/g, ionized gas), or line/continuum opacity — is your choice;
+pick the `κ` (scalar, field, or vector) that matches the source and band.
 
 !!! note "Physical units"
     `τ` is meaningful only when the data have physical units — true for RAMSES, and for PLUTO

--- a/src/Mera.jl
+++ b/src/Mera.jl
@@ -114,6 +114,7 @@ export
     gridoverlay,
     gridoverlay!,
     absorption_map,
+    dust_opacity,
     pdf,
     provenance,
     provenance_string,

--- a/src/functions/absorption.jl
+++ b/src/functions/absorption.jl
@@ -2,46 +2,137 @@
 # absorption_map — line-of-sight optical depth & transmission (continuum absorption)
 #
 #   absorption_map(data; kappa, sd_unit=:g_cm2, <projection view kwargs>)
-#       -> (tau, transmission, absorbed, sd, extent, los, up, center, pixsize, info)
+#       -> (tau, transmission, absorbed, sd, kappa_eff, extent, los, up, center, pixsize, info)
 #
-# The absorption analogue of `emission_map`: project the column density Σρ dl with Mera's
-# exact off-axis projection, then τ = κ·Σ and transmission = e^−τ. Constant (grey) opacity κ
-# in units inverse to `sd_unit` (e.g. cm²/g for the default g/cm²) — dust extinction, Thomson
-# scattering, a continuum cross-section, …
+# The absorption analogue of `emission_map`. The optical depth along a ray is τ = ∫ κ ρ dl.
+#   • grey (constant) opacity  κ        → τ = κ · Σ            (Σ = ∫ρ dl, the column density)
+#   • per-cell opacity κ(cell)          → τ = ⟨κ⟩_mass · Σ      (exact: ⟨κ⟩_mass·Σ = ∫κρ dl)
+# so a spatially varying opacity (metallicity-, phase-, temperature-, ionization-dependent, or
+# a wavelength chosen from `dust_opacity`) is handled by Mera's exact off-axis projection.
 # ====================================================================================
 
+# Representative Milky-Way (R_V = 3.1) extinction curve A_λ/A_V at a few wavelengths [μm].
+# Approximate (includes the rough 2175 Å bump); for precise work pass your own κ(λ).
+const _MW_ALAW = (
+    [0.15, 0.20, 0.22, 0.27, 0.36, 0.44, 0.55, 0.66, 0.81, 1.25, 1.65, 2.20],   # λ [μm]
+    [2.65, 1.90, 2.85, 2.00, 1.57, 1.32, 1.00, 0.75, 0.59, 0.29, 0.18, 0.12],   # A_λ/A_V
+)
+
 """
-    absorption_map(dataobject; kappa, sd_unit=:g_cm2, verbose=true, <projection view kwargs>)
-        -> NamedTuple
+    dust_opacity(wavelength_um; kappa_V=210.0, Z_over_Zsun=1.0, beta=1.8) -> Float64
 
-Continuum **absorption** map along the line of sight. Projects the column (surface) density
-with [`projection`](@ref) (the exact off-axis engine) and returns the **optical depth**
-`τ = κ · Σ`, the **transmission** `e^{-τ}`, and the **absorbed fraction** `1 - e^{-τ}`.
+Approximate **dust opacity per gram of gas** `κ(λ)` [cm²/g] for a Milky-Way (R_V≈3.1) extinction
+curve, for use as the `kappa` of [`absorption_map`](@ref). Returns `κ_V · (A_λ/A_V) · Z_over_Zsun`,
+where `A_λ/A_V` is interpolated (log–log) from a representative MW curve for `0.15 ≤ λ ≤ 2.2 μm` and
+extended into the IR as a `λ^{-beta}` power law beyond 2.2 μm.
 
-`kappa` is a constant (grey) opacity in units inverse to `sd_unit` — e.g. `cm²/g` for the
-default `sd_unit=:g_cm2` (so `τ` is dimensionless). All [`projection`](@ref) view/region
-keywords pass through (`los`/`up`, `direction`, `inclination`/`azimuth`, `center`,
-`range_unit`, `xrange`/…, `res`, `lmax`).
-
-Returns `(tau, transmission, absorbed, sd, sd_unit, extent, los, up, center, pixsize, info)`.
+* `kappa_V` — V-band opacity per gram of *gas* (default 210 cm²/g, i.e. `A_V/N_H≈5.3e-22` mag cm²
+  with μ≈1.4); this is why the old grey default `κ≈200` was "dust-like".
+* `Z_over_Zsun` — linear metallicity (dust-to-gas) scaling of the dust opacity.
+* `beta` — IR emissivity index for the `λ > 2.2 μm` extrapolation.
 
 ```julia
-a = absorption_map(gas; kappa=200.0)                # κ = 200 cm²/g (dust-like)
-# heatmap of a.transmission over a.extent  → a mock extinction / silhouette image
-a = absorption_map(gas; kappa=200.0, los=fr.los, up=fr.up, center=fr.center)   # off-axis
+κ = dust_opacity(0.55)              # V band ≈ 210 cm²/g
+κ = dust_opacity(0.15; Z_over_Zsun=0.3)   # FUV, metal-poor
+a = absorption_map(gas; kappa=κ)   # grey at that wavelength
 ```
 
-For a velocity-resolved absorption-line spectrum along a sightline, build a
-[`velocity_cube`](@ref) and combine with this τ (a light-ray spectrograph is planned).
-See also [`emission_map`](@ref) (the emission counterpart).
+!!! note "Approximate"
+    A single MW curve scaled by metallicity — adequate for mock extinction/silhouette images, not a
+    substitute for a dust radiative-transfer code. For a precise band pass your own `κ`.
 """
-function absorption_map(dataobject; kappa::Real, sd_unit::Symbol=:g_cm2,
-                        verbose::Bool=true, kwargs...)
-    p = projection(dataobject, :sd, sd_unit; verbose=verbose, show_progress=false, kwargs...)
+function dust_opacity(wavelength_um::Real; kappa_V::Real=210.0, Z_over_Zsun::Real=1.0, beta::Real=1.8)
+    λ = Float64(wavelength_um); λs, rs = _MW_ALAW
+    λ > 0 || throw(ArgumentError("wavelength_um must be > 0"))
+    if λ <= λs[1]
+        ratio = rs[1]                                            # flat below the bluest tabulated point
+    elseif λ >= λs[end]
+        ratio = rs[end] * (λs[end] / λ)^beta                    # IR power-law tail
+    else
+        i = searchsortedlast(λs, λ)                             # log–log interpolation in the table
+        t = (log(λ) - log(λs[i])) / (log(λs[i+1]) - log(λs[i]))
+        ratio = exp((1-t)*log(rs[i]) + t*log(rs[i+1]))
+    end
+    return kappa_V * ratio * Z_over_Zsun
+end
+
+"""
+    absorption_map(dataobject; kappa, sd_unit=:g_cm2, kappa_unit=:standard, verbose=true,
+                   <projection view kwargs>) -> NamedTuple
+
+Continuum **absorption** map along the line of sight. Returns the **optical depth** `τ = ∫κρ dl`,
+the **transmission** `e^{-τ}`, the **absorbed fraction** `1 - e^{-τ}`, the column density `sd`, and
+the column-effective opacity `kappa_eff` (= `τ/Σ`).
+
+`kappa` sets the opacity and may be
+
+* a **`Real`** — a constant (grey) opacity, `τ = κ·Σ` (e.g. `kappa=dust_opacity(0.55)`);
+* a **`Symbol`** — a per-cell opacity *field*: any [`getvar`](@ref) field, an [`add_field`](@ref)-
+  registered field, or a raw data column (e.g. a stored metallicity). `τ = ⟨κ⟩_mass·Σ`, which is
+  **exactly** `∫κρ dl`;
+* an **`AbstractVector`** — a per-cell opacity, one value per cell (full data length), in `kappa_unit`.
+
+So the opacity can depend on metallicity, gas phase, temperature or ionization (build the per-cell
+`κ` from `getvar`), and on wavelength (via [`dust_opacity`](@ref)). Units: `κ` must be inverse to
+`sd_unit` (cm²/g for the default `sd_unit=:g_cm2`) so `τ` is dimensionless; for a `Symbol`/vector,
+`kappa_unit` is the unit those values are in (default `:standard`, i.e. already cm²/g).
+
+All [`projection`](@ref) view/region keywords pass through (`los`/`up`, `direction`,
+`inclination`/`azimuth`, `center`, `range_unit`, `xrange`/…, `res`, `lmax`).
+
+```julia
+a = absorption_map(gas; kappa=210.0)                         # grey, dust-like
+a = absorption_map(gas; kappa=dust_opacity(0.55))            # grey at V band
+
+# metallicity-dependent dust opacity, per cell (κ ∝ Z, with a temperature dust-sublimation cutoff)
+κcell = dust_opacity(0.55) .* getvar(gas,:metals) ./ 0.0134 .* (getvar(gas,:T,:K) .< 1500.0)
+a = absorption_map(gas; kappa=κcell, los=fr.los, up=fr.up, center=fr.center)
+
+# phase-specific (only molecular gas absorbs) via a registered field, or a raw column
+a = absorption_map(gas; kappa=:my_kappa_field)
+```
+
+Returns `(tau, transmission, absorbed, sd, kappa_eff, sd_unit, extent, los, up, center, pixsize, info)`.
+See also [`emission_map`](@ref) (the emission counterpart) and [`dust_opacity`](@ref).
+"""
+function absorption_map(dataobject; kappa::Union{Real,Symbol,AbstractVector}, sd_unit::Symbol=:g_cm2,
+                        kappa_unit::Symbol=:standard, verbose::Bool=true, kwargs...)
+    p   = projection(dataobject, :sd, sd_unit; verbose=verbose, show_progress=false, kwargs...)
     sd  = p.maps[:sd]
-    tau = kappa .* sd
+    if kappa isa Real
+        kappa_eff = fill(Float64(kappa), size(sd))                    # grey: constant κ everywhere
+    else
+        # per-cell opacity → mass-weighted-mean κ per pixel; ⟨κ⟩_mass·Σ == ∫κρ dl exactly
+        kbar = _kappa_meanmap(dataobject, kappa, kappa_unit; kwargs...)
+        kappa_eff = kbar
+    end
+    tau = kappa_eff .* sd
     T   = exp.(-tau)
-    return (tau = tau, transmission = T, absorbed = 1 .- T, sd = sd, sd_unit = sd_unit,
-            extent = p.extent, los = p.los, up = p.up, center = p.center,
+    return (tau = tau, transmission = T, absorbed = 1 .- T, sd = sd, kappa_eff = kappa_eff,
+            sd_unit = sd_unit, extent = p.extent, los = p.los, up = p.up, center = p.center,
             pixsize = p.pixsize, info = dataobject.info)
+end
+
+# mass-weighted-mean opacity map for a per-cell κ given as a field Symbol or a per-cell vector.
+# A vector is added as a temporary column so it flows through the same projection view, then removed.
+function _kappa_meanmap(dataobject, kappa, kappa_unit::Symbol; kwargs...)
+    if kappa isa Symbol
+        pk = projection(dataobject, kappa, kappa_unit; weighting=[:mass],
+                        verbose=false, show_progress=false, kwargs...)
+        return pk.maps[kappa]
+    end
+    # AbstractVector: must be one value per cell
+    n = length(dataobject.data)
+    length(kappa) == n || throw(ArgumentError(
+        "kappa vector length $(length(kappa)) ≠ number of cells $n"))
+    tmp = :__kappa_abs__
+    saved = dataobject.data
+    try
+        dataobject.data = Mera.IndexedTables.pushcol(saved, tmp, Float64.(collect(kappa)))
+        pk = projection(dataobject, tmp, kappa_unit; weighting=[:mass],
+                        verbose=false, show_progress=false, kwargs...)
+        return pk.maps[tmp]
+    finally
+        dataobject.data = saved                                       # restore the user's table
+    end
 end

--- a/test/53_overlay_absorption_tests.jl
+++ b/test/53_overlay_absorption_tests.jl
@@ -49,6 +49,38 @@ if DATA_AVAILABLE && isdir(OA_PATH)
         fr = face_on(g)
         af = absorption_map(g; kappa=200.0, los=fr.los, up=fr.up, center=fr.center, verbose=false)
         @test maximum(af.tau) > 0
+        @test all(a.kappa_eff .== 200.0)                         # grey ⇒ uniform effective opacity
+    end
+
+    @testset "absorption_map: per-cell opacity (variable coefficients)" begin
+        # a CONSTANT per-cell vector must reproduce the grey result exactly — this pins the
+        # τ = ⟨κ⟩_mass·Σ = ∫κρ dl identity used for spatially varying opacity.
+        a  = absorption_map(g; kappa=200.0, verbose=false)
+        ncol = length(Mera.IndexedTables.colnames(g.data))
+        av = absorption_map(g; kappa=fill(200.0, length(g.data)), verbose=false)
+        @test all(isapprox.(av.tau, a.tau; rtol=1e-8))
+        @test all(av.kappa_eff .≈ 200.0)
+        # the temporary opacity column is removed afterwards (no leak)
+        @test length(Mera.IndexedTables.colnames(g.data)) == ncol
+        @test !(:__kappa_abs__ in Mera.IndexedTables.colnames(g.data))
+        # length guard
+        @test_throws ArgumentError absorption_map(g; kappa=[1.0,2.0], verbose=false)
+        # a genuinely varying κ gives a non-uniform kappa_eff and still finite, non-negative τ
+        kc = 200.0 .* (getvar(g,:rho,:nH) ./ 0.1)
+        av2 = absorption_map(g; kappa=kc, verbose=false)
+        @test all(isfinite, av2.tau) && all(av2.tau .>= 0)
+        @test maximum(av2.kappa_eff) > minimum(av2.kappa_eff)
+        # Symbol field path (mass-weighted κ map) runs and is finite
+        as = absorption_map(g; kappa=:rho, kappa_unit=:nH, verbose=false)
+        @test all(isfinite, as.kappa_eff)
+    end
+
+    @testset "dust_opacity wavelength helper" begin
+        @test isapprox(dust_opacity(0.55), 210.0; rtol=1e-9)         # V band anchor
+        @test dust_opacity(0.15) > dust_opacity(0.55) > dust_opacity(2.2)   # rises to the blue
+        @test isapprox(dust_opacity(0.55; Z_over_Zsun=0.5), 105.0; rtol=1e-9)  # linear in Z
+        @test dust_opacity(100.0) < dust_opacity(2.2)               # IR power-law tail falls
+        @test_throws ArgumentError dust_opacity(-1.0)
     end
 else
     @testset "overlay/absorption (skipped: spiral_clumps unavailable)" begin


### PR DESCRIPTION
## Summary

Makes the absorption coefficient in `absorption_map` **physics-dependent** instead of a single grey number, and adds a wavelength→opacity helper. The optical depth is the exact `τ = ∫κρ dl`.

## `absorption_map` — `kappa` can now be

| `kappa` | meaning |
|---|---|
| `Real` | grey opacity, `τ = κ·Σ` (unchanged) |
| `Symbol` | a per-cell opacity **field** — any `getvar` field, an `add_field`-registered field, or a raw data column (e.g. stored metallicity). `τ = ⟨κ⟩_mass·Σ`, which equals `∫κρ dl` exactly |
| `AbstractVector` | a per-cell opacity (one value per cell), in `kappa_unit` |

So κ can depend on **metallicity / dust-to-gas, gas phase, temperature, ionization** (build it from `getvar`) and on **wavelength**. Now also returns `kappa_eff = τ/Σ` (the column-effective opacity).

Per-cell vectors are projected through the same off-axis view via a temporary column that is removed afterwards (try/finally — no leak).

## `dust_opacity(λ_μm; kappa_V=210, Z_over_Zsun=1, beta=1.8)` (new)

Approximate Milky-Way (R_V≈3.1) dust opacity per gram of gas at a wavelength (log–log interpolation of A_λ/A_V, `λ^{-β}` IR tail), scaling linearly with metallicity. Convenient for picking a grey κ per band or building a per-cell κ. Documented as approximate (one scaled MW curve), not a dust-RT code.

## Tests / docs
- Test 53: a constant per-cell vector reproduces the grey result exactly (pins the `⟨κ⟩_mass·Σ = ∫κρ dl` identity), temp-column restoration + length guard, varying-κ `kappa_eff` spread, Symbol path, and `dust_opacity` anchors/scaling. 32/32 green.
- `overlay_absorption.md`: new "Variable opacity" section. Documenter build verified clean (`dust_opacity` renders; no broken refs).
