### PR TITLE
regions: value-type subregion for clumps (point membership)

### DIFF
--- a/src/functions/regions/region_algebra.jl
+++ b/src/functions/regions/region_algebra.jl
@@ -267,3 +267,22 @@ function subregion(obj::PartDataType, region::AbstractRegion; inverse::Bool=fals
     end
     return _copy_with_data(obj, newdata)
 end
+
+function subregion(obj::ClumpDataType, region::AbstractRegion; inverse::Bool=false, verbose::Bool=true)
+    verbose = checkverbose(verbose)
+    _, contains = _prepare(region, obj)
+    data = obj.data; bl = obj.boxlen          # clumps are points at their peak position (code units)
+    xs = IndexedTables.select(data, :peak_x); ys = IndexedTables.select(data, :peak_y); zs = IndexedTables.select(data, :peak_z)
+    nrows = length(data); keep = Vector{Bool}(undef, nrows)
+    @inbounds for i in 1:nrows
+        ins = contains(xs[i]/bl, ys[i]/bl, zs[i]/bl)
+        keep[i] = inverse ? !ins : ins
+    end
+    cols = IndexedTables.columns(data)
+    newdata = IndexedTables.table(map(c -> c[keep], cols); pkey = collect(IndexedTables.pkeynames(data)))
+    if verbose
+        println("Region: ", nameof(typeof(region)), "  (clumps)")
+        println("Selected clumps: ", count(keep), " / ", nrows)
+    end
+    return _copy_with_data(obj, newdata)
+end

--- a/test/07_regions.jl
+++ b/test/07_regions.jl
@@ -737,4 +737,19 @@ end
         end
     end
 
+    @testset "value-type regions on clumps (point membership)" begin
+        clumps = load_test_clumps(:spiral_clumps)
+        n = length(clumps.data)
+        if n > 0
+            R = 0.25 * clumps.boxlen * clumps.info.scale.kpc      # quarter-box radius about the centre
+            inn = subregion(clumps, Sphere(R; center=[:bc], range_unit=:kpc); verbose=false)
+            out = subregion(clumps, Sphere(R; center=[:bc], range_unit=:kpc); inverse=true, verbose=false)
+            @test inn isa Mera.ClumpDataType
+            @test length(inn.data) + length(out.data) == n        # region + complement = all clumps
+            # a difference removes (at most) the cylinder's clumps from the ball
+            comp = subregion(clumps, Sphere(R; range_unit=:kpc) \ Cylinder(0.3R, R; range_unit=:kpc); verbose=false)
+            @test length(comp.data) <= length(inn.data)
+        end
+    end
+
 end


### PR DESCRIPTION
Completes value-type region coverage — `subregion(clumps, ::AbstractRegion)` now works (point-membership on clump peak positions, like particles; inverse + combinators supported). The value-type API now covers every Mera data type. test/07_regions +3 (data-backed); 07_regions 79/79, 55 60/60.