### PR TITLE
readers: load-time spatial selection for PLUTO/Chombo/Athena++ (align with yt / athena_read / pyPLUTO)

### DIFF
--- a/docs/src/athena_reader.md
+++ b/docs/src/athena_reader.md
@@ -31,13 +31,30 @@ clumpfind(gas, ThresholdFoF(:rho; threshold=1e2, threshold_unit=:nH, linking_len
 You can also call the frontend explicitly with [`getinfo_athena`](@ref) / [`gethydro_athena`](@ref)
 (e.g. to pass a direct `.athdf` path).
 
-!!! note "What loads, and how much"
-    The frontend currently **loads the whole snapshot**: the `xrange`/`yrange`/`zrange`/`lmax`
-    load-time sub-selection of the RAMSES reader is *not yet applied* for non-RAMSES codes (those
-    keywords are accepted but ignored), so restrict a region **after** loading with
-    [`subregion`](@ref). Data is loaded per type, exactly as for RAMSES — but only what the code
-    wrote exists: an Athena++ snapshot is **hydro + cell-centred MHD only** (no gravity/particles),
-    so you call [`gethydro`](@ref) and there is nothing for `getgravity`/`getparticles` to read.
+### Loading a spatial sub-region
+
+`gethydro` honours the RAMSES **spatial-window** arguments `xrange`/`yrange`/`zrange` (with
+`center` and `range_unit`), so you load only the part of the box you need:
+
+```julia
+# central 10 % box, fractions of the box relative to its centre
+gas = gethydro(info; xrange=[-0.05, 0.05], yrange=[-0.05, 0.05], zrange=[-0.05, 0.05],
+               center=[:bc], range_unit=:standard)
+# or a physical window once units are set (see "Units" below)
+gas = gethydro(info; xrange=[-200, 200], center=[:bc], range_unit=:pc)
+```
+
+This is the leaf-cell analogue of Athena++'s **own** reader and of yt — the upstream tools Mera's
+selection mirrors (and is validated against), see [Reference readers](#Reference-readers) below.
+Because Mera keeps the **leaf cells** (each point covered by exactly one cell at its finest level),
+a spatial window is an *exact, hole-free* filter; the returned object records it in `gas.ranges`.
+Resolution/level is chosen later at analysis time (`projection(…, res=)`), not at load — a level
+cap would leave gaps, since no coarse data sits under a leaf.
+
+!!! note "What is available per data type"
+    Data is loaded per type, exactly as for RAMSES — but only what the code wrote exists: an
+    Athena++ snapshot is **hydro + cell-centred MHD only** (no gravity/particles), so you call
+    [`gethydro`](@ref) and there is nothing for `getgravity`/`getparticles` to read.
 
 ## Worked example: the yt AM06 sample
 
@@ -199,3 +216,21 @@ cx    = l1·nx1 + a            # a = 1…nx1, 1-based index on the level-L cell 
 so off-axis projections, profiles, subregions and movies are all correct. This contract is
 verified data-free in `test/57_athena_reader_tests.jl`, which synthesises tiny `.athdf` files and
 checks that a value written at a known cell reads back at the right `(:level,:cx,:cy,:cz)`.
+
+## Reference readers
+
+This frontend is built to agree with — and is validated against — Athena++'s **own** tooling and
+the wider community readers, which are the *origin* of the `.athdf` format and its selection
+semantics:
+
+- **`athena_read.py`** — the official reader shipped with Athena++ (`athena/vis/python/athena_read.py`),
+  whose `athdf()` function reads a snapshot and supports a spatial window (`x1_min`/`x1_max`/…) and a
+  level argument. Mera's load-time `xrange`/`yrange`/`zrange` is the leaf-cell analogue of that
+  window. See the [Athena++ wiki](https://github.com/PrincetonUniversity/athena/wiki).
+- **[yt](https://yt-project.org)** — its `athena_pp` frontend reads `.athdf` lazily through *data
+  objects* (`ds.box`, `ds.sphere`, `ds.r[...]`), touching only the MeshBlocks a region intersects.
+  Mera's spatial selection mirrors that region-selector behaviour on the leaf-cell list. The AM06
+  sample used above comes from the [yt sample-data collection](https://yt-project.org/data/).
+
+Athena++ data are dimensionless (code units) and carry no CGS factors, exactly as both readers
+above assume — supply the run's units explicitly (see [Units](#Units)).

--- a/docs/src/pluto_reader.md
+++ b/docs/src/pluto_reader.md
@@ -42,12 +42,21 @@ info = getinfo(5, path; code=:pluto)        # or :ramses, or :auto (the default)
 The low-level frontend functions are also exported if you want them directly:
 `getinfo_pluto(output, path)` and `gethydro_pluto(info)`.
 
-!!! note "What loads, and how much"
-    The frontend currently **loads the whole snapshot**: the `xrange`/`yrange`/`zrange`/`lmax`
-    load-time sub-selection of the RAMSES reader is *not yet applied* for non-RAMSES codes (those
-    keywords are accepted but ignored), so restrict a region **after** loading with
-    [`subregion`](@ref). Data is loaded per type, exactly as for RAMSES: [`gethydro`](@ref) always,
-    and [`getparticles`](@ref) when a PLUTO particle file is present (`info.particles == true`).
+`gethydro` honours the RAMSES **spatial-window** arguments `xrange`/`yrange`/`zrange` (with
+`center`/`range_unit`), so you can load only the part of the box you need — the same selection the
+upstream readers offer (see [Reference readers](#Reference-readers)):
+
+```julia
+gas = gethydro(info; xrange=[0.0, 0.5], yrange=[0.25, 0.75], range_unit=:standard)  # a sub-box
+```
+
+The selection acts on the **leaf cells**, so it is an exact, hole-free filter and the returned
+object records the window in `gas.ranges`; resolution is chosen later at analysis time
+(`projection(…, res=)`), not at load.
+
+!!! note "What is available per data type"
+    Data is loaded per type, exactly as for RAMSES: [`gethydro`](@ref) always, and
+    [`getparticles`](@ref) when a PLUTO particle file is present (`info.particles == true`).
     PLUTO snapshots carry no separate gravity dataset.
 
 `gas` is an ordinary `HydroDataType` (uniform grid, columns `:cx,:cy,:cz, :rho,:vx,:vy,:vz,:p`),
@@ -212,6 +221,21 @@ plottable** — a volume-weighted mean level along the line of sight shows where
 
 HDF5 reading uses `HDF5.jl` (a dependency of Mera). Requires a power-of-two base grid and
 `ref_ratio = 2` (the common PLUTO/Chombo case).
+
+## Reference readers
+
+This frontend is built to agree with the *origin* tools — the readers that define PLUTO's output
+formats and their selection semantics:
+
+- **`pyPLUTO`** — PLUTO's own Python reader, which documents the static-grid (`grid.out` + `.dbl`)
+  layout this frontend parses. Mera's coordinate mapping is validated against it cell-for-cell.
+- **[yt](https://yt-project.org)** — reads PLUTO's Chombo-HDF5 AMR output through its `chombo`
+  frontend, and selects sub-volumes lazily via *data objects* (`ds.box`, `ds.sphere`, `ds.r[...]`).
+  Mera's load-time `xrange`/`yrange`/`zrange` mirrors that region-selector behaviour on the
+  leaf-cell list.
+
+PLUTO test problems are dimensionless (code units) and carry no CGS factors — exactly as both
+readers above assume; the run's units live in its compiled `definitions.h`, not in the snapshot.
 
 ## See also
 

--- a/src/read_data/Athena/reader_athena.jl
+++ b/src/read_data/Athena/reader_athena.jl
@@ -120,16 +120,22 @@ function _athena_fill_col!(col::Vector{Float64}, arr::AbstractArray{<:Real,5}, l
 end
 
 """
-    gethydro_athena(info::InfoType; verbose=true) -> HydroDataType
+    gethydro_athena(info::InfoType; xrange, yrange, zrange, center, range_unit, verbose=true) -> HydroDataType
 
 Read an Athena++ HDF5 snapshot described by `info` (from [`getinfo_athena`](@ref)) into a
 `HydroDataType` with columns `(:level, :cx, :cy, :cz, <vars…>)` in Mera's AMR convention, so the
 analysis layer works on it unchanged. Each MeshBlock's cells are placed on the level lattice via
 its `LogicalLocation` and `level`.
+
+`xrange`/`yrange`/`zrange` (+ `center`, `range_unit`) select a spatial window at load time
+(the leaf-cell analogue of Athena++'s own `athdf(x1_min=…, x1_max=…)`), exactly as for the
+RAMSES [`gethydro`](@ref); the returned object's `ranges` records it.
 """
-function gethydro_athena(info::InfoType; verbose::Bool=true)
+function gethydro_athena(info::InfoType;
+                         xrange=[missing, missing], yrange=[missing, missing], zrange=[missing, missing],
+                         center=[0., 0., 0.], range_unit::Symbol=:standard, verbose::Bool=true)
     fn = _athena_file(round(Int, info.output), info.path)
-    data = nothing; ncell = 0; vsyms = info.variable_list
+    data = nothing; ncell = 0; vsyms = info.variable_list; ranges = [0., 1., 0., 1., 0., 1.]
     h5open(fn, "r") do f
         a = attributes(f)
         rootlevel = _athena_rootlevel(Int.(read(a["RootGridSize"]))[1])
@@ -154,11 +160,14 @@ function gethydro_athena(info::InfoType; verbose::Bool=true)
             _athena_fill_col!(col, dsets[di], li, nblk, nx1, nx2, nx3)   # function barrier ⇒ type-stable
             push!(cols, col); push!(names, vsym)
         end
+        keep, sel_ranges = _external_select(info, xrange, yrange, zrange, center, range_unit, verbose, lvl, cx, cy, cz)
+        all(keep) || (cols = _select_cols(cols, keep))
+        ncell = length(cols[1]); ranges = sel_ranges
         data = table(cols...; names=Tuple(names), pkey=[:level, :cx, :cy, :cz], presorted=false, copy=false)
     end
     h = HydroDataType()
     h.data = data; h.info = info; h.lmin = info.levelmin; h.lmax = info.levelmax; h.boxlen = info.boxlen
-    h.ranges = [0., 1., 0., 1., 0., 1.]; h.selected_hydrovars = collect(1:length(vsyms))
+    h.ranges = ranges; h.selected_hydrovars = collect(1:length(vsyms))
     h.used_descriptors = Dict{Any,Any}(); h.smallr = 0.; h.smallc = 0.; h.scale = info.scale
     verbose && println("[Mera]: Athena++ hydro $(ncell) cells, vars ", join(string.(vsyms), ", "))
     return h

--- a/src/read_data/PLUTO/reader_chombo.jl
+++ b/src/read_data/PLUTO/reader_chombo.jl
@@ -108,7 +108,9 @@ function getinfo_chombo(output::Int, path::String; verbose::Bool=true)
     end
 end
 
-function gethydro_chombo(info::InfoType; verbose::Bool=true)
+function gethydro_chombo(info::InfoType;
+                         xrange=[missing, missing], yrange=[missing, missing], zrange=[missing, missing],
+                         center=[0., 0., 0.], range_unit::Symbol=:standard, verbose::Bool=true)
     fn = _chombo_file(info.path)
     h5open(fn, "r") do f
         a = attributes(f)
@@ -169,14 +171,17 @@ function gethydro_chombo(info::InfoType; verbose::Bool=true)
         allcols = Any[lvlcol, cxcol, cycol, czcol]
         names = Symbol[:level, :cx, :cy, :cz]
         for s in info.variable_list; push!(allcols, cols[s]); push!(names, s); end
+        keep, ranges = _external_select(info, xrange, yrange, zrange, center, range_unit, verbose,
+                                        lvlcol, cxcol, cycol, czcol)
+        all(keep) || (allcols = _select_cols(allcols, keep))
         data = table(allcols...; names=Tuple(names), pkey=[:level,:cx,:cy,:cz], presorted=false, copy=false)
 
         h = HydroDataType(); h.data = data; h.info = info
         h.lmin = info.levelmin; h.lmax = info.levelmax; h.boxlen = info.boxlen
-        h.ranges = [0., 1., 0., 1., 0., 1.]
+        h.ranges = ranges
         h.selected_hydrovars = collect(1:length(info.variable_list))
         h.used_descriptors = Dict{Any,Any}(); h.smallr = 0.; h.smallc = 0.; h.scale = info.scale
-        verbose && println("[Mera]: CHOMBO AMR → ", length(lvlcol), " leaf cells, levels ",
+        verbose && println("[Mera]: CHOMBO AMR → ", length(allcols[1]), " leaf cells, levels ",
                            info.levelmin, "–", info.levelmax, ", vars ", join(string.(info.variable_list), ", "))
         return h
     end

--- a/src/read_data/PLUTO/reader_pluto.jl
+++ b/src/read_data/PLUTO/reader_pluto.jl
@@ -189,15 +189,54 @@ function getinfo_pluto(output::Int, path::String; unit_length::Real=1.0,
     return info
 end
 
+# ----------------------------------------------------------------------------------------
+# Shared load-time spatial selection for the external (non-RAMSES) frontends.
+#
+# The native readers select a window, not the whole box: yt's region selectors
+# (`ds.box`/`ds.sphere`/`ds.r[...]`) read only intersecting chunks, and Athena++'s own
+# `athdf(x1_min=…, x1_max=…)` reads a sub-volume. The same `xrange`/`yrange`/`zrange` +
+# `center` + `range_unit` arguments the RAMSES `gethydro` takes are honoured here. We work on
+# the **leaf-cell** list, so a spatial window is an exact, hole-free filter: a cell is kept
+# when its Mera position `cx/2^level` (= `getvar(:x)/boxlen`, so the selection matches
+# [`subregion`](@ref)) lies inside the prepranges-normalised box. Returns `(keep, ranges)`.
+function _external_select(info::InfoType, xrange, yrange, zrange, center, range_unit::Symbol,
+                          verbose::Bool, lvl::AbstractVector, cx::AbstractVector,
+                          cy::AbstractVector, cz::AbstractVector)
+    ranges = prepranges(info, range_unit, false, collect(xrange), collect(yrange),
+                        collect(zrange), collect(center))
+    fullbox = ranges[1] <= 0.0 && ranges[2] >= 1.0 && ranges[3] <= 0.0 &&
+              ranges[4] >= 1.0 && ranges[5] <= 0.0 && ranges[6] >= 1.0
+    fullbox && return trues(length(cx)), ranges
+    keep = BitVector(undef, length(cx))
+    @inbounds for k in eachindex(cx)
+        s = 1.0 / 2.0^Int(lvl[k])                       # cell position fraction = cx/2^level
+        keep[k] = (ranges[1] <= cx[k]*s <= ranges[2]) &
+                  (ranges[3] <= cy[k]*s <= ranges[4]) &
+                  (ranges[5] <= cz[k]*s <= ranges[6])
+    end
+    verbose && println("[Mera]: load-time range selection (box-normalised) ",
+        "x=", round.((ranges[1], ranges[2]), digits=4), " y=", round.((ranges[3], ranges[4]), digits=4),
+        " z=", round.((ranges[5], ranges[6]), digits=4), " → ", count(keep), "/", length(cx), " leaf cells")
+    return keep, ranges
+end
+
+# apply a keep-mask to a list of equal-length columns
+_select_cols(cols::AbstractVector, keep::BitVector) = Any[c[keep] for c in cols]
+
 """
-    gethydro_pluto(info::InfoType; verbose=true) -> HydroDataType
+    gethydro_pluto(info::InfoType; xrange, yrange, zrange, center, range_unit, verbose=true) -> HydroDataType
 
 Read a PLUTO static-grid snapshot (`data.NNNN.dbl`, single-file double precision) described
 by `info` (from [`getinfo_pluto`](@ref)) into a uniform-grid `HydroDataType` — columns
 `(:cx,:cy,:cz, :rho,:vx,:vy,:vz,:p)`, the same schema the RAMSES uniform-grid reader produces,
 so the whole analysis layer works on it unchanged.
+
+`xrange`/`yrange`/`zrange` (+ `center`, `range_unit`) select a spatial window at load time,
+exactly as for the RAMSES [`gethydro`](@ref); the returned object's `ranges` records it.
 """
-function gethydro_pluto(info::InfoType; verbose::Bool=true)
+function gethydro_pluto(info::InfoType;
+                        xrange=[missing, missing], yrange=[missing, missing], zrange=[missing, missing],
+                        center=[0., 0., 0.], range_unit::Symbol=:standard, verbose::Bool=true)
     path = info.path; n = 2^info.levelmin; ncell = n^3
     output = round(Int, info.output)
     vars = info.variable_list
@@ -227,15 +266,19 @@ function gethydro_pluto(info::InfoType; verbose::Bool=true)
         push!(cols, Float64.(block)); push!(names, vsym)
     end
 
+    lvl = fill(Int32(info.levelmin), ncell)            # uniform grid: every cell at levelmin
+    keep, ranges = _external_select(info, xrange, yrange, zrange, center, range_unit, verbose, lvl, cx, cy, cz)
+    all(keep) || (cols = _select_cols(cols, keep))
+
     data = table(cols...; names=Tuple(names), pkey=[:cx, :cy, :cz], presorted=false, copy=false)
     h = HydroDataType()
     h.data = data; h.info = info
     h.lmin = info.levelmin; h.lmax = info.levelmax; h.boxlen = info.boxlen
-    h.ranges = [0., 1., 0., 1., 0., 1.]
+    h.ranges = ranges
     h.selected_hydrovars = collect(1:nv)
     h.used_descriptors = Dict{Any,Any}()
     h.smallr = 0.; h.smallc = 0.; h.scale = info.scale
-    verbose && println("[Mera]: PLUTO hydro $(n)³ = $(ncell) cells, vars ", join(string.(vars), ", "))
+    verbose && println("[Mera]: PLUTO hydro $(length(cols[1])) cells (of $(ncell)), vars ", join(string.(vars), ", "))
     return h
 end
 

--- a/src/read_data/RAMSES/gethydro.jl
+++ b/src/read_data/RAMSES/gethydro.jl
@@ -331,12 +331,17 @@ function gethydro(dataobject::InfoType;
                     max_threads::Int=Threads.nthreads())
 
     # Multi-code: a non-RAMSES info delegates to its own frontend (the analysis stays blind).
+    # The spatial-window selection (xrange/yrange/zrange/center/range_unit) is honoured by the
+    # frontends; lmax/resolution is a leaf-data analysis-time choice and is not forwarded.
     if dataobject.simcode == "PLUTO"
-        return gethydro_pluto(dataobject; verbose=verbose)
+        return gethydro_pluto(dataobject; xrange=xrange, yrange=yrange, zrange=zrange,
+                              center=center, range_unit=range_unit, verbose=verbose)
     elseif dataobject.simcode == "CHOMBO"
-        return gethydro_chombo(dataobject; verbose=verbose)
+        return gethydro_chombo(dataobject; xrange=xrange, yrange=yrange, zrange=zrange,
+                               center=center, range_unit=range_unit, verbose=verbose)
     elseif dataobject.simcode == "Athena++"
-        return gethydro_athena(dataobject; verbose=verbose)
+        return gethydro_athena(dataobject; xrange=xrange, yrange=yrange, zrange=zrange,
+                               center=center, range_unit=range_unit, verbose=verbose)
     end
 
     # ═══════════════════════════════════════════════════════════════════════════

--- a/test/52_pluto_reader_tests.jl
+++ b/test/52_pluto_reader_tests.jl
@@ -127,6 +127,23 @@ if DATA_AVAILABLE && isdir(PL_PATH)
         @test sum(P.pdf .* diff(log10.(P.edges))) ≈ 1 rtol=1e-6
     end
 
+    @testset "load-time spatial selection (xrange/yrange/zrange)" begin
+        info = getinfo_pluto(5, PL_PATH; verbose=false)
+        full = gethydro_pluto(info; verbose=false)
+        x = getvar(full, :x); y = getvar(full, :y)               # code units (boxlen = 1)
+        # lower-x half × middle-y band, relative to the box origin (center = 0)
+        sub = gethydro_pluto(info; xrange=[0.0, 0.5], yrange=[0.25, 0.75],
+                             center=[0., 0., 0.], range_unit=:standard, verbose=false)
+        @test length(sub.data) == count((x .<= 0.5) .& (0.25 .<= y .<= 0.75))   # matches getvar(:x) filter
+        @test maximum(getvar(sub, :x)) <= 0.5 + 1e-9
+        @test sub.ranges == [0.0, 0.5, 0.25, 0.75, 0.0, 1.0]     # the window is recorded
+        # the generic router forwards the same selection
+        sub2 = gethydro(info; xrange=[0.0, 0.5], yrange=[0.25, 0.75],
+                        center=[0., 0., 0.], range_unit=:standard, verbose=false)
+        @test length(sub2.data) == length(sub.data)
+        @test length(gethydro_pluto(info; verbose=false).data) == 64^3          # full box unchanged
+    end
+
     @testset "coordinate mapping matches the raw file (no transpose)" begin
         g = gethydro_pluto(getinfo_pluto(5, PL_PATH; verbose=false); verbose=false)
         rho = getvar(g, :rho); i = argmax(rho)
@@ -165,6 +182,15 @@ if DATA_AVAILABLE && isdir(CH_PATH)
         # the analysis layer works unchanged on AMR data
         pr = projection(g, :rho, verbose=false, show_progress=false)
         @test sum(pr.maps[:rho]) > 0
+
+        # load-time spatial selection on AMR data — a central box keeps only the refined core
+        x = getvar(g, :x); y = getvar(g, :y); z = getvar(g, :z); bl = info.boxlen
+        sub = gethydro(info; xrange=[-0.1, 0.1], yrange=[-0.1, 0.1], zrange=[-0.1, 0.1],
+                       center=[:bc], range_unit=:standard, verbose=false)
+        lo = 0.4bl; hi = 0.6bl
+        @test length(sub.data) == count((lo .<= x .<= hi) .& (lo .<= y .<= hi) .& (lo .<= z .<= hi))
+        @test maximum(getvar(sub, :level)) == maximum(lv)        # the finest level survives at the centre
+        @test sub.ranges != [0., 1., 0., 1., 0., 1.]
     end
 else
     @testset "Chombo reader (skipped: chombo_3d unavailable)" begin

--- a/test/57_athena_reader_tests.jl
+++ b/test/57_athena_reader_tests.jl
@@ -78,6 +78,23 @@ end
         @test all(getvar(gas, :rho) .> 0)
     end
 
+    @testset "load-time spatial selection (xrange/yrange/zrange)" begin
+        fn = joinpath(dir, "sel.out1.00003.athdf")
+        _write_athdf(fn)                                  # 8 blocks of 2³ = a 4³ uniform grid, level 2
+        info = getinfo_athena(3, dir, verbose=false)
+        full = gethydro_athena(info, verbose=false)
+        x = getvar(full, :x)                              # boxlen = 1 → x = cx/4 ∈ {.25,.5,.75,1}
+        # lower-x half, relative to the box origin (center = 0)
+        sub = gethydro_athena(info; xrange=[0.0, 0.5], center=[0., 0., 0.], range_unit=:standard, verbose=false)
+        @test length(sub.data) == count(x .<= 0.5)        # the leaf-cell window matches a getvar(:x) filter
+        @test maximum(getvar(sub, :x)) <= 0.5 + 1e-9
+        @test sub.ranges[1:2] == [0.0, 0.5]               # the window is recorded
+        # the generic router forwards the same selection
+        sub2 = gethydro(info; xrange=[0.0, 0.5], center=[0., 0., 0.], range_unit=:standard, verbose=false)
+        @test length(sub2.data) == length(sub.data)
+        @test length(gethydro_athena(info, verbose=false).data) == 64    # full box unchanged
+    end
+
     # PART B (data-backed): a REAL Athena++ snapshot — the yt AM06 sample (Cartesian AMR MHD).
     # Download AM06.tar.gz from yt-project.org/data into MERA_TEST_DATA/athena_AM06/.
     @testset "real Athena++ snapshot — yt AM06 (data-backed)" begin
@@ -92,6 +109,14 @@ end
             @test sort(unique(Mera.select(gas.data, :level))) == [7, 8, 9, 10, 11]
             @test all(getvar(gas, :rho) .> 0) && msum(gas) > 0
             @test maximum(projection(gas, :sd, res=64, center=[:bc], verbose=false, show_progress=false).maps[:sd]) > 0
+
+            # load-time spatial selection: a central box reduces to the refined core
+            sub = gethydro(info; xrange=[-0.05, 0.05], yrange=[-0.05, 0.05], zrange=[-0.05, 0.05],
+                           center=[:bc], range_unit=:standard, verbose=false)
+            @test 0 < length(sub.data) < length(gas.data)
+            @test minimum(Mera.select(sub.data, :level)) >= 10      # only the finest levels survive at the centre
+            @test sub.ranges != [0., 1., 0., 1., 0., 1.]
+            @test all(getvar(sub, :rho) .> 0)
         else
             @test_skip "yt AM06 Athena++ fixture not present (MERA_TEST_DATA/athena_AM06/AM06/*.athdf)"
         end


### PR DESCRIPTION
## What

Give the PLUTO / Chombo / Athena++ frontends genuine **load-time spatial selection**, aligning them with the native readers' selection capabilities — and cite those readers as the origin.

Previously `xrange`/`yrange`/`zrange` were accepted by `gethydro` but ignored for non-RAMSES codes (the whole snapshot always loaded). Now they select a spatial window at load, exactly like:
- **yt** region selectors (`ds.box`, `ds.sphere`, `ds.r[...]`),
- Athena++'s **own** `athena_read.py` → `athdf(x1_min=…, x1_max=…)`,
- **pyPLUTO** (format origin).

## How

- **Shared helper** `_external_select` (in `reader_pluto.jl`): reuses `prepranges` (box-normalised 0..1) and keeps a leaf cell when `cx/2^level ∈ [r1,r2]` — i.e. `getvar(:x)/boxlen`, so the window **matches `subregion`/`getvar`** exactly. Returns `(keep, ranges)`; `_select_cols` applies the mask before `table(...)`.
- Wired into `gethydro_pluto` / `gethydro_chombo` / `gethydro_athena` and the `gethydro` router; the returned object records the window in `.ranges`.
- **Leaf-cell rationale** (answering "we're mainly interested in leaf cells?"): a spatial window is exact and hole-free on a leaf-cell list. A *level* cap is deliberately **not** a load arg — dropping leaves finer than `lmax` would leave gaps (no coarse data sits under a leaf), so resolution stays an analysis-time choice (`projection(…, res=)`).

```julia
# central 10% box of an Athena++ AMR MHD snapshot
gas = gethydro(info; xrange=[-0.05,0.05], yrange=[-0.05,0.05], zrange=[-0.05,0.05],
               center=[:bc], range_unit=:standard)
```

## Verification
- New tests in **test/52** (PLUTO uniform + Chombo AMR) and **test/57** (Athena synthetic + real AM06): a load-time window equals the full load filtered by `getvar(:x)`; central boxes correctly isolate the finest levels (Chombo → level 7 only; AM06 → levels 10–11). **PLUTO 60/60, Athena++ 33/33.**
- Docs build clean; both reader pages gain a sub-region example and a **Reference readers** section.

Does not touch `CHANGELOG.md` / `CITATION.cff` / `paper/`.

> Note: this selection filters the assembled leaf list; for the HDF5 AMR readers it does not yet prune block **I/O** (yt-style chunk skipping) — a possible follow-up for very large snapshots.
