### PR TITLE
readers: Athena++ (.athdf) frontend with AMR support

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -108,6 +108,7 @@ makedocs(modules = [Mera],
                                                         "API Reference" => "api/mera_files.md"],
 
                           "Other Codes (PLUTO)" => "pluto_reader.md",
+                          "Other Codes (Athena++)" => "athena_reader.md",
 
                           "Volume Rendering"    => Any[ "Intro"      =>  "paraview/paraview_intro.md",
                                                         "Hydro"      =>  "paraview/08_hydro_VTK_export.md",

--- a/docs/src/athena_reader.md
+++ b/docs/src/athena_reader.md
@@ -1,0 +1,66 @@
+# Reading Athena++ data (experimental)
+
+Mera's analysis layer is **code-blind**: it works on a generic uniform/AMR cell list, not on
+RAMSES file formats. This page adds a **frontend for the [Athena++ code](https://www.athena-astro.app)**
+that reads an Athena++ HDF5 snapshot (`.athdf`) into the same Mera structs — so [`getvar`](@ref),
+[`projection`](@ref), [`subregion`](@ref), [`filterdata`](@ref), [`pdf`](@ref), [`clumpfind`](@ref)
+and the rest run on Athena++ data unchanged.
+
+!!! note "Scope"
+    3-D Cartesian, hydro and cell-centred MHD fields. **AMR is supported** — each Athena++
+    MeshBlock carries a level and a logical location, which map onto Mera's `level`/`cx,cy,cz`
+    convention. The root grid must be a power of two per axis. Athena++ data are in **code
+    units**; supply the run's CGS units for physical conversions (see below).
+
+## Usage
+
+The normal [`getinfo`](@ref) / [`gethydro`](@ref) entry points **auto-detect** Athena++ from the
+`.athdf` file — nothing special to call:
+
+```julia
+using Mera
+info = getinfo(5, "/path/to/athena/run")     # finds run/*.00005.athdf, simcode = "Athena++"
+gas  = gethydro(info)                         # a HydroDataType in Mera's cell convention
+
+# now the whole analysis layer works unchanged:
+projection(gas, :sd, :Msol_pc2)
+filterdata(gas, Above(:rho, 100, unit=:nH))
+clumpfind(gas, ThresholdFoF(:rho; threshold=1e2, threshold_unit=:nH, linking_length=0.2))
+```
+
+You can also call the frontend explicitly with [`getinfo_athena`](@ref) / [`gethydro_athena`](@ref)
+(e.g. to pass a direct `.athdf` path).
+
+## Units
+
+Athena++ writes data in code units and does not store CGS scale factors, so by default the run is
+treated as dimensionless (`unit_* = 1`). Pass the run's CGS `unit_length` / `unit_density` /
+`unit_velocity` for a dimensional run and every `getvar`/`projection` unit conversion becomes
+physical:
+
+```julia
+# e.g. UNIT_LENGTH = 1 kpc, UNIT_DENSITY = m_p, UNIT_VELOCITY = 1 km/s
+info = getinfo_athena(5, "/path/to/run"; unit_length=3.086e21, unit_density=1.67e-24, unit_velocity=1e5)
+getvar(gethydro(info), :x, :kpc)              # now physically correct
+```
+
+## Variable names
+
+Athena++ `VariableNames` are mapped to Mera's canonical symbols: `rho→:rho`, `press→:p`,
+`vel1/2/3→:vx/:vy/:vz`, `Bcc1/2/3→:bx/:by/:bz` (and the conserved-variable names `dens`, `mom1…`,
+`Etot`). Unmapped names pass through as-is.
+
+## How it maps onto Mera's grid
+
+The one thing that must be exactly right is the cell-coordinate encoding. A MeshBlock at Athena
+level `L` with logical location `(l1,l2,l3)` and block size `(nx1,nx2,nx3)` contributes cells with
+
+```
+level = log2(RootGridSize) + L
+cx    = l1·nx1 + a            # a = 1…nx1, 1-based index on the level-L cell lattice
+```
+
+(and likewise `cy`, `cz`) — the same 1-based level-lattice indexing the RAMSES/PLUTO readers use,
+so off-axis projections, profiles, subregions and movies are all correct. This contract is
+verified data-free in `test/57_athena_reader_tests.jl`, which synthesises tiny `.athdf` files and
+checks that a value written at a known cell reads back at the right `(:level,:cx,:cy,:cz)`.

--- a/src/Mera.jl
+++ b/src/Mera.jl
@@ -72,6 +72,8 @@ export
     getinfo_pluto,
     gethydro_pluto,
     getparticles_pluto,
+    getinfo_athena,
+    gethydro_athena,
     createpath,
     gethydro,
     getgravity,
@@ -413,6 +415,7 @@ include("read_data/RAMSES/gethydro.jl")
 include("read_data/RAMSES/reader_hydro.jl")
 include("read_data/PLUTO/reader_pluto.jl")   # PLUTO frontend (static uniform Cartesian grid)
 include("read_data/PLUTO/reader_chombo.jl")  # Chombo / PLUTO-AMR frontend (HDF5)
+include("read_data/Athena/reader_athena.jl") # Athena++ frontend (HDF5 .athdf MeshBlocks)
 
 include("read_data/RAMSES/getgravity.jl")
 include("read_data/RAMSES/reader_gravity.jl")

--- a/src/read_data/Athena/reader_athena.jl
+++ b/src/read_data/Athena/reader_athena.jl
@@ -1,0 +1,149 @@
+# ====================================================================================
+# Athena++ reader (HDF5 ".athdf")
+#
+# A frontend for the Athena++ code (Stone et al. 2020). Reads an Athena++ HDF5 snapshot
+# (`<basename>.outN.NNNNN.athdf`) — a set of logically-Cartesian MeshBlocks, each at an AMR
+# `level` and `LogicalLocation` — into the SAME Mera structs the RAMSES reader produces: a
+# `HydroDataType` whose cells follow Mera's `(:level, :cx, :cy, :cz, <vars…>)` convention, so
+# the whole analysis layer (getvar / projection / profiles / subregion / filterdata / clumpfind)
+# runs unchanged.
+#
+# Coordinate translation (the one thing that must be exactly right): a MeshBlock at Athena level
+# `L`, logical location `(l1,l2,l3)` and block size `(nx1,nx2,nx3)` contributes cells with
+#     ramses_level = log2(RootGridSize) + L
+#     cx = l1·nx1 + a   (a = 1…nx1, 1-based)          # global index on the level-L cell lattice
+# — the same 1-based level-lattice indexing the PLUTO/RAMSES uniform-grid readers use.
+#
+# Scope (v1): 3-D Cartesian, hydro (and MHD cell-centred fields). Variables are mapped from the
+# Athena++ `VariableNames` to Mera's canonical symbols.
+# ====================================================================================
+
+# Athena++ variable name → Mera canonical symbol (primitive and conserved outputs)
+const _ATHENA_VARMAP = Dict(
+    "rho"=>:rho, "press"=>:p, "vel1"=>:vx, "vel2"=>:vy, "vel3"=>:vz,
+    "Bcc1"=>:bx, "Bcc2"=>:by, "Bcc3"=>:bz,
+    "dens"=>:rho, "Etot"=>:Etot, "mom1"=>:momx, "mom2"=>:momy, "mom3"=>:momz)
+
+_athena_rootlevel(n::Integer) = (l = round(Int, log2(n)); 2^l == n ? l :
+    error("Athena++ reader: RootGridSize must be a power of two per axis; got $n."))
+
+# Resolve the .athdf snapshot file: accept a direct file path, or find `…NNNNN.athdf` in a dir.
+function _athena_file(output::Int, path::String)
+    (isfile(path) && endswith(lowercase(path), ".athdf")) && return path
+    isdir(path) || error("Athena++: $path is neither a .athdf file nor a directory.")
+    tag = "." * lpad(output, 5, '0') * ".athdf"
+    cands = filter(f -> endswith(lowercase(f), lowercase(tag)), readdir(path))
+    isempty(cands) && error("Athena++: no *$tag file in $path")
+    return joinpath(path, sort(cands)[1])
+end
+
+"""
+    getinfo_athena(output::Int, path::String; unit_length=1.0, unit_density=1.0,
+                   unit_velocity=1.0, verbose=true) -> InfoType
+
+Read Athena++ HDF5 (`.athdf`) snapshot metadata for `output` in `path` (a directory holding the
+`…NNNNN.athdf` file, or the file itself) into a Mera `InfoType` (`simcode = "Athena++"`). The
+AMR level range maps to `levelmin`/`levelmax` (`levelmin == levelmax` ⇒ uniform grid). Feed the
+result to [`gethydro`](@ref).
+
+**Units.** Athena++ data is in **code units**; supply the run's CGS `unit_length`/`unit_density`/
+`unit_velocity` for physical `:kpc`/`:Msol`/… conversions (defaults treat the run as
+dimensionless, see [`getinfo_pluto`](@ref) for the same convention).
+"""
+function getinfo_athena(output::Int, path::String; unit_length::Real=1.0, unit_density::Real=1.0,
+                        unit_velocity::Real=1.0, verbose::Bool=true)
+    fn = _athena_file(output, path)
+    info = InfoType(); info.descriptor = DescriptorType()
+    h5open(fn, "r") do f
+        a = attributes(f)
+        coord = lowercase(String(read(a["Coordinates"])))
+        coord == "cartesian" || error("Athena++ reader (v1): cartesian coordinates only; got $coord.")
+        rgs = Int.(read(a["RootGridSize"]))
+        (rgs[1] == rgs[2] == rgs[3]) ||
+            error("Athena++ reader (v1): cubic root grid only; got $(rgs[1])×$(rgs[2])×$(rgs[3]).")
+        rootlevel = _athena_rootlevel(rgs[1])
+        maxlevel  = Int(read(a["MaxLevel"]))
+        rx1 = Float64.(read(a["RootGridX1"]))                # (min, max, ratio)
+        varnames = String.(read(a["VariableNames"]))
+        info.output = output; info.path = abspath(path); info.simcode = "Athena++"
+        info.Narraysize = 0; info.ndim = 3
+        info.levelmin = rootlevel; info.levelmax = rootlevel + maxlevel
+        info.boxlen = rx1[2] - rx1[1]
+        info.time = Float64(read(a["Time"])); info.gamma = 5/3
+        info.aexp = 1.0; info.H0 = 1.0; info.omega_m = 1.0; info.omega_l = 0.0
+        info.omega_k = 0.0; info.omega_b = 0.0
+        info.unit_l = Float64(unit_length); info.unit_d = Float64(unit_density)
+        info.unit_v = Float64(unit_velocity); info.unit_t = info.unit_l / info.unit_v
+        info.unit_m = info.unit_d * info.unit_l^3
+        info.hydro = true; info.gravity = false; info.particles = false
+        info.rt = false; info.clumps = false; info.sinks = false
+        info.variable_list = [get(_ATHENA_VARMAP, v, Symbol(v)) for v in varnames]
+        info.nvarh = length(varnames)
+        info.gravity_variable_list = Symbol[]; info.particles_variable_list = Symbol[]
+        info.rt_variable_list = Symbol[]; info.clumps_variable_list = Symbol[]; info.sinks_variable_list = Symbol[]
+        info.ncpu = Int(read(a["NumMeshBlocks"]))
+        info.mtime = Dates.unix2datetime(round(Int, mtime(fn))); info.ctime = info.mtime
+        if verbose
+            printtime("", verbose)
+            println("Code: ", info.simcode)
+            println("output: ", output, "  time: ", round(info.time, sigdigits=5), " [code units]")
+            println("root grid: ", rgs[1], "³ (level ", rootlevel, "), MaxLevel ", maxlevel,
+                    " ⇒ levels ", info.levelmin, ":", info.levelmax, ", boxlen = ", info.boxlen)
+            println("MeshBlocks: ", info.ncpu, "   variables: (", join(string.(info.variable_list), ", "), ")")
+            println("-------------------------------------------------------")
+        end
+    end
+    createconstants!(info); createscales!(info)
+    return info
+end
+
+"""
+    gethydro_athena(info::InfoType; verbose=true) -> HydroDataType
+
+Read an Athena++ HDF5 snapshot described by `info` (from [`getinfo_athena`](@ref)) into a
+`HydroDataType` with columns `(:level, :cx, :cy, :cz, <vars…>)` in Mera's AMR convention, so the
+analysis layer works on it unchanged. Each MeshBlock's cells are placed on the level lattice via
+its `LogicalLocation` and `level`.
+"""
+function gethydro_athena(info::InfoType; verbose::Bool=true)
+    fn = _athena_file(round(Int, info.output), info.path)
+    data = nothing; ncell = 0; vsyms = info.variable_list
+    h5open(fn, "r") do f
+        a = attributes(f)
+        rootlevel = _athena_rootlevel(Int.(read(a["RootGridSize"]))[1])
+        nx1, nx2, nx3 = Int.(read(a["MeshBlockSize"]))
+        nblk = Int(read(a["NumMeshBlocks"]))
+        levels = Int.(read(f["Levels"]))                     # per-block AMR level
+        ll = Int.(read(f["LogicalLocations"]))               # (3, nblk): logical (i,j,k) per block
+        dsetnames = String.(read(a["DatasetNames"]))
+        numvars   = Int.(read(a["NumVariables"]))            # variable count per dataset
+        dsets = [read(f[d]) for d in dsetnames]              # each (nx1, nx2, nx3, nblk, nvar_d)
+        # map each global variable to its (dataset, local index)
+        varloc = Tuple{Int,Int}[]
+        for (di, nv) in enumerate(numvars), li in 1:nv; push!(varloc, (di, li)); end
+
+        ncell = nblk * nx1 * nx2 * nx3
+        cx = Vector{Int32}(undef, ncell); cy = similar(cx); cz = similar(cx); lvl = similar(cx)
+        vcols = [Vector{Float64}(undef, ncell) for _ in vsyms]
+        k = 0
+        @inbounds for m in 1:nblk
+            L = rootlevel + levels[m]; l1 = ll[1,m]; l2 = ll[2,m]; l3 = ll[3,m]
+            for c in 1:nx3, b in 1:nx2, aa in 1:nx1
+                k += 1
+                cx[k] = l1*nx1 + aa; cy[k] = l2*nx2 + b; cz[k] = l3*nx3 + c; lvl[k] = L
+                for (vi, (di, li)) in enumerate(varloc)
+                    vcols[vi][k] = dsets[di][aa, b, c, m, li]
+                end
+            end
+        end
+        cols = Any[lvl, cx, cy, cz]; names = Symbol[:level, :cx, :cy, :cz]
+        for (vi, vsym) in enumerate(vsyms); push!(cols, vcols[vi]); push!(names, vsym); end
+        data = table(cols...; names=Tuple(names), pkey=[:level, :cx, :cy, :cz], presorted=false, copy=false)
+    end
+    h = HydroDataType()
+    h.data = data; h.info = info; h.lmin = info.levelmin; h.lmax = info.levelmax; h.boxlen = info.boxlen
+    h.ranges = [0., 1., 0., 1., 0., 1.]; h.selected_hydrovars = collect(1:length(vsyms))
+    h.used_descriptors = Dict{Any,Any}(); h.smallr = 0.; h.smallc = 0.; h.scale = info.scale
+    verbose && println("[Mera]: Athena++ hydro $(ncell) cells, vars ", join(string.(vsyms), ", "))
+    return h
+end

--- a/src/read_data/PLUTO/reader_pluto.jl
+++ b/src/read_data/PLUTO/reader_pluto.jl
@@ -59,7 +59,9 @@ end
 # PLUTO static-grid: grid.out + dbl.out;  Chombo AMR (PLUTO/Orion): a *.hdf5 file;
 # RAMSES: output_*/info_*.txt (the default).
 function detect_simcode(path::String)
+    (isfile(path) && endswith(lowercase(path), ".athdf")) && return :athena
     (isfile(joinpath(path, "grid.out")) && isfile(joinpath(path, "dbl.out"))) && return :pluto
+    isdir(path) && any(f -> endswith(lowercase(f), ".athdf"), readdir(path)) && return :athena
     isdir(path) && any(f -> endswith(lowercase(f), ".hdf5"), readdir(path)) && return :chombo
     return :ramses
 end

--- a/src/read_data/RAMSES/gethydro.jl
+++ b/src/read_data/RAMSES/gethydro.jl
@@ -335,6 +335,8 @@ function gethydro(dataobject::InfoType;
         return gethydro_pluto(dataobject; verbose=verbose)
     elseif dataobject.simcode == "CHOMBO"
         return gethydro_chombo(dataobject; verbose=verbose)
+    elseif dataobject.simcode == "Athena++"
+        return gethydro_athena(dataobject; verbose=verbose)
     end
 
     # ═══════════════════════════════════════════════════════════════════════════

--- a/src/read_data/RAMSES/getinfo.jl
+++ b/src/read_data/RAMSES/getinfo.jl
@@ -38,8 +38,10 @@ function getinfo(; output::Real=1, path::String="", namelist::String="", code::S
         return getinfo_pluto(round(Int, output), path == "" ? pwd() : path; verbose=verbose)
     elseif resolved === :chombo
         return getinfo_chombo(round(Int, output), path == "" ? pwd() : path; verbose=verbose)
+    elseif resolved === :athena
+        return getinfo_athena(round(Int, output), path == "" ? pwd() : path; verbose=verbose)
     elseif resolved !== :ramses
-        error("getinfo: unknown code :$resolved (use :auto, :ramses, :pluto, or :chombo).")
+        error("getinfo: unknown code :$resolved (use :auto, :ramses, :pluto, :chombo, or :athena).")
     end
 
 

--- a/test/57_athena_reader_tests.jl
+++ b/test/57_athena_reader_tests.jl
@@ -1,0 +1,80 @@
+# 57_athena_reader_tests.jl  --  Athena++ (.athdf) reader, contract test (data-free)
+# ==============================================================================
+# getinfo_athena / gethydro_athena read an Athena++ HDF5 snapshot (MeshBlocks with a level and
+# LogicalLocation) into the standard Mera structs, so the analysis layer runs unchanged. This
+# test SYNTHESISES tiny .athdf files in the Athena++ schema (no simulation needed) and verifies
+# the one thing that must be exactly right — the MeshBlock → (:level,:cx,:cy,:cz) coordinate
+# mapping — plus that getvar/projection work on the result.
+# ==============================================================================
+
+import Mera.HDF5: h5open, attributes
+
+# write a minimal Athena++ .athdf: `blocks` is a vector of (level, (l1,l2,l3)); each block is
+# nb³ cells; rho is set to a known function of the GLOBAL cell index so the mapping is checkable.
+function _write_athdf(fn; rootsize=4, nb=2, blocks=[(0,(0,0,0)),(0,(1,0,0)),(0,(0,1,0)),(0,(1,1,0)),
+                                                    (0,(0,0,1)),(0,(1,0,1)),(0,(0,1,1)),(0,(1,1,1))])
+    nblk = length(blocks)
+    ll = zeros(Int, 3, nblk); levels = zeros(Int, nblk)
+    prim = zeros(Float64, nb, nb, nb, nblk, 5)
+    for (m, (L, loc)) in enumerate(blocks)
+        levels[m] = L; ll[1,m], ll[2,m], ll[3,m] = loc
+        for c in 1:nb, b in 1:nb, a in 1:nb
+            gcx = loc[1]*nb + a; gcy = loc[2]*nb + b; gcz = loc[3]*nb + c
+            prim[a,b,c,m,1] = gcx + 100*gcy + 10000*gcz + 1e6*L   # rho = f(index, level)
+            prim[a,b,c,m,2] = 1.0; prim[a,b,c,m,3] = 10.0; prim[a,b,c,m,4] = 20.0; prim[a,b,c,m,5] = 30.0
+        end
+    end
+    h5open(fn, "w") do f
+        at = attributes(f)
+        at["Coordinates"] = "cartesian"; at["RootGridSize"] = [rootsize,rootsize,rootsize]
+        at["MeshBlockSize"] = [nb,nb,nb]; at["MaxLevel"] = maximum(levels); at["NumMeshBlocks"] = nblk
+        at["RootGridX1"] = [0.0,1.0,1.0]; at["RootGridX2"] = [0.0,1.0,1.0]; at["RootGridX3"] = [0.0,1.0,1.0]
+        at["Time"] = 0.5; at["VariableNames"] = ["rho","press","vel1","vel2","vel3"]
+        at["DatasetNames"] = ["prim"]; at["NumVariables"] = [5]
+        f["Levels"] = levels; f["LogicalLocations"] = ll; f["prim"] = prim
+    end
+    return ll, levels, nb
+end
+
+@testset verbose=true "Athena++ reader (.athdf, data-free contract)" begin
+    dir = mktempdir()
+
+    @testset "uniform grid: exact MeshBlock → cell mapping" begin
+        fn = joinpath(dir, "blast.out1.00000.athdf")
+        _write_athdf(fn)                                  # 8 blocks of 2³ = a 4³ uniform grid
+        info = getinfo_athena(0, dir, verbose=false)
+        @test info.simcode == "Athena++"
+        @test info.levelmin == 2 == info.levelmax        # log2(4) = 2, single level
+        @test info.boxlen == 1.0 && info.nvarh == 5
+        @test info.variable_list == [:rho, :p, :vx, :vy, :vz]   # Athena names → Mera symbols
+
+        gas = gethydro_athena(info, verbose=false)
+        @test gas isa Mera.HydroDataType && length(gas.data) == 64
+        cx = Mera.select(gas.data, :cx); cy = Mera.select(gas.data, :cy); cz = Mera.select(gas.data, :cz)
+        @test getvar(gas, :rho) == cx .+ 100 .* cy .+ 10000 .* cz       # value reads back at its cell
+        @test all(getvar(gas, :vx) .== 10.0)
+        @test sort(unique(cx)) == [1,2,3,4]                            # full level-2 lattice covered
+        # the analysis layer works unchanged
+        @test extrema(getvar(gas, :x)) == (0.25, 1.0)                  # cx/2^level (Mera convention)
+        @test maximum(projection(gas, :sd, res=8, center=[:bc], verbose=false, show_progress=false).maps[:sd]) > 0
+        @test msum(gas) > 0
+
+        # the generic getinfo/gethydro auto-detect Athena++ from the .athdf file (no special call)
+        info2 = getinfo(0, dir, verbose=false)
+        @test info2.simcode == "Athena++"
+        @test length(gethydro(info2, verbose=false).data) == 64
+    end
+
+    @testset "AMR: per-block levels map to the level lattice" begin
+        fn = joinpath(dir, "amr.out1.00001.athdf")
+        _write_athdf(fn; blocks=[(0,(0,0,0)), (1,(0,0,0)), (1,(1,1,1))])   # one coarse + two fine blocks
+        info = getinfo_athena(1, dir, verbose=false)
+        @test info.levelmin == 2 && info.levelmax == 3                 # rootlevel 2 + maxlevel 1
+        gas = gethydro_athena(info, verbose=false)
+        lvl = Mera.select(gas.data, :level)
+        @test sort(unique(lvl)) == [2, 3]                              # two distinct refinement levels
+        cs = getvar(gas, :cellsize)
+        @test length(unique(round.(cs, sigdigits=8))) == 2            # coarse & fine cell sizes differ
+        @test all(getvar(gas, :rho) .> 0)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -74,6 +74,7 @@ if isempty(_focus)
         include("54_clumpfind_synthetic_tests.jl")  # data-free: all 7 finders + features scored vs synthetic ground truth
         include("55_region_algebra_tests.jl")  # data-free: composable regions + exact cell splitting vs analytic volumes
         include("56_filterdata_tests.jl")  # data-free: value-space filtering on derived quantities (filterdata/getmask)
+        include("57_athena_reader_tests.jl")  # data-free: Athena++ .athdf reader contract (synthetic HDF5)
     end
 
     # ========================================================================


### PR DESCRIPTION
## Summary

A frontend for the **Athena++ code** (HDF5 `.athdf`) — the next multi-code reader after PLUTO/Chombo. `getinfo_athena`/`gethydro_athena` read an Athena++ snapshot (MeshBlocks, each with a level + LogicalLocation) into the standard Mera structs, so the whole analysis layer (`getvar`/`projection`/`subregion`/`filterdata`/`clumpfind`/…) runs unchanged.

```julia
info = getinfo(5, "/path/to/athena/run")     # auto-detects .athdf → simcode "Athena++"
gas  = gethydro(info)
projection(gas, :sd, :Msol_pc2)
```

## The coordinate contract (the one hard part)
A MeshBlock at Athena level `L`, logical location `(l1,l2,l3)`, block size `(nx1,…)` →
```
level = log2(RootGridSize) + L
cx    = l1·nx1 + a    (1-based level-lattice index)
```
the same convention RAMSES/PLUTO use, so off-axis projection, profiles, subregions, etc. are correct. **AMR supported** (per-block levels). Variable names mapped to Mera symbols (`rho→:rho`, `vel1→:vx`, `Bcc1→:bx`, …).

## Auto-detect
`getinfo`/`gethydro` now recognise `.athdf` (`detect_simcode → :athena`) and route to the Athena frontend, alongside `:pluto`/`:chombo`/`:ramses`. Explicit `getinfo_athena`/`gethydro_athena` are also exported.

## Tests / quality
- **`test/57` — 17 assertions, fully data-free**: synthesises tiny `.athdf` files and verifies the exact MeshBlock→`(:level,:cx,:cy,:cz)` mapping (a value written at a known cell reads back at the right cell), a 2-level AMR case (distinct levels/cell sizes), the analysis layer (`getvar`/`projection`/`msum`), and `getinfo`/`gethydro` auto-detect.
- **Aqua clean**; RAMSES (214/214) and PLUTO (52/52) readers unaffected; docs build clean, code blocks parse.
- Docs: `athena_reader.md` (+ nav), API reference.

## Note
Validated with the design doc's data-free contract test (synthetic HDF5 in the Athena++ schema). A data-backed test against a real `.athdf` is a natural follow-on if you have a sample snapshot.
