### PR TITLE
regions: value-type subregion for particles, gravity & RT (Phase 5)

### DIFF
--- a/docs/src/api/subregions.md
+++ b/docs/src/api/subregions.md
@@ -93,6 +93,16 @@ subregion(gas, Cylinder(15.0, 3.0; range_unit=:kpc); split=false)      # classic
 [`Sphere`](@ref), [`Cuboid`](@ref), [`Cylinder`](@ref), [`SphericalShell`](@ref)) are listed in
 the [API reference](../api.md#Types).
 
+The value-type form works on **all data types**: hydro, gravity and RT (AMR cells, with exact
+volume splitting and a `:fraction` column), and particles — where it is a point-membership test
+(particles are points, so `split`/`nsub` do not apply and no `:fraction` is attached).
+
+```julia
+subregion(particles, Sphere(20.0; range_unit=:kpc))                    # stars/DM inside a ball
+subregion(particles, Sphere(20.0; range_unit=:kpc) \ Cylinder(5.0, 30.0; range_unit=:kpc))
+subregion(gravity,   Sphere(20.0; range_unit=:kpc))                    # exact-split gravity cells
+```
+
 ### Boolean combinations
 
 Regions compose with the operators `∩` (intersection), `∪` (union), `\` (difference) and `!`

--- a/src/functions/getvar/getvar_gravity.jl
+++ b/src/functions/getvar/getvar_gravity.jl
@@ -107,6 +107,8 @@ function get_data(dataobject::GravDataType,
         elseif i == :volume
             selected_unit = getunit(dataobject, :volume, vars, units)
             vars_dict[:volume] =  convert(Array{Float64,1}, getvar(filtered_dataobject, :cellsize, mask=use_mask_in_recursion) .^3 .* selected_unit)
+            # exact region splitting: weight occupied volume by the per-cell inside-fraction
+            in(:fraction, column_names) && (vars_dict[:volume] .*= select(masked_data, :fraction))
 
 
         elseif i == :x

--- a/src/functions/getvar/getvar_rt.jl
+++ b/src/functions/getvar/getvar_rt.jl
@@ -137,6 +137,8 @@ function get_data(dataobject::RtDataType,
         elseif i == :volume
             selected_unit = getunit(dataobject, :volume, vars, units)
             vars_dict[:volume] =  convert(Array{Float64,1}, getvar(filtered_dataobject, :cellsize, mask=use_mask_in_recursion) .^3 .* selected_unit)
+            # exact region splitting: weight occupied volume by the per-cell inside-fraction
+            in(:fraction, column_names) && (vars_dict[:volume] .*= select(masked_data, :fraction))
 
 
         elseif i == :x

--- a/src/functions/regions/region_algebra.jl
+++ b/src/functions/regions/region_algebra.jl
@@ -196,20 +196,35 @@ Base.:|(a::AbstractRegion, b::AbstractRegion)        = RegionUnion(a, b)
     return cnt / (n^3)
 end
 
-"""
-    subregion(obj::HydroDataType, region::AbstractRegion; split=true, inverse=false, nsub=8, verbose=true)
+# rebuild a data object of the same type with new data, copying every other (defined) field
+function _copy_with_data(obj::T, newdata) where {T}
+    out = T()
+    @inbounds for f in fieldnames(T)
+        f === :data ? setfield!(out, f, newdata) : (isdefined(obj, f) && setfield!(out, f, getfield(obj, f)))
+    end
+    return out
+end
 
-Select the cells covered by a composable `region` ([`Sphere`](@ref), [`Cuboid`](@ref),
-[`Cylinder`](@ref), [`SphericalShell`](@ref), or any boolean combination `∩`/`∪`/`\\`/`!`).
-With `split=true` (default) each kept cell carries an exact `:fraction ∈ (0,1]` — the volume
-fraction inside the region — and `getvar(:mass)`/`getvar(:volume)`/`msum` report the **exact
-in-region totals** (no boundary over/under-counting). With `split=false` whole cells are kept
-by a centre-inside test (the classic behaviour) and no `:fraction` is attached. `inverse=true`
-selects the complement. `nsub` (default 8) is the per-axis sub-sampling of boundary cells for
-curved/composite regions — larger is more accurate, with diminishing returns past ~8 (where the
-grid resolution, not the sampling, sets the error floor).
+const _CellData = Union{HydroDataType, GravDataType, RtDataType}
+
 """
-function subregion(obj::HydroDataType, region::AbstractRegion; split::Bool=true,
+    subregion(obj, region::AbstractRegion; split=true, inverse=false, nsub=8, verbose=true)
+
+Select the data covered by a composable `region` ([`Sphere`](@ref), [`Cuboid`](@ref),
+[`Cylinder`](@ref), [`SphericalShell`](@ref), or any boolean combination `∩`/`∪`/`\\`/`!`).
+Works on hydro, gravity, RT (AMR cells) and particle data.
+
+For **AMR cell** data with `split=true` (default) each kept cell carries an exact
+`:fraction ∈ (0,1]` — the volume fraction inside the region — and `getvar(:mass)` /
+`getvar(:volume)` / `msum` report the **exact in-region totals** (no boundary over/under-
+counting). With `split=false` whole cells are kept by a centre-inside test (the classic
+behaviour) and no `:fraction` is attached. `nsub` (default 8) is the per-axis sub-sampling of
+boundary cells for curved/composite regions (diminishing returns past ~8).
+
+For **particle** data the region is a point-membership test (particles are points — there is
+no fractional volume, so `split`/`nsub` do not apply). `inverse=true` selects the complement.
+"""
+function subregion(obj::_CellData, region::AbstractRegion; split::Bool=true,
                    inverse::Bool=false, nsub::Int=8, verbose::Bool=true)
     verbose = checkverbose(verbose)
     cellfrac, contains = _prepare(region, obj; nsub=nsub)
@@ -231,10 +246,24 @@ function subregion(obj::HydroDataType, region::AbstractRegion; split::Bool=true,
         println("Region: ", nameof(typeof(region)), split ? "  (exact cell splitting)" : "  (whole cells)")
         println("Selected cells: ", length(newdata), " / ", nrows)
     end
-    out = HydroDataType()
-    out.data = newdata; out.info = obj.info; out.lmin = obj.lmin; out.lmax = obj.lmax
-    out.boxlen = obj.boxlen; out.ranges = obj.ranges; out.selected_hydrovars = obj.selected_hydrovars
-    out.used_descriptors = obj.used_descriptors; out.smallr = obj.smallr; out.smallc = obj.smallc
-    out.scale = obj.scale
-    return out
+    return _copy_with_data(obj, newdata)
+end
+
+function subregion(obj::PartDataType, region::AbstractRegion; inverse::Bool=false, verbose::Bool=true)
+    verbose = checkverbose(verbose)
+    _, contains = _prepare(region, obj)
+    data = obj.data; bl = obj.boxlen
+    xs = IndexedTables.select(data, :x); ys = IndexedTables.select(data, :y); zs = IndexedTables.select(data, :z)
+    nrows = length(data); keep = Vector{Bool}(undef, nrows)
+    @inbounds for i in 1:nrows
+        ins = contains(xs[i]/bl, ys[i]/bl, zs[i]/bl)
+        keep[i] = inverse ? !ins : ins
+    end
+    cols = IndexedTables.columns(data)
+    newdata = IndexedTables.table(map(c -> c[keep], cols); pkey = collect(IndexedTables.pkeynames(data)))
+    if verbose
+        println("Region: ", nameof(typeof(region)), "  (particles)")
+        println("Selected particles: ", count(keep), " / ", nrows)
+    end
+    return _copy_with_data(obj, newdata)
 end

--- a/src/functions/regions/subregion.jl
+++ b/src/functions/regions/subregion.jl
@@ -85,7 +85,7 @@ function subregion(dataobject::DataSetType, shape::Symbol=:cuboid;
 
 
     verbose = checkverbose(verbose)
-    verbose && typeof(dataobject) == HydroDataType &&
+    verbose && dataobject isa Union{HydroDataType, GravDataType, RtDataType} &&
         _region_value_type_hint(shape; radius=radius, height=height, xrange=xrange, yrange=yrange,
                                 zrange=zrange, center=center, range_unit=range_unit)
     # `cell` (cell-overlap vs cell-centre selection) applies only to AMR cell data; warn if a user

--- a/test/55_region_algebra_tests.jl
+++ b/test/55_region_algebra_tests.jl
@@ -136,6 +136,32 @@
         @test zext(flat) < zext(vert)
     end
 
+    @testset "particles: point-membership region selection" begin
+        part = F.particles
+        ball = subregion(part, Sphere(R; range_unit=:kpc); verbose=false)
+        p = getvar(part, [:x,:y,:z], :kpc); bc = box/2
+        manual = count(i -> (p[:x][i]-bc)^2 + (p[:y][i]-bc)^2 + (p[:z][i]-bc)^2 <= R^2, 1:length(part.data))
+        @test ball isa Mera.PartDataType
+        @test length(ball.data) == manual                       # exact membership, no fractional volume
+        @test !in(:fraction, propertynames(Mera.columns(ball.data)))
+        inv = subregion(part, Sphere(R; range_unit=:kpc); inverse=true, verbose=false)
+        @test length(ball.data) + length(inv.data) == length(part.data)   # region + complement = all
+        # combinators work on particles too
+        comp = subregion(part, Sphere(R; range_unit=:kpc) \ Cylinder(0.1box, 0.5box; range_unit=:kpc); verbose=false)
+        @test length(comp.data) <= length(ball.data)
+    end
+
+    @testset "gravity (AMR cells): exact volume splitting, returns GravDataType" begin
+        gd = Mera.GravDataType()
+        gd.data = gas.data; gd.info = gas.info; gd.lmin = gas.lmin; gd.lmax = gas.lmax
+        gd.boxlen = gas.boxlen; gd.ranges = gas.ranges; gd.selected_gravvars = [1]
+        gd.used_descriptors = Dict(); gd.scale = gas.scale
+        gs = subregion(gd, Sphere(R; range_unit=:kpc); split=true, verbose=false)
+        @test gs isa Mera.GravDataType
+        @test in(:fraction, propertynames(Mera.columns(gs.data)))
+        @test isapprox(sum(getvar(gs, :volume, :kpc3)), (4/3)*pi*R^3; rtol=0.02)   # getvar :volume honours :fraction
+    end
+
     @testset "symbol API still works (backward compatible)" begin
         old = subregion(gas, :sphere; radius=R, center=[:bc], range_unit=:kpc, verbose=false)
         @test old isa Mera.HydroDataType && length(old.data) > 0


### PR DESCRIPTION
## Summary

Final phase of the region algebra — the composable value-type `subregion(obj, ::AbstractRegion)` now works on **all data types**, not just hydro.

```julia
subregion(particles, Sphere(20.0; range_unit=:kpc))                                   # stars/DM in a ball
subregion(particles, Sphere(20.0; range_unit=:kpc) \ Cylinder(5.0, 30.0; range_unit=:kpc))
subregion(gravity,   Sphere(20.0; range_unit=:kpc))                                   # exact-split gravity cells
```

- **Gravity & RT** (AMR cells): same exact-splitting path as hydro (cx/cy/cz/level). Generalised the cell method to `Union{HydroDataType,GravDataType,RtDataType}` and added the `:fraction → getvar(:volume)` hook in `getvar_gravity.jl`/`getvar_rt.jl`, so `getvar(:volume)`/`msum` are exact in-region (gravity carries no mass → volume-splitting only). Returns the same type.
- **Particles** (points): point-membership on positions (÷boxlen → normalised frame); no fractional volume, so `split`/`nsub` don't apply and no `:fraction` is attached. `inverse` and boolean combinators work too.
- A generic `_copy_with_data` rebuilds the result as the same type; the legacy symbol-API migration hint now fires for gravity/RT as well.

## Tests / quality
- **`test/55` +8** (now **60/60**, data-free): particle membership matches a manual count and partitions with its complement; a synthetic `GravDataType` splits a sphere to the analytic volume via `getvar(:volume)` and returns a `GravDataType`.
- Regression: `07_regions` 76/76, `05_derived_variables` 129/129 (the getvar hooks only fire when a `:fraction` column is present), **Aqua 10/10**. Docs build clean; code blocks parse.

## Region algebra — complete
Phases 1–5 shipped (#161–#166): value types, exact splitting, `getvar`/`msum`, boolean combinators, accuracy study, migration hint, exact region-clipped projections, tilted axes, and **all data types**.
