### PR TITLE
docs: link Extend-the-Data-Table to the simpler derived-quantities path

### DIFF
--- a/docs/src/05_multi_Masking_Filtering.md
+++ b/docs/src/05_multi_Masking_Filtering.md
@@ -794,6 +794,9 @@ sub    = @filter gas.data :rho >= 1e-2     # raw table → filtered table (class
 Add costum columns/variables to the data that can be automatically processed in some functions:
 (note: to take advantage of the Mera unit management, store new data in code-units)
 
+!!! tip "Simpler alternative — derived quantities"
+    If you only need a quantity for *analysis* (not a stored column), you usually don't have to add one. [`getvar`](@ref) computes many derived quantities directly — e.g. `getvar(gas, :mach)`, `:T`, `:vr`, `:r_cylinder`, `:cs`, … — and these are exactly what `filterdata`/`getmask`, `projection` and the statistics functions accept. To register *your own* reusable derived quantity by formula, use [`add_field`](@ref). See [Derived Fields & add_field](derived_fields.md) and [How Quantities Are Computed](computation_reference.md). Materialising a column (below) is only needed when you want the values stored in the table itself.
+
 ```julia
 # calculate the Mach number in each cell
 mach = getvar(gas, :mach);


### PR DESCRIPTION
Adds a tip in the masking tutorial's 'Extend the Data Table' section pointing to the simpler alternative for readers who only need a quantity for analysis: `getvar` computes many derived quantities directly (`:mach`/`:T`/`:vr`/`:r_cylinder`/…) and `add_field` registers custom ones — no need to materialise a column. Links to Derived Fields & How Quantities Are Computed. (Also mirrored into the source notebook along with the masking modernization + Value-Space/Quick-Start cells.)