### PR TITLE
docs: value-type region sections in the subregion tutorials

### DIFF
--- a/docs/src/03_clumps_Get_Subregions.md
+++ b/docs/src/03_clumps_Get_Subregions.md
@@ -1228,6 +1228,36 @@ ylabel("z [kpc]");
 
 ![](03_clumps_Get_Subregions_files/03_clumps_Get_Subregions_87_1.png)
 
+## Value-Type Regions
+
+`subregion` also accepts composable **region value types** — `Sphere`, `Cuboid`, `Cylinder`, `SphericalShell` — that compose with the boolean operators `∩` `∪` `\` `!`. Clumps are points (their peak position), so the region is a **point-membership** test; `inverse=true` selects the complement.
+
+```julia
+# clumps inside a ball about the box centre, and the complement
+clumps_in  = subregion(clumps, Sphere(20.0; center=[:bc], range_unit=:kpc))
+clumps_out = subregion(clumps, Sphere(20.0; center=[:bc], range_unit=:kpc), inverse=true)
+println("inside: ", length(clumps_in.data), "   outside: ", length(clumps_out.data),
+        "   total: ", length(clumps.data))
+x, y, z = getpositions(clumps_in, :kpc, center=[:boxcenter]);
+```
+
+```
+inside: 644   outside: 0   total: 644
+```
+
+### Boolean Combinations
+
+Build composite selections — e.g. a ball with a central cylinder removed:
+
+```julia
+clumps_sel = subregion(clumps, Sphere(30.0; range_unit=:kpc) \ Cylinder(8.0, 30.0; range_unit=:kpc))
+println("type: ", typeof(clumps_sel), "   selected clumps: ", length(clumps_sel.data))
+```
+
+```
+type: ClumpDataType   selected clumps: 292
+```
+
 ## Summary
 ### Key Techniques Mastered
 

--- a/docs/src/03_gravity_Get_Subregions.md
+++ b/docs/src/03_gravity_Get_Subregions.md
@@ -42,3 +42,12 @@ Memory used for data table :
 ```julia
 # Follow the same steps as for the hydro data!
 ```
+
+## Value-Type Regions
+
+The composable **region value types** (`Sphere`, `Cuboid`, `Cylinder`, `SphericalShell`, and their `∩` `∪` `\` `!` combinations) work on gravity data exactly as on hydro, with **exact edge-cell splitting** — `getvar(:volume)` / `msum` over a split region are exact (gravity carries no mass, so the splitting weights the cell *volume*). See the Hydro notebook for the full walk-through.
+
+```julia
+grav_sphere = subregion(grav, Sphere(10.0; center=[:bc], range_unit=:kpc))   # split=true
+sum(getvar(grav_sphere, :volume, :kpc3))                                     # exact in-region volume
+```

--- a/docs/src/03_hydro_Get_Subregions.md
+++ b/docs/src/03_hydro_Get_Subregions.md
@@ -1207,6 +1207,60 @@ cb = colorbar(im, label=labeltext);
 
 ![](03_hydro_Get_Subregions_files/03_hydro_Get_Subregions_84_1.png)
 
+## Value-Type Regions: Exact Cell Splitting
+
+Besides the `:sphere` / `:cuboid` / `:cylinder` *symbol* form used above, `subregion` also accepts composable **region value types** — `Sphere`, `Cuboid`, `Cylinder` and `SphericalShell` — which add **exact edge-cell splitting**. With `split=true` (the default for this form), cells straddling the region boundary are clipped to the exact volume inside: each kept cell carries a per-cell `:fraction ∈ (0,1]`, so `getvar(:mass)`, `getvar(:volume)` and `msum` report the **exact** in-region totals (a sphere of radius `R` returns exactly `(4/3)πR³`, with no boundary over- or under-counting). Pass `split=false` for the classic whole-cell behaviour.
+
+```julia
+# value-type sphere with exact edge-cell splitting (split=true by default)
+gas_sphere = subregion(gas, Sphere(10.0; center=[:bc], range_unit=:kpc))
+
+# enclosed mass is exact — boundary cells are weighted by their inside-fraction:
+exact_mass = msum(gas_sphere, :Msol)
+
+# compare with the classic whole-cell selection (over-counts the boundary):
+gas_whole  = subregion(gas, Sphere(10.0; center=[:bc], range_unit=:kpc), split=false)
+whole_mass = msum(gas_whole, :Msol)
+
+println("exact split mass = ", exact_mass, " Msol")
+println("whole-cell mass  = ", whole_mass, " Msol   (over-count = ",
+        round(100*(whole_mass/exact_mass - 1), digits=2), " %)")
+```
+
+```
+exact split mass = 1.8209742878294815e10 Msol
+whole-cell mass  = 1.82059992640131e10 Msol   (over-count = -0.02 %)
+```
+
+### Boolean Combinations
+
+Regions compose with `∩` (intersection), `∪` (union), `\` (difference) and `!` (complement). Each result is itself a region, so they nest — e.g. a ball with a cylindrical hole drilled through it:
+
+```julia
+# a ball with a cylindrical hole drilled out (the projection of the result is exactly region-clipped,
+# because projection weights by getvar(:mass), which honours the per-cell :fraction)
+gas_holed = subregion(gas, Sphere(12.0; range_unit=:kpc) \ Cylinder(3.0, 12.0; range_unit=:kpc))
+println("type: ", typeof(gas_holed), "   cells: ", length(gas_holed.data))
+```
+
+```
+type: HydroDataType   cells: 12081619
+```
+
+### Tilted Cylinders / Disks
+
+`Cylinder` takes an `axis` (any non-zero 3-vector — its symmetry direction), so you can select an inclined disk or cylinder, e.g. along a galaxy's spin vector. A thin cylinder is a disk; the default `axis=[0,0,1]` is the classic z-aligned cylinder.
+
+```julia
+# a thin disk tilted in the x-z plane
+gas_disk = subregion(gas, Cylinder(15.0, 1.0; axis=[1.0,0.0,2.0], range_unit=:kpc))
+println("tilted-disk cells: ", length(gas_disk.data), "   mass: ", msum(gas_disk, :Msol), " Msol")
+```
+
+```
+tilted-disk cells: 4557706   mass: 6.295667826746608e9 Msol
+```
+
 ## Summary
 
 This notebook provided comprehensive coverage of spatial selection techniques for hydrodynamic simulation data analysis using Mera.jl's powerful geometric filtering capabilities.

--- a/docs/src/03_particles_Get_Subregions.md
+++ b/docs/src/03_particles_Get_Subregions.md
@@ -1132,6 +1132,36 @@ cb = colorbar(im, label=labeltext);
 
 ![](03_particles_Get_Subregions_files/03_particles_Get_Subregions_85_1.png)
 
+## Value-Type Regions
+
+`subregion` also accepts composable **region value types** — `Sphere`, `Cuboid`, `Cylinder`, `SphericalShell` — that compose with the boolean operators `∩` `∪` `\` `!`. For particles the region is a **point-membership** test (particles are points, so there is no fractional volume — `split`/`nsub` do not apply). `inverse=true` selects the complement.
+
+```julia
+# particles inside a ball, and the complement outside it
+part_in  = subregion(particles, Sphere(10.0; center=[:bc], range_unit=:kpc))
+part_out = subregion(particles, Sphere(10.0; center=[:bc], range_unit=:kpc), inverse=true)
+println("inside: ", length(part_in.data), "   outside: ", length(part_out.data),
+        "   total: ", length(particles.data))
+```
+
+```
+inside: 419529   outside: 89410   total: 508939
+```
+
+### Boolean Combinations
+
+Compose primitives into complex regions — e.g. a ball with a tilted cylinder removed:
+
+```julia
+# a ball with a cylindrical channel removed (tilted along [1,0,2])
+part_sel = subregion(particles, Sphere(12.0; range_unit=:kpc) \ Cylinder(3.0, 12.0; axis=[1.0,0.0,2.0], range_unit=:kpc))
+println("type: ", typeof(part_sel), "   selected: ", length(part_sel.data))
+```
+
+```
+type: PartDataType   selected: 338503
+```
+
 ## Summary
 
 This tutorial demonstrated comprehensive spatial selection techniques for particle simulation data using Mera.jl. The key accomplishments include:


### PR DESCRIPTION
Adds a 'Value-Type Regions' section to each of the four subregion tutorial pages (hydro/gravity/particles/clumps), with real outputs run on the manu_sim_sf_L14 galaxy fixture — exact cell splitting, boolean combinators, tilted disks (hydro), point-membership (particles/clumps), exact volume splitting (gravity). Inserted surgically into the already-cleaned tutorial markdown to preserve existing content. Docs build clean; code blocks parse (test/30). The source notebooks carry the same cells + outputs.