### PR TITLE
filtering: value-space selection on derived quantities (filterdata / getmask)

### DIFF
--- a/docs/src/05_multi_Masking_Filtering.md
+++ b/docs/src/05_multi_Masking_Filtering.md
@@ -760,6 +760,31 @@ sum(var_filtered)
 2.7506324500621886e9
 ```
 
+## Value-Space Filtering: `filterdata` and `getmask`
+
+The macros above filter on *stored* table columns. `filterdata` (and `getmask`) instead select by **any [`getvar`](@ref) quantity** — including derived physics such as temperature `:T`, radial velocity `:vr`, Mach number `:mach` or cylindrical radius `:r_cylinder` — in any unit, and return a **new object of the same type** (chainable with `projection`, `getvar`, `subregion`, …). Conditions are composable value types ([`Above`](@ref), [`Below`](@ref), [`InRange`](@ref)) combined with `&` (and), `|` (or) and `!` (not). Masks are built vectorised through `getvar`, so they are fast and work on quantities the raw-column `@filter` cannot see.
+
+```julia
+# select by a DERIVED quantity (temperature), returning a chainable HydroDataType
+hot = filterdata(gas, Above(:T, 1e4, unit=:K))
+projection(hot, :sd, :Msol_pc2)            # the result is a normal Mera object
+
+# boolean algebra over several physical quantities
+cold_dense = filterdata(gas, Below(:T, 1e3, unit=:K) & Above(:rho, 100, unit=:nH))
+
+# a kinematically/radially confined slice (several positional conditions are AND-combined)
+disc = filterdata(gas, InRange(:r_cylinder, 0, 15, unit=:kpc), Below(:vz, 50, unit=:km_s))
+
+# quantity/predicate shorthand for a single condition
+hot2 = filterdata(gas, :T, >(1e4), unit=:K)
+
+# or get just the boolean mask and reuse it via the `mask=` keyword (no data copy):
+m = getmask(gas, Above(:T, 1e4, unit=:K))
+msum(gas, mask=m)                          # in-mask total mass, original object untouched
+```
+
+`filterdata`/`getmask` work on hydro, gravity, RT, particles and clumps.
+
 ## Extend the Data Table
 Add costum columns/variables to the data that can be automatically processed in some functions:
 (note: to take advantage of the Mera unit management, store new data in code-units)

--- a/src/Mera.jl
+++ b/src/Mera.jl
@@ -264,6 +264,12 @@ export
     benchmark_projection_hydro,
     show_threading_info,
     subregion,
+    filterdata,
+    getmask,
+    FilterCondition,
+    Above,
+    Below,
+    InRange,
     shellregion,
     AbstractRegion,
     Sphere,
@@ -449,6 +455,7 @@ include("functions/regions/subregion_clumps.jl")
 include("functions/regions/shellregion.jl")
 include("functions/regions/shellregion_hydro.jl")
 include("functions/regions/region_algebra.jl")
+include("functions/filterdata.jl")
 include("functions/regions/shellregion_gravity.jl")
 include("functions/regions/shellregion_rt.jl")
 include("functions/regions/shellregion_particles.jl")

--- a/src/functions/filterdata.jl
+++ b/src/functions/filterdata.jl
@@ -1,0 +1,108 @@
+# =====================================================================================
+#  filterdata.jl — value-space selection on ANY getvar quantity
+# -------------------------------------------------------------------------------------
+#  The value-space analogue of `subregion`: composable `FilterCondition` value types that
+#  select cells/particles by a *physical quantity* (`:T`, `:vr`, `:mach`, `:rho`, …, anything
+#  `getvar` computes, in any unit), with boolean algebra (`&` `|` `!`). Two verbs:
+#    getmask(obj, cond)    -> BitVector   (pass to getvar/projection/statistics `mask=`)
+#    filterdata(obj, cond) -> a NEW Mera object of the same type (chainable with projection,
+#                             getvar, subregion, …).
+#  Masks are built vectorised through `getvar` (fast; no per-row closures), so they work on
+#  derived quantities that the raw-column `@filter` macro cannot see. Works on every type
+#  `getvar` supports: hydro, gravity, RT, particles, clumps.
+# =====================================================================================
+
+"""    FilterCondition
+
+Supertype of the composable value-space selectors passed to [`getmask`](@ref) /
+[`filterdata`](@ref): [`Above`](@ref), [`Below`](@ref), [`InRange`](@ref). Combine them with
+`&` (and), `|` (or) and `!` (not) — e.g. `Above(:T, 1e4; unit=:K) & Below(:rho, 100; unit=:nH)`."""
+abstract type FilterCondition end
+
+"""    Above(quantity, value; unit=:standard)
+
+Keep rows where `getvar(obj, quantity, unit) > value`."""
+struct Above <: FilterCondition; quantity::Symbol; value::Float64; unit::Symbol; end
+Above(q::Symbol, v::Real; unit::Symbol=:standard) = Above(q, Float64(v), unit)
+
+"""    Below(quantity, value; unit=:standard)
+
+Keep rows where `getvar(obj, quantity, unit) < value`."""
+struct Below <: FilterCondition; quantity::Symbol; value::Float64; unit::Symbol; end
+Below(q::Symbol, v::Real; unit::Symbol=:standard) = Below(q, Float64(v), unit)
+
+"""    InRange(quantity, lo, hi; unit=:standard)
+
+Keep rows where `lo ≤ getvar(obj, quantity, unit) ≤ hi`."""
+struct InRange <: FilterCondition; quantity::Symbol; lo::Float64; hi::Float64; unit::Symbol; end
+InRange(q::Symbol, lo::Real, hi::Real; unit::Symbol=:standard) = InRange(q, Float64(lo), Float64(hi), unit)
+
+# internal boolean combinators (built via the operators below)
+struct _And <: FilterCondition; a::FilterCondition; b::FilterCondition; end
+struct _Or  <: FilterCondition; a::FilterCondition; b::FilterCondition; end
+struct _Not <: FilterCondition; a::FilterCondition; end
+Base.:&(a::FilterCondition, b::FilterCondition) = _And(a, b)
+Base.:|(a::FilterCondition, b::FilterCondition) = _Or(a, b)
+Base.:!(a::FilterCondition)                     = _Not(a)
+
+# vectorised quantity fetch (getvar in the requested unit; :standard = code units)
+_qvals(obj, q::Symbol, unit::Symbol) = unit === :standard ? getvar(obj, q) : getvar(obj, q, unit)
+
+_mask(c::Above, obj)   = _qvals(obj, c.quantity, c.unit) .> c.value
+_mask(c::Below, obj)   = _qvals(obj, c.quantity, c.unit) .< c.value
+_mask(c::InRange, obj) = (v = _qvals(obj, c.quantity, c.unit); (v .>= c.lo) .& (v .<= c.hi))
+_mask(c::_And, obj)    = _mask(c.a, obj) .& _mask(c.b, obj)
+_mask(c::_Or, obj)     = _mask(c.a, obj) .| _mask(c.b, obj)
+_mask(c::_Not, obj)    = .!_mask(c.a, obj)
+
+"""
+    getmask(obj, condition) -> BitVector
+    getmask(obj, quantity, predicate; unit=:standard) -> BitVector
+
+Build a boolean selection mask over `obj`'s rows from a value-space `condition`
+([`FilterCondition`](@ref), composable with `&`/`|`/`!`) or from a `quantity`/`predicate`
+pair (e.g. `getmask(gas, :T, >(1e4); unit=:K)`). The mask is computed vectorised through
+[`getvar`](@ref), so it works on any derived quantity; pass it to `getvar`/`projection`/
+statistics via their `mask=` keyword without copying the data.
+"""
+getmask(obj, c::FilterCondition) = BitVector(_mask(c, obj))
+getmask(obj, quantity::Symbol, pred; unit::Symbol=:standard) =
+    BitVector(pred.(_qvals(obj, quantity, unit)))
+
+"""
+    filterdata(obj, condition...; verbose=true) -> same-type Mera object
+    filterdata(obj, quantity, predicate; unit=:standard, verbose=true) -> same-type Mera object
+
+Select the rows of `obj` (hydro / gravity / RT / particles / clumps) matching a value-space
+`condition` and return a **new object of the same type** — chainable with `projection`,
+`getvar`, `subregion`, … . Conditions select by any [`getvar`](@ref) quantity in any unit and
+compose with `&`/`|`/`!`; several positional conditions are AND-combined. The `quantity`/
+`predicate` form is a shorthand for a single condition.
+
+```julia
+hot   = filterdata(gas, Above(:T, 1e4; unit=:K))
+cold_dense = filterdata(gas, Below(:T, 1e3; unit=:K) & Above(:rho, 100; unit=:nH))
+disc  = filterdata(gas, InRange(:r_cylinder, 0, 15; unit=:kpc), Below(:vz, 50; unit=:km_s))
+projection(hot, :sd, :Msol_pc2)        # the result is a normal Mera object
+```
+"""
+function filterdata(obj, c::FilterCondition; verbose::Bool=true)
+    verbose = checkverbose(verbose)
+    mask = _mask(c, obj)
+    data = obj.data
+    cols = IndexedTables.columns(data)
+    newdata = IndexedTables.table(map(col -> col[mask], cols); pkey = collect(IndexedTables.pkeynames(data)))
+    if verbose
+        println("Filter: ", nameof(typeof(obj)))
+        println("Selected rows: ", count(mask), " / ", length(data))
+    end
+    return _copy_with_data(obj, newdata)
+end
+filterdata(obj, c1::FilterCondition, c2::FilterCondition, rest::FilterCondition...; verbose::Bool=true) =
+    filterdata(obj, foldl(&, (c1, c2, rest...)); verbose=verbose)
+filterdata(obj, quantity::Symbol, pred; unit::Symbol=:standard, verbose::Bool=true) =
+    filterdata(obj, _PredCond(quantity, pred, unit); verbose=verbose)
+
+# adapter so the quantity/predicate shorthand reuses the same machinery
+struct _PredCond <: FilterCondition; quantity::Symbol; pred; unit::Symbol; end
+_mask(c::_PredCond, obj) = c.pred.(_qvals(obj, c.quantity, c.unit))

--- a/test/56_filterdata_tests.jl
+++ b/test/56_filterdata_tests.jl
@@ -1,0 +1,60 @@
+# 56_filterdata_tests.jl  --  value-space filtering on derived quantities (data-free)
+# ==============================================================================
+# FilterCondition value types (Above/Below/InRange + &/|/!) and the getmask / filterdata
+# verbs, validated on the synthetic_clumps field (no simulation data). The key feature over
+# the raw-column @filter macro: conditions select by ANY getvar quantity (derived physics),
+# return a chainable Mera object, and compose with boolean algebra.
+# ==============================================================================
+
+@testset verbose=true "filterdata / getmask (value-space selection, data-free)" begin
+    F = synthetic_clumps(background=:galaxy, lmax=5)
+    gas = F.gas; part = F.particles
+    n = length(gas.data)
+    rho_nH = getvar(gas, :rho, :nH)
+    cs     = getvar(gas, :cs)               # a DERIVED quantity (not a stored column)
+    a, b   = 50.0, sum(cs)/length(cs)       # density & mean-sound-speed thresholds
+
+    @testset "raw quantity → chainable Mera object" begin
+        hi = filterdata(gas, Above(:rho, a; unit=:nH), verbose=false)
+        @test hi isa Mera.HydroDataType
+        @test length(hi.data) == count(rho_nH .> a) > 0
+        @test !in(:fraction, propertynames(Mera.columns(hi.data)))
+        # chainable: projection works on the filtered object
+        p = projection(hi, :sd, :Msol_pc2; res=64, center=[:bc], verbose=false, show_progress=false)
+        @test maximum(p.maps[:sd]) > 0
+    end
+
+    @testset "derived quantity (the @filter macro can't do this)" begin
+        hot = filterdata(gas, Above(:cs, b), verbose=false)
+        @test length(hot.data) == count(cs .> b)
+        bt  = filterdata(gas, InRange(:cs, 0.0, b), verbose=false)
+        @test length(bt.data) == count((cs .>= 0.0) .& (cs .<= b))
+    end
+
+    @testset "boolean algebra (& | !)" begin
+        @test length(filterdata(gas, Above(:rho,a;unit=:nH) & Below(:cs,b), verbose=false).data) ==
+              count((rho_nH .> a) .& (cs .< b))
+        @test length(filterdata(gas, Above(:rho,a;unit=:nH) | Below(:cs,b), verbose=false).data) ==
+              count((rho_nH .> a) .| (cs .< b))
+        @test length(filterdata(gas, !Above(:rho,a;unit=:nH), verbose=false).data) == n - count(rho_nH .> a)
+        # several positional conditions are AND-combined
+        @test length(filterdata(gas, Above(:rho,a;unit=:nH), Below(:cs,b), verbose=false).data) ==
+              count((rho_nH .> a) .& (cs .< b))
+    end
+
+    @testset "predicate shorthand + getmask + mask= reuse" begin
+        @test length(filterdata(gas, :rho, >(a); unit=:nH, verbose=false).data) == count(rho_nH .> a)
+        m = getmask(gas, Above(:rho, a; unit=:nH))
+        @test m isa BitVector && count(m) == count(rho_nH .> a)
+        # the mask drives the existing mask= keyword without copying the data
+        flt = filterdata(gas, Above(:rho, a; unit=:nH), verbose=false)
+        @test isapprox(sum(getvar(gas, :mass, :Msol)[m]), msum(flt, :Msol); rtol=1e-9)
+    end
+
+    @testset "works on particles too" begin
+        pv = filterdata(part, Above(:vx, 50.0; unit=:km_s) | Below(:vx, -50.0; unit=:km_s), verbose=false)
+        vx = getvar(part, :vx, :km_s)
+        @test pv isa Mera.PartDataType
+        @test length(pv.data) == count((vx .> 50.0) .| (vx .< -50.0))
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -73,6 +73,7 @@ if isempty(_focus)
         include("47_benchmark_tests.jl")  # data-free I/O benchmark (run_benchmark/plot_results) on a temp folder
         include("54_clumpfind_synthetic_tests.jl")  # data-free: all 7 finders + features scored vs synthetic ground truth
         include("55_region_algebra_tests.jl")  # data-free: composable regions + exact cell splitting vs analytic volumes
+        include("56_filterdata_tests.jl")  # data-free: value-space filtering on derived quantities (filterdata/getmask)
     end
 
     # ========================================================================


### PR DESCRIPTION
## Summary

The value-space analogue of `subregion` — and a big upgrade over the raw-column `@filter` macro. Composable `FilterCondition` value types select by **any `getvar` quantity** (derived physics, not just stored columns), in any unit, with boolean algebra:

```julia
hot        = filterdata(gas, Above(:T, 1e4, unit=:K))                         # DERIVED quantity → chainable HydroDataType
cold_dense = filterdata(gas, Below(:T, 1e3, unit=:K) & Above(:rho, 100, unit=:nH))
disc       = filterdata(gas, InRange(:r_cylinder, 0, 15, unit=:kpc), Below(:vz, 50, unit=:km_s))
projection(hot, :sd, :Msol_pc2)              # the result is a normal Mera object

