### PR TITLE
regions: CylindricalShell value type + shell tutorial sections

### DIFF
--- a/docs/src/03_clumps_Get_Subregions.md
+++ b/docs/src/03_clumps_Get_Subregions.md
@@ -1258,6 +1258,17 @@ println("type: ", typeof(clumps_sel), "   selected clumps: ", length(clumps_sel.
 type: ClumpDataType   selected clumps: 292
 ```
 
+### Shell Regions
+
+```julia
+clumps_shell = subregion(clumps, SphericalShell(5.0, 20.0; range_unit=:kpc))
+println("clumps in spherical shell [5,20] kpc: ", length(clumps_shell.data), " / ", length(clumps.data))
+```
+
+```
+clumps in spherical shell [5,20] kpc: 427 / 644
+```
+
 ## Summary
 ### Key Techniques Mastered
 

--- a/docs/src/03_hydro_Get_Subregions.md
+++ b/docs/src/03_hydro_Get_Subregions.md
@@ -1261,6 +1261,22 @@ println("tilted-disk cells: ", length(gas_disk.data), "   mass: ", msum(gas_disk
 tilted-disk cells: 4557706   mass: 6.295667826746608e9 Msol
 ```
 
+### Shell Regions
+
+`SphericalShell` and `CylindricalShell` are the value-type analogues of `shellregion(:sphere)` / `shellregion(:cylinder)`, with the same exact edge-cell splitting (and a tunable `axis` for the cylindrical shell). A shell is also just a difference, e.g. `Sphere(r_out) \ Sphere(r_in)`.
+
+```julia
+gas_sshell = subregion(gas, SphericalShell(6.0, 10.0; range_unit=:kpc))
+gas_cshell = subregion(gas, CylindricalShell(3.0, 8.0, 4.0; range_unit=:kpc))
+println("spherical shell:   mass = ", msum(gas_sshell, :Msol), " Msol   cells = ", length(gas_sshell.data))
+println("cylindrical shell: mass = ", msum(gas_cshell, :Msol), " Msol   cells = ", length(gas_cshell.data))
+```
+
+```
+spherical shell:   mass = 8.254683536097689e9 Msol   cells = 4157946
+cylindrical shell: mass = 1.0586921852642824e10 Msol   cells = 6859080
+```
+
 ## Summary
 
 This notebook provided comprehensive coverage of spatial selection techniques for hydrodynamic simulation data analysis using Mera.jl's powerful geometric filtering capabilities.

--- a/docs/src/03_particles_Get_Subregions.md
+++ b/docs/src/03_particles_Get_Subregions.md
@@ -1162,6 +1162,19 @@ println("type: ", typeof(part_sel), "   selected: ", length(part_sel.data))
 type: PartDataType   selected: 338503
 ```
 
+### Shell Regions
+
+`SphericalShell` / `CylindricalShell` work as point-membership selections too:
+
+```julia
+part_shell = subregion(particles, SphericalShell(10.0, 20.0; range_unit=:kpc))
+println("particles in spherical shell [10,20] kpc: ", length(part_shell.data), " / ", length(particles.data))
+```
+
+```
+particles in spherical shell [10,20] kpc: 88446 / 508939
+```
+
 ## Summary
 
 This tutorial demonstrated comprehensive spatial selection techniques for particle simulation data using Mera.jl. The key accomplishments include:

--- a/docs/src/api/subregions.md
+++ b/docs/src/api/subregions.md
@@ -73,7 +73,7 @@ shellregion(data, :sphere, radius=[8., 12.], range_unit=:kpc)
 ## Composable regions with exact cell splitting
 
 Alongside the symbol API (`subregion(data, :sphere; …)`), `subregion` accepts a **region value
-type** ([`Sphere`](@ref), [`Cuboid`](@ref), [`Cylinder`](@ref), [`SphericalShell`](@ref)). With
+type** ([`Sphere`](@ref), [`Cuboid`](@ref), [`Cylinder`](@ref), [`SphericalShell`](@ref), [`CylindricalShell`](@ref)). With
 `split=true` (the default for this form), cells straddling the region boundary are **clipped
 exactly**: each kept cell carries a `:fraction ∈ (0,1]` equal to the volume fraction inside the
 region, and [`getvar`](@ref)`(:mass)` / `(:volume)` / [`msum`](@ref) report the **exact in-region
@@ -85,6 +85,7 @@ msum(gas_in, :Msol)        # exact enclosed mass (boundary cells weighted by the
 
 subregion(gas, Cuboid(xrange=[-10,10], yrange=[-10,10], zrange=[-2,2], range_unit=:kpc))
 subregion(gas, SphericalShell(10.0, 20.0; range_unit=:kpc))
+subregion(gas, CylindricalShell(3.0, 8.0, 4.0; range_unit=:kpc))   # value-type analogue of shellregion(:cylinder)
 subregion(gas, Cylinder(15.0, 3.0; range_unit=:kpc); split=false)      # classic whole-cell selection
 ```
 

--- a/src/Mera.jl
+++ b/src/Mera.jl
@@ -270,6 +270,7 @@ export
     Cylinder,
     Cuboid,
     SphericalShell,
+    CylindricalShell,
 
 # miscellaneous
     viewmodule,

--- a/src/functions/regions/region_algebra.jl
+++ b/src/functions/regions/region_algebra.jl
@@ -69,6 +69,16 @@ end
 SphericalShell(r_in::Real, r_out::Real; center=[:bc], range_unit::Symbol=:kpc) =
     SphericalShell(Float64(r_in), Float64(r_out), Vector{Any}(center), range_unit)
 
+"""    CylindricalShell(r_in, r_out, height; axis=[0,0,1], center=[:bc], range_unit=:kpc)
+
+A cylindrical shell `r_in ≤ r_cyl ≤ r_out` of half-height `height` along `axis` (the value-type
+analogue of `shellregion(:cylinder)`; `axis` allows a tilted shell)."""
+struct CylindricalShell <: AbstractRegion
+    r_in::Float64; r_out::Float64; height::Float64; axis::Vector{Float64}; center::Vector{Any}; range_unit::Symbol
+end
+CylindricalShell(r_in::Real, r_out::Real, height::Real; axis=[0.,0.,1.], center=[:bc], range_unit::Symbol=:kpc) =
+    CylindricalShell(Float64(r_in), Float64(r_out), Float64(height), Float64.(axis), Vector{Any}(center), range_unit)
+
 """    Cylinder(radius, height; axis=[0,0,1], center=[:bc], range_unit=:kpc)
 
 A cylinder of cylindrical `radius` spanning `±height` along `axis` (so `height` is the
@@ -131,6 +141,13 @@ end
 function _prepare(r::SphericalShell, obj; nsub::Int=8)
     cf_out, in_out = _prepare(Sphere(r.r_out; center=r.center, range_unit=r.range_unit), obj; nsub=nsub)
     cf_in,  in_in  = _prepare(Sphere(r.r_in;  center=r.center, range_unit=r.range_unit), obj; nsub=nsub)
+    cellfrac(nx,ny,nz,h) = cf_out(nx,ny,nz,h) - cf_in(nx,ny,nz,h)   # both convex → exact difference
+    contains(x,y,z) = in_out(x,y,z) && !in_in(x,y,z)
+    return cellfrac, contains
+end
+function _prepare(r::CylindricalShell, obj; nsub::Int=8)
+    cf_out, in_out = _prepare(Cylinder(r.r_out, r.height; axis=r.axis, center=r.center, range_unit=r.range_unit), obj; nsub=nsub)
+    cf_in,  in_in  = _prepare(Cylinder(r.r_in,  r.height; axis=r.axis, center=r.center, range_unit=r.range_unit), obj; nsub=nsub)
     cellfrac(nx,ny,nz,h) = cf_out(nx,ny,nz,h) - cf_in(nx,ny,nz,h)   # both convex → exact difference
     contains(x,y,z) = in_out(x,y,z) && !in_in(x,y,z)
     return cellfrac, contains

--- a/test/55_region_algebra_tests.jl
+++ b/test/55_region_algebra_tests.jl
@@ -62,6 +62,21 @@
         @test isapprox(vol(s) + vol(inv), Vbox; rtol=1e-6)      # region + complement = whole box
     end
 
+    @testset "shell value types (spherical + cylindrical)" begin
+        rin, rout = 0.12box, 0.28box
+        ss = subregion(gas, SphericalShell(rin, rout; range_unit=:kpc); verbose=false)
+        @test isapprox(vol(ss), (4/3)*pi*(rout^3 - rin^3); rtol=0.02)
+        # a cylindrical shell of half-height H
+        H = 0.20box
+        cs = subregion(gas, CylindricalShell(rin, rout, H; range_unit=:kpc); verbose=false)
+        @test isapprox(vol(cs), pi*(rout^2 - rin^2)*(2H); rtol=0.02)
+        # a tilted cylindrical shell has the same volume (orientation-invariant)
+        cst = subregion(gas, CylindricalShell(rin, rout, H; axis=[1.,1.,1.], range_unit=:kpc); verbose=false)
+        @test isapprox(vol(cst), pi*(rout^2 - rin^2)*(2H); rtol=0.03)
+        # the spherical shell equals a concentric Sphere-difference
+        @test isapprox(vol(ss), vol(subregion(gas, Sphere(rout; range_unit=:kpc) \ Sphere(rin; range_unit=:kpc); verbose=false)); rtol=1e-6)
+    end
+
     @testset "boolean combinators (∩ ∪ \\ !)" begin
         A = Sphere(R; range_unit=:kpc)
         B = Cylinder(0.18box, 0.5box; range_unit=:kpc)


### PR DESCRIPTION
Completes the value-type shell story: adds **CylindricalShell** (value-type analogue of `shellregion(:cylinder)`, exact splitting, tilis axis) to complement the existing `SphericalShell`. test/55 +4 (64/64; shell volumes vs analytic, tilt-invariance, shell==Sphere-difference); Aqua 10/10. Docs: api/subregions.md + a 'Shell Regions' subsection in the hydro/particles/clumps subregion tutorials with outputs from the manu_sim_sf_L14 galaxy fixture. The value-type API now covers spherical and cylindrical shells across all data types.