### PR TITLE
regions: fix value-type subregion on uniform grids (no :level column)

### DIFF
--- a/src/functions/regions/region_algebra.jl
+++ b/src/functions/regions/region_algebra.jl
@@ -229,11 +229,14 @@ function subregion(obj::_CellData, region::AbstractRegion; split::Bool=true,
     verbose = checkverbose(verbose)
     cellfrac, contains = _prepare(region, obj; nsub=nsub)
     data = obj.data
-    lvl = IndexedTables.select(data, :level)
     cxv = IndexedTables.select(data, :cx); cyv = IndexedTables.select(data, :cy); czv = IndexedTables.select(data, :cz)
+    # AMR carries a per-cell :level; a uniform grid has none → every cell is at lmax
+    isamr = :level in propertynames(IndexedTables.columns(data))
+    lvl = isamr ? IndexedTables.select(data, :level) : nothing
     nrows = length(data); frac = Vector{Float64}(undef, nrows)
     @inbounds for idx in 1:nrows
-        f = 1.0 / 2^lvl[idx]; nx = cxv[idx]*f; ny = cyv[idx]*f; nz = czv[idx]*f; half = 0.5f
+        f = 1.0 / 2^(isamr ? lvl[idx] : obj.lmax)
+        nx = cxv[idx]*f; ny = cyv[idx]*f; nz = czv[idx]*f; half = 0.5f
         fr = split ? cellfrac(nx,ny,nz,half) : (contains(nx,ny,nz) ? 1.0 : 0.0)
         frac[idx] = inverse ? 1.0 - fr : fr
     end
@@ -241,7 +244,7 @@ function subregion(obj::_CellData, region::AbstractRegion; split::Bool=true,
     cols = IndexedTables.columns(data)
     keptcols = map(c -> c[keep], cols)
     newcols = split ? merge(keptcols, (fraction = frac[keep],)) : keptcols
-    newdata = IndexedTables.table(newcols; pkey = [:level, :cx, :cy, :cz])
+    newdata = IndexedTables.table(newcols; pkey = collect(IndexedTables.pkeynames(data)))
     if verbose
         println("Region: ", nameof(typeof(region)), split ? "  (exact cell splitting)" : "  (whole cells)")
         println("Selected cells: ", length(newdata), " / ", nrows)

--- a/test/07_regions.jl
+++ b/test/07_regions.jl
@@ -737,6 +737,24 @@ end
         end
     end
 
+    @testset "value-type regions on a uniform grid (no :level column)" begin
+        # spiral_ugrid is a uniform grid: its hydro table has no :level column, so the cell
+        # method must fall back to lmax (regression for the AMR-only assumption).
+        hydro = load_test_hydro(:spiral_ugrid)
+        if length(hydro.data) > 0
+            @test !(:level in propertynames(hydro.data.columns))         # genuinely uniform grid
+            R = 0.20 * hydro.boxlen * hydro.info.scale.kpc
+            gs = subregion(hydro, Sphere(R; center=[:bc], range_unit=:kpc); verbose=false)
+            gw = subregion(hydro, Sphere(R; center=[:bc], range_unit=:kpc); split=false, verbose=false)
+            @test gs isa Mera.HydroDataType && length(gs.data) > 0
+            @test in(:fraction, propertynames(gs.data.columns))          # split attached a :fraction
+            @test isapprox(msum(gs, :Msol), msum(gw, :Msol); rtol=0.05)  # split & centre-test bracket the exact mass
+            # combinators work on the uniform grid too
+            gc = subregion(hydro, Sphere(R; range_unit=:kpc) \ Cylinder(0.3R, R; range_unit=:kpc); verbose=false)
+            @test gc isa Mera.HydroDataType
+        end
+    end
+
     @testset "value-type regions on clumps (point membership)" begin
         clumps = load_test_clumps(:spiral_clumps)
         n = length(clumps.data)


### PR DESCRIPTION
The cell-based `subregion(obj, ::AbstractRegion)` assumed an AMR `:level` column (and pkey), erroring on uniform grids. Now falls back to `obj.lmax` when `:level` is absent and preserves the table's pkey via `pkeynames`. Caught while validating the revised subregion tutorial notebooks against the uniform-grid `spiral_ugrid` fixture. test/07_regions +5; 07_regions 84/84.