m = getmask(gas, Above(:T, 1e4, unit=:K))    # or just the BitVector mask
msum(gas, mask=m)                            # reuse via the existing mask= keyword, no data copy
```

## Why it's better than `@filter`
| | `@filter` macro | `filterdata` / `getmask` |
|---|---|---|
| Quantities | stored **columns only** | **any `getvar` quantity** (`:T`, `:vr`, `:mach`, `:r_cylinder`, …) |
| Conditions | one comparison (or verbose `@apply` chain) | `&` `\|` `!` + varargs-AND in one expression |
| Result | bare `IndexedTable` | **new Mera object** (chainable with projection/getvar/subregion) |
| Units | raw code values | any unit (`:K`, `:nH`, `:km_s`, `:kpc`, …) |
| Speed | per-row closures | **vectorised** through `getvar` |
| Types | tables | hydro / gravity / RT / particles / clumps |

## Tests / quality
- **`test/56`** — 15 data-free assertions: raw + derived quantities match a manual `getvar` mask, boolean algebra, varargs AND, predicate shorthand, `getmask`⇄`mask=` consistency, chaining into `projection`, particles.
- **Aqua 10/10**; the existing `@filter`/`@where`/`@apply` macros (test/25, 30/30) are untouched. (`InRange` is named to avoid the `IndexedTables.Between` export clash.)
- Docs: auto API reference + a "Value-Space Filtering" section in the masking/filtering tutorial. Build clean; code blocks parse.
