### PR TITLE
regions: composable region value types + exact edge-cell splitting (Phase 1)

### DIFF
--- a/docs/src/api/subregions.md
+++ b/docs/src/api/subregions.md
@@ -70,6 +70,30 @@ shellregion(data, :sphere, radius=[8., 12.], range_unit=:kpc)
 ### Spherical Parameters
 - **`radius`**: Sphere radius (solid) or `[inner, outer]` (shell)
 
+## Composable regions with exact cell splitting
+
+Alongside the symbol API (`subregion(data, :sphere; …)`), `subregion` accepts a **region value
+type** ([`Sphere`](@ref), [`Cuboid`](@ref), [`Cylinder`](@ref), [`SphericalShell`](@ref)). With
+`split=true` (the default for this form), cells straddling the region boundary are **clipped
+exactly**: each kept cell carries a `:fraction ∈ (0,1]` equal to the volume fraction inside the
+region, and [`getvar`](@ref)`(:mass)` / `(:volume)` / [`msum`](@ref) report the **exact in-region
+totals** — a sphere of radius `R` returns `(4/3)πR³`, with no boundary over- or under-counting.
+
+```julia
+gas_in = subregion(gas, Sphere(20.0; center=[:bc], range_unit=:kpc))   # split=true
+msum(gas_in, :Msol)        # exact enclosed mass (boundary cells weighted by their inside-fraction)
+
+subregion(gas, Cuboid(xrange=[-10,10], yrange=[-10,10], zrange=[-2,2], range_unit=:kpc))
+subregion(gas, SphericalShell(10.0, 20.0; range_unit=:kpc))
+subregion(gas, Cylinder(15.0, 3.0; range_unit=:kpc); split=false)      # classic whole-cell selection
+```
+
+`split=false` reproduces the classic centre-inside, whole-cell selection (no `:fraction`).
+`inverse=true` selects the complement. (Phase 1: hydro; boolean combinators, tilted axes and
+projection-of-split-cells are planned follow-ups.) The region types
+([`AbstractRegion`](@ref), [`Sphere`](@ref), [`Cuboid`](@ref), [`Cylinder`](@ref),
+[`SphericalShell`](@ref)) are listed in the [API reference](../api.md#Types).
+
 ## Additional Analysis Functions
 
 - [`getextent`](@ref) - Get spatial extent information  

--- a/src/Mera.jl
+++ b/src/Mera.jl
@@ -265,6 +265,11 @@ export
     show_threading_info,
     subregion,
     shellregion,
+    AbstractRegion,
+    Sphere,
+    Cylinder,
+    Cuboid,
+    SphericalShell,
 
 # miscellaneous
     viewmodule,
@@ -442,6 +447,7 @@ include("functions/regions/subregion_clumps.jl")
 # Shellregion
 include("functions/regions/shellregion.jl")
 include("functions/regions/shellregion_hydro.jl")
+include("functions/regions/region_algebra.jl")
 include("functions/regions/shellregion_gravity.jl")
 include("functions/regions/shellregion_rt.jl")
 include("functions/regions/shellregion_particles.jl")

--- a/src/functions/getvar/getvar_hydro.jl
+++ b/src/functions/getvar/getvar_hydro.jl
@@ -177,6 +177,9 @@ function get_data(  dataobject::HydroDataType,
                 cellsize_vals = getvar(filtered_dataobject, :cellsize, mask=use_mask_in_recursion)
                 vars_dict[:volume] = convert(Array{Float64,1}, cellsize_vals .^3 .* selected_unit)
             end
+            # exact region splitting (subregion(obj, ::AbstractRegion; split=true)): scale the
+            # occupied volume by the per-cell inside-fraction so totals are exact in-region.
+            in(:fraction, column_names) && (vars_dict[:volume] .*= select(masked_data, :fraction))
 
         elseif i == :jeanslength
             selected_unit = getunit(dataobject, :jeanslength, vars, units)
@@ -221,6 +224,8 @@ function get_data(  dataobject::HydroDataType,
             else # if uniform grid
                 vars_dict[:mass] = select( masked_data, :rho=>p->p * (boxlen / 2^lmax)^3 ) .* selected_unit
             end
+            # exact region splitting: weight by the per-cell inside-fraction (see :volume above)
+            in(:fraction, column_names) && (vars_dict[:mass] .*= select(masked_data, :fraction))
 
         elseif i == :cs
             selected_unit = getunit(dataobject, :cs, vars, units)

--- a/src/functions/regions/region_algebra.jl
+++ b/src/functions/regions/region_algebra.jl
@@ -1,0 +1,157 @@
+# =====================================================================================
+#  region_algebra.jl — composable region value types with EXACT edge-cell splitting
+# -------------------------------------------------------------------------------------
+#  Phase 1 prototype. Adds a value-type region API to `subregion` alongside the existing
+#  `subregion(obj, :sphere; …)` symbol API (which is untouched). A region selects cells
+#  and — with `split=true` (default) — attaches a per-cell `:fraction ∈ (0,1]` giving the
+#  exact volume fraction of the cell inside the region, so `getvar(:mass)`/`:volume`/`msum`
+#  report the exact in-region totals (a sphere of radius R returns (4/3)πR³, no edge
+#  over/under-counting). Boolean combinators, projection integration and tilted axes are
+#  later phases.
+#
+#  Everything works in the normalised [0,1] box frame, matching the existing region filters
+#  (cell centre = cx/2^level, half-size = 0.5/2^level). Physical centre/lengths are converted
+#  to that frame with `prepboxcenter` + the `·getunit/boxlen` rule (identical to `prepranges`).
+# =====================================================================================
+
+"""    AbstractRegion
+
+Supertype of the composable region value types passed to [`subregion`](@ref):
+[`Cuboid`](@ref), [`Sphere`](@ref), [`Cylinder`](@ref), [`SphericalShell`](@ref). A region
+is a geometry-relative-to-`center` value type; `subregion(obj, region)` selects the cells it
+covers and, with `split=true`, attaches the exact per-cell inside-fraction."""
+abstract type AbstractRegion end
+
+"""    Sphere(radius; center=[:bc], range_unit=:kpc)
+
+A ball of `radius` (in `range_unit`) about `center`."""
+struct Sphere <: AbstractRegion
+    radius::Float64; center::Vector{Any}; range_unit::Symbol
+end
+Sphere(radius::Real; center=[:bc], range_unit::Symbol=:kpc) = Sphere(Float64(radius), Vector{Any}(center), range_unit)
+
+"""    SphericalShell(r_in, r_out; center=[:bc], range_unit=:kpc)
+
+The shell `r_in ≤ |r| ≤ r_out` (in `range_unit`) about `center`."""
+struct SphericalShell <: AbstractRegion
+    r_in::Float64; r_out::Float64; center::Vector{Any}; range_unit::Symbol
+end
+SphericalShell(r_in::Real, r_out::Real; center=[:bc], range_unit::Symbol=:kpc) =
+    SphericalShell(Float64(r_in), Float64(r_out), Vector{Any}(center), range_unit)
+
+"""    Cylinder(radius, height; center=[:bc], range_unit=:kpc)
+
+A z-aligned cylinder of cylindrical `radius`, spanning `center_z ± height` (so `height` is the
+half-height, matching the existing `subregion(:cylinder)` convention)."""
+struct Cylinder <: AbstractRegion
+    radius::Float64; height::Float64; center::Vector{Any}; range_unit::Symbol
+end
+Cylinder(radius::Real, height::Real; center=[:bc], range_unit::Symbol=:kpc) =
+    Cylinder(Float64(radius), Float64(height), Vector{Any}(center), range_unit)
+
+"""    Cuboid(; xrange, yrange, zrange, center=[:bc], range_unit=:kpc)
+
+An axis-aligned box; `xrange`/`yrange`/`zrange` are `[lo, hi]` offsets from `center` (in
+`range_unit`), as in `subregion(:cuboid)`."""
+struct Cuboid <: AbstractRegion
+    xrange::Vector{Float64}; yrange::Vector{Float64}; zrange::Vector{Float64}
+    center::Vector{Any}; range_unit::Symbol
+end
+Cuboid(; xrange, yrange, zrange, center=[:bc], range_unit::Symbol=:kpc) =
+    Cuboid(Float64.(xrange), Float64.(yrange), Float64.(zrange), Vector{Any}(center), range_unit)
+
+# physical center (handles :bc) + a length→normalised factor, exactly as prepranges does
+function _norm_frame(obj, center, range_unit)
+    c = prepboxcenter(obj.info, range_unit, center)
+    tonorm(v) = range_unit === :standard ? Float64(v) : Float64(v) * getunit(obj.info, range_unit) / obj.boxlen
+    return Float64[tonorm(c[1]), tonorm(c[2]), tonorm(c[3])], tonorm
+end
+
+# `_prepare(region, obj) -> (cellfrac, contains)` in the normalised frame:
+#   cellfrac(nx,ny,nz,half) -> exact volume fraction of the cell in the region (0..1)
+#   contains(nx,ny,nz)      -> Bool, cell-centre-inside test (for split=false)
+function _prepare(r::Sphere, obj)
+    c, tonorm = _norm_frame(obj, r.center, r.range_unit); R = tonorm(r.radius)
+    inside(x,y,z) = (x-c[1])^2 + (y-c[2])^2 + (z-c[3])^2 <= R*R
+    return ((nx,ny,nz,h) -> _convex_fraction(inside,nx,ny,nz,h)), inside
+end
+function _prepare(r::Cylinder, obj)
+    c, tonorm = _norm_frame(obj, r.center, r.range_unit); R = tonorm(r.radius); H = tonorm(r.height)
+    inside(x,y,z) = (x-c[1])^2 + (y-c[2])^2 <= R*R && abs(z-c[3]) <= H
+    return ((nx,ny,nz,h) -> _convex_fraction(inside,nx,ny,nz,h)), inside
+end
+function _prepare(r::Cuboid, obj)
+    c, tonorm = _norm_frame(obj, r.center, r.range_unit)
+    xlo=c[1]+tonorm(r.xrange[1]); xhi=c[1]+tonorm(r.xrange[2])
+    ylo=c[2]+tonorm(r.yrange[1]); yhi=c[2]+tonorm(r.yrange[2])
+    zlo=c[3]+tonorm(r.zrange[1]); zhi=c[3]+tonorm(r.zrange[2])
+    inside(x,y,z) = xlo<=x<=xhi && ylo<=y<=yhi && zlo<=z<=zhi
+    # axis-aligned ∩ axis-aligned is exact: product of per-axis overlap fractions
+    ov(lo,hi,c0,h) = clamp(min(hi,c0+h) - max(lo,c0-h), 0.0, 2h) / (2h)
+    cellfrac(nx,ny,nz,h) = ov(xlo,xhi,nx,h) * ov(ylo,yhi,ny,h) * ov(zlo,zhi,nz,h)
+    return cellfrac, inside
+end
+function _prepare(r::SphericalShell, obj)
+    cf_out, in_out = _prepare(Sphere(r.r_out; center=r.center, range_unit=r.range_unit), obj)
+    cf_in,  in_in  = _prepare(Sphere(r.r_in;  center=r.center, range_unit=r.range_unit), obj)
+    cellfrac(nx,ny,nz,h) = cf_out(nx,ny,nz,h) - cf_in(nx,ny,nz,h)   # both convex → exact difference
+    contains(x,y,z) = in_out(x,y,z) && !in_in(x,y,z)
+    return cellfrac, contains
+end
+
+# exact-in-the-limit fraction for a CONVEX region: 8 corners + centre fast-path, else n³ sub-sample.
+# (Only boundary cells reach the sub-sample; interior/exterior are O(1).)
+@inline function _convex_fraction(inside, nx, ny, nz, half; n::Int=6)
+    allin = true; allout = true
+    @inbounds for dz in (-half,half), dy in (-half,half), dx in (-half,half)
+        if inside(nx+dx, ny+dy, nz+dz); allout = false; else; allin = false; end
+    end
+    if inside(nx,ny,nz); allout = false; else; allin = false; end
+    allin  && return 1.0
+    allout && return 0.0
+    cnt = 0; step = 2half/n
+    @inbounds for i in 0:n-1, j in 0:n-1, k in 0:n-1
+        inside(nx-half+(i+0.5)*step, ny-half+(j+0.5)*step, nz-half+(k+0.5)*step) && (cnt += 1)
+    end
+    return cnt / (n^3)
+end
+
+"""
+    subregion(obj::HydroDataType, region::AbstractRegion; split=true, inverse=false, verbose=true)
+
+Select the cells covered by a composable `region` ([`Sphere`](@ref), [`Cuboid`](@ref),
+[`Cylinder`](@ref), [`SphericalShell`](@ref)). With `split=true` (default) each kept cell
+carries an exact `:fraction ∈ (0,1]` — the volume fraction inside the region — and
+`getvar(:mass)`/`getvar(:volume)`/`msum` report the **exact in-region totals** (no boundary
+over/under-counting). With `split=false` whole cells are kept by a centre-inside test (the
+classic behaviour) and no `:fraction` is attached. `inverse=true` selects the complement.
+"""
+function subregion(obj::HydroDataType, region::AbstractRegion; split::Bool=true,
+                   inverse::Bool=false, verbose::Bool=true)
+    verbose = checkverbose(verbose)
+    cellfrac, contains = _prepare(region, obj)
+    data = obj.data
+    lvl = IndexedTables.select(data, :level)
+    cxv = IndexedTables.select(data, :cx); cyv = IndexedTables.select(data, :cy); czv = IndexedTables.select(data, :cz)
+    nrows = length(data); frac = Vector{Float64}(undef, nrows)
+    @inbounds for idx in 1:nrows
+        f = 1.0 / 2^lvl[idx]; nx = cxv[idx]*f; ny = cyv[idx]*f; nz = czv[idx]*f; half = 0.5f
+        fr = split ? cellfrac(nx,ny,nz,half) : (contains(nx,ny,nz) ? 1.0 : 0.0)
+        frac[idx] = inverse ? 1.0 - fr : fr
+    end
+    keep = frac .> 1e-12
+    cols = IndexedTables.columns(data)
+    keptcols = map(c -> c[keep], cols)
+    newcols = split ? merge(keptcols, (fraction = frac[keep],)) : keptcols
+    newdata = IndexedTables.table(newcols; pkey = [:level, :cx, :cy, :cz])
+    if verbose
+        println("Region: ", nameof(typeof(region)), split ? "  (exact cell splitting)" : "  (whole cells)")
+        println("Selected cells: ", length(newdata), " / ", nrows)
+    end
+    out = HydroDataType()
+    out.data = newdata; out.info = obj.info; out.lmin = obj.lmin; out.lmax = obj.lmax
+    out.boxlen = obj.boxlen; out.ranges = obj.ranges; out.selected_hydrovars = obj.selected_hydrovars
+    out.used_descriptors = obj.used_descriptors; out.smallr = obj.smallr; out.smallc = obj.smallc
+    out.scale = obj.scale
+    return out
+end

--- a/test/55_region_algebra_tests.jl
+++ b/test/55_region_algebra_tests.jl
@@ -1,0 +1,70 @@
+# 55_region_algebra_tests.jl  --  Composable regions with exact edge-cell splitting
+# ==============================================================================
+# Phase 1 of the region-algebra work: AbstractRegion value types (Sphere/Cuboid/
+# Cylinder/SphericalShell) selected by subregion(obj, region; split), with an exact
+# per-cell :fraction honoured by getvar(:mass)/:volume/msum. Validated data-free against
+# analytic volumes on a full uniform grid built by synthetic_clumps (no simulation data).
+# ==============================================================================
+
+@testset verbose=true "region algebra — exact cell splitting (data-free)" begin
+    # full uniform 32³ grid in a 1 kpc box (background=:galaxy populates every cell; the
+    # density field is irrelevant for the geometric volume tests).
+    F   = synthetic_clumps(background=:galaxy, lmax=5)
+    gas = F.gas
+    box = gas.boxlen * gas.scale.kpc
+    Vbox = sum(getvar(gas, :volume, :kpc3))
+    R    = 0.30 * box
+
+    vol(s) = sum(getvar(s, :volume, :kpc3))
+    cases = (
+        ("sphere",  Sphere(R; range_unit=:kpc),                                (4/3)*pi*R^3,            0.02),
+        ("shell",   SphericalShell(0.15box, R; range_unit=:kpc),               (4/3)*pi*(R^3-(0.15box)^3), 0.02),
+        ("cylinder",Cylinder(R, 0.20box; range_unit=:kpc),                     pi*R^2*(2*0.20box),     0.02),
+        ("cuboid",  Cuboid(xrange=[-0.2box,0.2box], yrange=[-0.2box,0.2box], zrange=[-0.2box,0.2box], range_unit=:kpc),
+                    (0.4box)^3,  1e-4),
+    )
+
+    @testset "exact volumes vs analytic ($name)" for (name, reg, Vexact, tol) in cases
+        s = subregion(gas, reg; split=true, verbose=false)
+        w = subregion(gas, reg; split=false, verbose=false)
+        @test isapprox(vol(s), Vexact; rtol=tol)               # split ≈ analytic
+        @test abs(vol(s)/Vexact - 1) <= abs(vol(w)/Vexact - 1) + 1e-9  # split no worse than whole-cell
+        fr = Mera.select(s.data, :fraction)
+        @test all(0.0 .< fr .<= 1.0 + 1e-9)                     # valid fractions
+        if name != "cuboid"
+            @test any(x -> 1e-6 < x < 1 - 1e-6, fr)            # genuine edge cells were split
+        end
+    end
+
+    @testset "whole-cell over-counts a convex region" begin
+        s = subregion(gas, Sphere(R; range_unit=:kpc); split=true,  verbose=false)
+        w = subregion(gas, Sphere(R; range_unit=:kpc); split=false, verbose=false)
+        @test vol(w) > vol(s)                                   # whole boundary cells inflate the volume
+        @test !in(:fraction, propertynames(Mera.columns(w.data)))   # split=false attaches no :fraction
+        @test in(:fraction, propertynames(Mera.columns(s.data)))
+    end
+
+    @testset "getvar honours :fraction for :volume and :mass" begin
+        s  = subregion(gas, Sphere(R; range_unit=:kpc); split=true, verbose=false)
+        fr = Mera.select(s.data, :fraction)
+        # :volume == cellsize³ · fraction  (cellsize itself is geometric, NOT weighted)
+        @test getvar(s, :volume, :kpc3) ≈ getvar(s, :cellsize, :kpc).^3 .* fr
+        # :mass == ρ · cellsize³ · fraction
+        @test getvar(s, :mass, :Msol) ≈ getvar(s, :rho, :Msol_pc3) .* getvar(s, :cellsize, :pc).^3 .* fr
+        # msum trims the boundary mass relative to whole cells
+        w = subregion(gas, Sphere(R; range_unit=:kpc); split=false, verbose=false)
+        @test msum(s, :Msol) < msum(w, :Msol)
+    end
+
+    @testset "inverse selects the complement (split volumes are partitioned exactly)" begin
+        s   = subregion(gas, Sphere(R; range_unit=:kpc); split=true, verbose=false)
+        inv = subregion(gas, Sphere(R; range_unit=:kpc); split=true, inverse=true, verbose=false)
+        @test isapprox(vol(s) + vol(inv), Vbox; rtol=1e-6)      # region + complement = whole box
+    end
+
+    @testset "symbol API still works (backward compatible)" begin
+        old = subregion(gas, :sphere; radius=R, center=[:bc], range_unit=:kpc, verbose=false)
+        @test old isa Mera.HydroDataType && length(old.data) > 0
+        @test !in(:fraction, propertynames(Mera.columns(old.data)))   # legacy path unchanged
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -72,6 +72,7 @@ if isempty(_focus)
         include("46_data_awareness_tests.jl")  # data-free descriptor/MHD detection + optional capability/descriptor/quantity-awareness blocks
         include("47_benchmark_tests.jl")  # data-free I/O benchmark (run_benchmark/plot_results) on a temp folder
         include("54_clumpfind_synthetic_tests.jl")  # data-free: all 7 finders + features scored vs synthetic ground truth
+        include("55_region_algebra_tests.jl")  # data-free: composable regions + exact cell splitting vs analytic volumes
     end
 
     # ========================================================================


### PR DESCRIPTION
## Summary

Phase 1 of the region-algebra work you asked for: a **composable region value-type API** for `subregion` with **exact edge-cell splitting**, alongside the existing `subregion(obj, :sphere; …)` symbol API (untouched, backward-compatible).

```julia
gas_in = subregion(gas, Sphere(20.0; center=[:bc], range_unit=:kpc))   # split=true (default)
msum(gas_in, :Msol)        # EXACT enclosed mass — boundary cells weighted by inside-fraction

subregion(gas, Cuboid(xrange=[-10,10], yrange=[-10,10], zrange=[-2,2], range_unit=:kpc))
subregion(gas, SphericalShell(10.0, 20.0; range_unit=:kpc))
subregion(gas, Cylinder(15.0, 3.0; range_unit=:kpc); split=false)      # classic whole-cell
```

## What it does
- **`AbstractRegion`** + **`Sphere` / `Cuboid` / `Cylinder` / `SphericalShell`** value types (exported).
- **Exact splitting** (`split=true`): each cell straddling the boundary carries a `:fraction ∈ (0,1]` = the volume fraction inside the region. Cuboid∩cell is analytic; curved/shell regions sub-sample only the boundary shell (6³ points; interior/exterior are O(1) via an 8-corner fast path).
- **`getvar(:mass)`/`(:volume)`/`msum` honour `:fraction`** → exact in-region totals; a sphere of radius R returns (4/3)πR³, no boundary over/under-counting. The hook only fires when a `:fraction` column is present, so **normal data is unaffected**.
- `split=false` = classic centre-inside whole-cell selection; `inverse=true` = complement.

## Accuracy (data-free, vs analytic volumes, 32³ grid)
| region | split error | whole-cell error |
|---|--:|--:|
| Sphere | −0.02% | 1.0% |
| SphericalShell | −0.02% | 1.21% |
| Cylinder | −0.99% | 2.78% |
| Cuboid | **exact** | 4.76% |

## Tests / quality
- `test/55` — 24 data-free assertions: analytic volumes, split strictly beats whole-cell, `:fraction` identities for `:volume` and `:mass`, inverse partitions the box exactly, symbol API backward-compatible.
- Regression: `07_regions` 76/76, `05_derived_variables` 129/129 (hooks don't touch normal data). **Aqua 10/10**. Docs build clean.

## Scope
Phase 1 = hydro. Planned follow-ups: boolean combinators (`∩`/`∪`/`\`/`!`), tilted/arbitrary axes, and **projection of split cells** (the `:overlap` supersampler already enumerates sub-cell points, so gating them by the region is the natural next step).
