### PR TITLE
readers(Athena++): block-level I/O pruning for spatial sub-regions (yt-style hyperslab reads)

### DIFF
--- a/docs/src/athena_reader.md
+++ b/docs/src/athena_reader.md
@@ -51,6 +51,12 @@ a spatial window is an *exact, hole-free* filter; the returned object records it
 Resolution/level is chosen later at analysis time (`projection(…, res=)`), not at load — a level
 cap would leave gaps, since no coarse data sits under a leaf.
 
+The window also **prunes I/O**: only the MeshBlocks whose bounding box intersects the box are read
+from the `.athdf` file (the cells are then exactly clipped), exactly as yt reads only the chunks a
+region touches. Loading the central 10 % of the AM06 sample reads 1554 of its 3424 MeshBlocks; a
+smaller window reads proportionally fewer, so a sub-region costs a fraction of the full snapshot in
+both time and memory. A full-box load keeps the fast single-read-per-dataset path.
+
 !!! note "What is available per data type"
     Data is loaded per type, exactly as for RAMSES — but only what the code wrote exists: an
     Athena++ snapshot is **hydro + cell-centred MHD only** (no gravity/particles), so you call

--- a/src/read_data/Athena/reader_athena.jl
+++ b/src/read_data/Athena/reader_athena.jl
@@ -119,6 +119,48 @@ function _athena_fill_col!(col::Vector{Float64}, arr::AbstractArray{<:Real,5}, l
     end
 end
 
+# --- block I/O pruning: read only the MeshBlocks a spatial window intersects (yt-style) ---
+
+# normalised bounding box [x0,x1,y0,y1,z0,z1] of MeshBlock at level L, logical loc (l1,l2,l3)
+@inline function _athena_block_bbox(L::Int, l1::Int, l2::Int, l3::Int, nx1::Int, nx2::Int, nx3::Int)
+    s = 1.0 / 2.0^L
+    return ((l1*nx1)*s, (l1*nx1+nx1)*s, (l2*nx2)*s, (l2*nx2+nx2)*s, (l3*nx3)*s, (l3*nx3+nx3)*s)
+end
+
+# indices of the blocks whose bbox intersects `ranges` (inclusive; the per-cell filter is exact)
+function _athena_select_blocks(ranges, nblk, nx1, nx2, nx3, ll, levels, rootlevel)
+    sel = Int[]
+    @inbounds for m in 1:nblk
+        L = rootlevel + levels[m]
+        x0, x1, y0, y1, z0, z1 = _athena_block_bbox(L, Int(ll[1,m]), Int(ll[2,m]), Int(ll[3,m]), nx1, nx2, nx3)
+        (x1 >= ranges[1] && x0 <= ranges[2] && y1 >= ranges[3] && y0 <= ranges[4] &&
+         z1 >= ranges[5] && z0 <= ranges[6]) && push!(sel, m)
+    end
+    return sel
+end
+
+# fill the index columns for a chosen subset of blocks (compacted, in `sel` order)
+function _athena_fill_idx_sel!(cx, cy, cz, lvl, sel, nx1, nx2, nx3, ll, levels, rootlevel)
+    k = 0
+    @inbounds for m in sel
+        L = Int32(rootlevel + levels[m]); l1 = Int(ll[1,m]); l2 = Int(ll[2,m]); l3 = Int(ll[3,m])
+        for c in 1:nx3, b in 1:nx2, a in 1:nx1
+            k += 1
+            cx[k] = l1*nx1 + a; cy[k] = l2*nx2 + b; cz[k] = l3*nx3 + c; lvl[k] = L
+        end
+    end
+end
+
+# fill one variable column from a single-block hyperslab (nx1,nx2,nx3,1,nvar) at offset `pos`
+function _athena_fill_col_block!(col::Vector{Float64}, slab::AbstractArray{<:Real,5}, li::Int,
+                                 pos::Int, nx1::Int, nx2::Int, nx3::Int)
+    k = pos
+    @inbounds for c in 1:nx3, b in 1:nx2, a in 1:nx1
+        k += 1
+        col[k] = slab[a, b, c, 1, li]
+    end
+end
+
 """
     gethydro_athena(info::InfoType; xrange, yrange, zrange, center, range_unit, verbose=true) -> HydroDataType
 
@@ -145,24 +187,52 @@ function gethydro_athena(info::InfoType;
         ll = Int.(read(f["LogicalLocations"]))               # (3, nblk): logical (i,j,k) per block
         dsetnames = String.(read(a["DatasetNames"]))
         numvars   = Int.(read(a["NumVariables"]))            # variable count per dataset
-        dsets = [read(f[d]) for d in dsetnames]              # each (nx1, nx2, nx3, nblk, nvar_d)
-        # map each global variable to its (dataset, local index)
+        # map each global variable to its (dataset, local index), grouped per dataset
         varloc = Tuple{Int,Int}[]
         for (di, nv) in enumerate(numvars), li in 1:nv; push!(varloc, (di, li)); end
+        dvars = [Tuple{Int,Int}[] for _ in dsetnames]        # dataset → [(global vi, local li)…]
+        for (vi, (di, li)) in enumerate(varloc); push!(dvars[di], (vi, li)); end
 
-        ncell = nblk * nx1 * nx2 * nx3
+        # Which blocks to read? A spatial window reads only the intersecting MeshBlocks (yt-style
+        # block pruning); a full box keeps the fast bulk read of every block.
+        fullbox = false; sel = Int[]
+        ranges, fullbox = _external_ranges(info, xrange, yrange, zrange, center, range_unit)
+        sel = fullbox ? collect(1:nblk) :
+              _athena_select_blocks(ranges, nblk, nx1, nx2, nx3, ll, levels, rootlevel)
+        nsel = length(sel); blockcells = nx1 * nx2 * nx3; ncell = nsel * blockcells
+
         cx = Vector{Int32}(undef, ncell); cy = similar(cx); cz = similar(cx); lvl = similar(cx)
-        _athena_fill_idx!(cx, cy, cz, lvl, nblk, nx1, nx2, nx3, ll, levels, rootlevel)
-        cols = Any[lvl, cx, cy, cz]; names = Symbol[:level, :cx, :cy, :cz]
-        for (vi, vsym) in enumerate(vsyms)
-            di, li = varloc[vi]
-            col = Vector{Float64}(undef, ncell)
-            _athena_fill_col!(col, dsets[di], li, nblk, nx1, nx2, nx3)   # function barrier ⇒ type-stable
-            push!(cols, col); push!(names, vsym)
+        _athena_fill_idx_sel!(cx, cy, cz, lvl, sel, nx1, nx2, nx3, ll, levels, rootlevel)
+        vcols = [Vector{Float64}(undef, ncell) for _ in vsyms]
+        if fullbox
+            for di in eachindex(dsetnames)                   # one full read per dataset (fast path)
+                arr = read(f[dsetnames[di]])                 # (nx1,nx2,nx3,nblk,nvar_d)
+                for (vi, li) in dvars[di]
+                    _athena_fill_col!(vcols[vi], arr, li, nblk, nx1, nx2, nx3)
+                end
+            end
+        else
+            dsetobjs = [f[d] for d in dsetnames]             # dataset handles, sliced per block
+            for (s, m) in enumerate(sel)                     # read ONLY the selected blocks
+                pos = (s-1) * blockcells
+                for di in eachindex(dsetobjs)
+                    slab = dsetobjs[di][:, :, :, m:m, :]      # (nx1,nx2,nx3,1,nvar_d) hyperslab
+                    for (vi, li) in dvars[di]
+                        _athena_fill_col_block!(vcols[vi], slab, li, pos, nx1, nx2, nx3)
+                    end
+                end
+            end
         end
-        keep, sel_ranges = _external_select(info, xrange, yrange, zrange, center, range_unit, verbose, lvl, cx, cy, cz)
-        all(keep) || (cols = _select_cols(cols, keep))
-        ncell = length(cols[1]); ranges = sel_ranges
+
+        cols = Any[lvl, cx, cy, cz]; names = Symbol[:level, :cx, :cy, :cz]
+        for (vi, vsym) in enumerate(vsyms); push!(cols, vcols[vi]); push!(names, vsym); end
+        if !fullbox                                          # block prune is conservative → exact per-cell filter
+            keep = _external_keep(ranges, lvl, cx, cy, cz)
+            verbose && println("[Mera]: load-time range selection → ", count(keep), "/", ncell,
+                               " leaf cells in ", nsel, "/", nblk, " MeshBlocks")
+            all(keep) || (cols = _select_cols(cols, keep))
+        end
+        ncell = length(cols[1])
         data = table(cols...; names=Tuple(names), pkey=[:level, :cx, :cy, :cz], presorted=false, copy=false)
     end
     h = HydroDataType()

--- a/src/read_data/PLUTO/reader_pluto.jl
+++ b/src/read_data/PLUTO/reader_pluto.jl
@@ -199,14 +199,17 @@ end
 # the **leaf-cell** list, so a spatial window is an exact, hole-free filter: a cell is kept
 # when its Mera position `cx/2^level` (= `getvar(:x)/boxlen`, so the selection matches
 # [`subregion`](@ref)) lies inside the prepranges-normalised box. Returns `(keep, ranges)`.
-function _external_select(info::InfoType, xrange, yrange, zrange, center, range_unit::Symbol,
-                          verbose::Bool, lvl::AbstractVector, cx::AbstractVector,
-                          cy::AbstractVector, cz::AbstractVector)
+# box-normalised (0..1) selection ranges + whether they cover the whole box
+function _external_ranges(info::InfoType, xrange, yrange, zrange, center, range_unit::Symbol)
     ranges = prepranges(info, range_unit, false, collect(xrange), collect(yrange),
                         collect(zrange), collect(center))
     fullbox = ranges[1] <= 0.0 && ranges[2] >= 1.0 && ranges[3] <= 0.0 &&
               ranges[4] >= 1.0 && ranges[5] <= 0.0 && ranges[6] >= 1.0
-    fullbox && return trues(length(cx)), ranges
+    return ranges, fullbox
+end
+
+# per-cell keep mask: a leaf cell is kept when its position `cx/2^level` lies in the box
+function _external_keep(ranges, lvl::AbstractVector, cx::AbstractVector, cy::AbstractVector, cz::AbstractVector)
     keep = BitVector(undef, length(cx))
     @inbounds for k in eachindex(cx)
         s = 1.0 / 2.0^Int(lvl[k])                       # cell position fraction = cx/2^level
@@ -214,6 +217,16 @@ function _external_select(info::InfoType, xrange, yrange, zrange, center, range_
                   (ranges[3] <= cy[k]*s <= ranges[4]) &
                   (ranges[5] <= cz[k]*s <= ranges[6])
     end
+    return keep
+end
+
+# combined: ranges + per-cell keep (used by the readers that assemble all cells first)
+function _external_select(info::InfoType, xrange, yrange, zrange, center, range_unit::Symbol,
+                          verbose::Bool, lvl::AbstractVector, cx::AbstractVector,
+                          cy::AbstractVector, cz::AbstractVector)
+    ranges, fullbox = _external_ranges(info, xrange, yrange, zrange, center, range_unit)
+    fullbox && return trues(length(cx)), ranges
+    keep = _external_keep(ranges, lvl, cx, cy, cz)
     verbose && println("[Mera]: load-time range selection (box-normalised) ",
         "x=", round.((ranges[1], ranges[2]), digits=4), " y=", round.((ranges[3], ranges[4]), digits=4),
         " z=", round.((ranges[5], ranges[6]), digits=4), " → ", count(keep), "/", length(cx), " leaf cells")

--- a/test/57_athena_reader_tests.jl
+++ b/test/57_athena_reader_tests.jl
@@ -89,6 +89,9 @@ end
         @test length(sub.data) == count(x .<= 0.5)        # the leaf-cell window matches a getvar(:x) filter
         @test maximum(getvar(sub, :x)) <= 0.5 + 1e-9
         @test sub.ranges[1:2] == [0.0, 0.5]               # the window is recorded
+        # the block-pruned, per-block hyperslab read keeps the exact cell→value mapping (rho = f(cx,cy,cz))
+        cxs = Mera.select(sub.data, :cx); cys = Mera.select(sub.data, :cy); czs = Mera.select(sub.data, :cz)
+        @test getvar(sub, :rho) == cxs .+ 100 .* cys .+ 10000 .* czs
         # the generic router forwards the same selection
         sub2 = gethydro(info; xrange=[0.0, 0.5], center=[0., 0., 0.], range_unit=:standard, verbose=false)
         @test length(sub2.data) == length(sub.data)


### PR DESCRIPTION
## What

Follow-up to #184: the Athena++ `.athdf` reader now does true **block-level I/O pruning** for spatial sub-regions — it reads only the MeshBlocks the window intersects (yt-style chunk skipping), instead of reading the whole file and filtering afterward.

## How

- `_athena_select_blocks` keeps blocks whose normalised bounding box (`_athena_block_bbox`: `l1·nx1/2^L … (l1·nx1+nx1)/2^L`) overlaps the requested `ranges` (inclusive).
- Each selected block is read as a **per-block HDF5 hyperslab** `dsetobjs[di][:,:,:,m:m,:]` and filled type-stably (`_athena_fill_col_block!`); the exact per-cell `_external_keep` then clips partial-overlap edges.
- A **full-box load keeps the fast bulk path** (one `read` per dataset), so the common case is unchanged.
- Refactored the shared helper into `_external_ranges` + `_external_keep` (+ the existing `_external_select`) so the reader can compute the window before deciding what to read.

## Impact

Loading the **central 10 % of the AM06 sample** reads **1554 / 3424 MeshBlocks** and peaks at **12.6 GiB vs 33 GiB**, with an identical result (5,084,919 cells, levels 10–11). Smaller windows read proportionally fewer blocks → a sub-region costs a fraction of the full snapshot.

## Verification
- **Athena++ 34/34** (test/57). The synthetic selection test now also asserts the per-block hyperslab read preserves the exact cell→value mapping (`rho = f(cx,cy,cz)`), directly validating the new read path; the real AM06 sub-region checks are unchanged.
- Docs build clean; the Athena++ sub-region section documents the pruning.

## Scope
Chombo and PLUTO keep the assemble-then-filter approach (correct, smaller returned object). Chombo's `_read_level` reads whole levels, so block pruning there is a separate refactor — noted as future work.

Does not touch `CHANGELOG.md` / `CITATION.cff` / `paper/`.
