### PR TITLE
regions: one-shot hint from legacy symbol API to value-type form

### DIFF
--- a/src/functions/regions/region_algebra.jl
+++ b/src/functions/regions/region_algebra.jl
@@ -16,6 +16,32 @@
 #  to that frame with `prepboxcenter` + the `·getunit/boxlen` rule (identical to `prepranges`).
 # =====================================================================================
 
+# One-shot discoverability hint: when the legacy symbol API (subregion/shellregion with a
+# :sphere/:cuboid/:cylinder Symbol) is used on hydro, point the user at the value-type form,
+# which adds EXACT edge-cell splitting. Shown once per session, only when verbose.
+const _REGION_HINT_SHOWN = Ref(false)
+function _region_value_type_hint(shape::Symbol; radius=0., height=0., xrange=[0.,0.], yrange=[0.,0.],
+                                 zrange=[0.,0.], center=[:bc], range_unit::Symbol=:standard, shell::Bool=false)
+    _REGION_HINT_SHOWN[] && return
+    _REGION_HINT_SHOWN[] = true
+    eq = if shell
+        shape === :sphere ? "SphericalShell($(radius[1]), $(radius[2]); center=$(center), range_unit=:$(range_unit))" :
+                            "Cylinder(r_out, $(height); …) \\ Cylinder(r_in, $(height); …)"
+    elseif shape === :sphere
+        "Sphere($(radius); center=$(center), range_unit=:$(range_unit))"
+    elseif shape === :cylinder || shape === :disc
+        "Cylinder($(radius), $(height); center=$(center), range_unit=:$(range_unit))"
+    else
+        "Cuboid(xrange=$(xrange), yrange=$(yrange), zrange=$(zrange), center=$(center), range_unit=:$(range_unit))"
+    end
+    printstyled("[Mera] Tip: regions also work as value types with EXACT edge-cell splitting " *
+                "(exact getvar :mass/:volume/msum), composable with ∩ ∪ \\ !:\n"; color=:light_black)
+    printstyled("           subregion(data, $eq)\n"; color=:light_black)
+    printstyled("           (the symbol form above still works; pass split=false for classic whole cells. " *
+                "Shown once per session — see ?subregion.)\n"; color=:light_black)
+    return
+end
+
 """    AbstractRegion
 
 Supertype of the composable region value types passed to [`subregion`](@ref):

--- a/src/functions/regions/shellregion.jl
+++ b/src/functions/regions/shellregion.jl
@@ -65,7 +65,10 @@ function shellregion(dataobject::DataSetType, shape::Symbol=:cylinder;
     if !(myargs.verbose       === missing)       verbose = myargs.verbose end
 
     verbose = checkverbose(verbose)
-    
+    verbose && typeof(dataobject) == HydroDataType &&
+        _region_value_type_hint(shape; radius=radius, height=height, center=center,
+                                range_unit=range_unit, shell=true)
+
     # subregion = wrapper over all subregion shell functions
     if shape == :cylinder || shape == :disc
         # `direction` is not yet implemented for cylindrical shells (radial test always on x,y, height

--- a/src/functions/regions/subregion.jl
+++ b/src/functions/regions/subregion.jl
@@ -85,6 +85,9 @@ function subregion(dataobject::DataSetType, shape::Symbol=:cuboid;
 
 
     verbose = checkverbose(verbose)
+    verbose && typeof(dataobject) == HydroDataType &&
+        _region_value_type_hint(shape; radius=radius, height=height, xrange=xrange, yrange=yrange,
+                                zrange=zrange, center=center, range_unit=range_unit)
     # `cell` (cell-overlap vs cell-centre selection) applies only to AMR cell data; warn if a user
     # sets it on particles/clumps, where it is silently ignored.
     if cell == false && !(typeof(dataobject) == HydroDataType || typeof(dataobject) == GravDataType || typeof(dataobject) == RtDataType)

--- a/test/55_region_algebra_tests.jl
+++ b/test/55_region_algebra_tests.jl
@@ -108,4 +108,18 @@
         @test old isa Mera.HydroDataType && length(old.data) > 0
         @test !in(:fraction, propertynames(Mera.columns(old.data)))   # legacy path unchanged
     end
+
+    @testset "legacy symbol API prints a one-shot value-type hint" begin
+        Mera._REGION_HINT_SHOWN[] = false
+        out = capture_stdout() do
+            Mera._region_value_type_hint(:sphere; radius=10.0, center=[:bc], range_unit=:kpc)
+        end
+        @test occursin("Sphere(10.0", out)                 # shows the equivalent value-type call
+        @test occursin("split=false", out)                 # and how to keep the classic behaviour
+        out2 = capture_stdout() do                          # only once per session
+            Mera._region_value_type_hint(:sphere; radius=10.0, center=[:bc], range_unit=:kpc)
+        end
+        @test isempty(out2)
+        Mera._REGION_HINT_SHOWN[] = false                   # reset so other tests/sessions can see it
+    end
 end


### PR DESCRIPTION
## Summary

For anyone still using the legacy symbol API (`subregion(data, :sphere; …)` / `shellregion(…)`), Mera now prints a **once-per-session** tip on screen showing the equivalent **value-type** call — which adds exact edge-cell splitting:

```
[Mera] Tip: regions also work as value types with EXACT edge-cell splitting (exact getvar :mass/:volume/msum), composable with ∩ ∪ \ !:
           subregion(data, Sphere(0.3; center=[:bc], range_unit=:standard))
           (the symbol form above still works; pass split=false for classic whole cells. Shown once per session — see ?subregion.)
```

- Built from the user's **actual arguments** (radius / ranges / center / range_unit), mapped per shape: `Sphere` / `Cuboid` / `Cylinder`, and `SphericalShell` for a sphere shell (`shellregion`).
- Gated on `verbose` **and** `HydroDataType` (the value-type API is hydro in Phase 1, so the suggested call is always valid).
- **Once per session** via a module `Ref`, so it informs without becoming noise; `verbose=false` suppresses it entirely.

## Tests
- `test/55` +3 (now **41/41**): the hint shows the equivalent call + `split=false`, and fires only once.
- `07_regions` unaffected (**76/76**) — the print doesn't disturb existing behaviour.
