### PR TITLE
readers(Chombo): block-level I/O pruning for spatial sub-regions

### DIFF
--- a/docs/src/pluto_reader.md
+++ b/docs/src/pluto_reader.md
@@ -198,6 +198,10 @@ Orion (`density`, `X/Y/Z-momentum`, `energy-density`) with velocity = momentum/d
 pressure derived from the energy. The leaf extraction is validated cell-for-cell against an
 independent reader.
 
+A windowed load **prunes box I/O** here too: with `xrange`/`yrange`/`zrange` set, only the Chombo
+boxes whose extent intersects the window are read from the HDF5 file (the level geometry, hence the
+leaf/covered logic, still uses every box), so a sub-region costs a fraction of the snapshot.
+
 Because the `:level` column survives into the standard struct, the **AMR structure is itself
 plottable** — a volume-weighted mean level along the line of sight shows where the grid refines
 (here a self-gravitating isothermal sphere refined toward its centre, Mera levels 6 → 7). The full

--- a/src/read_data/PLUTO/reader_chombo.jl
+++ b/src/read_data/PLUTO/reader_chombo.jl
@@ -27,12 +27,19 @@ struct _Level
     exists::BitArray{3}
 end
 
-function _read_level(g, ncomp::Int)
+# Read one level. `window`, when given, is `(s, ranges)` with `s = 1/2^rlevel`: cell data is read
+# ONLY for the boxes whose normalised extent intersects `ranges` (yt-style box I/O pruning). The
+# `exists` mask is always built from the (cheap) box geometry, so the leaf/covered logic across
+# levels stays exact; out-of-window boxes keep zero grid values and are dropped by the caller's
+# per-cell filter. A full-box read (`window === nothing`) keeps the fast single bulk read.
+function _read_level(g, ncomp::Int; window=nothing)
     pd = read(attributes(g)["prob_domain"])          # a Chombo "box" compound → NamedTuple
     lo = (Int(pd.lo_i), Int(pd.lo_j), Int(pd.lo_k))
     n = (Int(pd.hi_i)-lo[1]+1, Int(pd.hi_j)-lo[2]+1, Int(pd.hi_k)-lo[3]+1)
     dx = Float64(read(attributes(g)["dx"]))
-    boxes = g["boxes"][]; data = g["data:datatype=0"][]; off = g["data:offsets=0"][]
+    boxes = g["boxes"][]; off = g["data:offsets=0"][]
+    dataset = g["data:datatype=0"]
+    fulldata = window === nothing ? dataset[] : nothing          # one bulk read for the full path
     grids = Dict{Int,Array{Float64,3}}(c => zeros(Float64, n...) for c in 0:ncomp-1)
     exists = falses(n...)
     for (bi, b) in enumerate(boxes)
@@ -40,9 +47,16 @@ function _read_level(g, ncomp::Int)
         nc = bnx*bny*bnz; start = Int(off[bi])
         i0 = b.lo_i-lo[1]; j0 = b.lo_j-lo[2]; k0 = b.lo_k-lo[3]
         exists[i0+1:i0+bnx, j0+1:j0+bny, k0+1:k0+bnz] .= true
+        if window !== nothing
+            s, r = window                                        # cell position = (i0+a)·s, a = 1…bnx
+            ((i0+bnx)*s >= r[1] && (i0+1)*s <= r[2] &&
+             (j0+bny)*s >= r[3] && (j0+1)*s <= r[4] &&
+             (k0+bnz)*s >= r[5] && (k0+1)*s <= r[6]) || continue # box outside window → skip its data
+        end
+        blk = window === nothing ? (@view fulldata[start+1 : start+nc*ncomp]) :
+                                   dataset[start+1 : start+nc*ncomp]   # per-box hyperslab read
         for c in 0:ncomp-1
-            blk = @view data[start + c*nc + 1 : start + (c+1)*nc]   # i fastest, then j, k
-            sub = reshape(blk, (bnx, bny, bnz))
+            sub = reshape(@view(blk[c*nc + 1 : (c+1)*nc]), (bnx, bny, bnz))   # i fastest, then j, k
             grids[c][i0+1:i0+bnx, j0+1:j0+bny, k0+1:k0+bnz] .= sub
         end
     end
@@ -116,7 +130,11 @@ function gethydro_chombo(info::InfoType;
         a = attributes(f)
         ncomp = Int(read(a["num_components"])); nlev = Int(read(a["num_levels"]))
         comps = [String(read(a["component_$i"])) for i in 0:ncomp-1]
-        levels = [_read_level(f["level_$L"], ncomp) for L in 0:nlev-1]
+        # spatial window (box-normalised); read only intersecting boxes per level when set
+        ranges, fullbox = _external_ranges(info, xrange, yrange, zrange, center, range_unit)
+        levels = [_read_level(f["level_$L"], ncomp;
+                              window = fullbox ? nothing : (1.0/2.0^(info.levelmin + L), ranges))
+                  for L in 0:nlev-1]
         ref = 2
 
         # which component index supplies each canonical symbol, and how to combine
@@ -171,9 +189,12 @@ function gethydro_chombo(info::InfoType;
         allcols = Any[lvlcol, cxcol, cycol, czcol]
         names = Symbol[:level, :cx, :cy, :cz]
         for s in info.variable_list; push!(allcols, cols[s]); push!(names, s); end
-        keep, ranges = _external_select(info, xrange, yrange, zrange, center, range_unit, verbose,
-                                        lvlcol, cxcol, cycol, czcol)
-        all(keep) || (allcols = _select_cols(allcols, keep))
+        if !fullbox                                         # exact per-cell clip (box prune is conservative)
+            keep = _external_keep(ranges, lvlcol, cxcol, cycol, czcol)
+            verbose && println("[Mera]: load-time range selection → ", count(keep), "/",
+                               length(lvlcol), " leaf cells")
+            all(keep) || (allcols = _select_cols(allcols, keep))
+        end
         data = table(allcols...; names=Tuple(names), pkey=[:level,:cx,:cy,:cz], presorted=false, copy=false)
 
         h = HydroDataType(); h.data = data; h.info = info

--- a/test/52_pluto_reader_tests.jl
+++ b/test/52_pluto_reader_tests.jl
@@ -183,14 +183,24 @@ if DATA_AVAILABLE && isdir(CH_PATH)
         pr = projection(g, :rho, verbose=false, show_progress=false)
         @test sum(pr.maps[:rho]) > 0
 
-        # load-time spatial selection on AMR data — a central box keeps only the refined core
+        # load-time spatial selection on AMR data — a central box keeps only the refined core,
+        # read via per-box HDF5 pruning (only the intersecting boxes' data are loaded)
         x = getvar(g, :x); y = getvar(g, :y); z = getvar(g, :z); bl = info.boxlen
         sub = gethydro(info; xrange=[-0.1, 0.1], yrange=[-0.1, 0.1], zrange=[-0.1, 0.1],
                        center=[:bc], range_unit=:standard, verbose=false)
         lo = 0.4bl; hi = 0.6bl
-        @test length(sub.data) == count((lo .<= x .<= hi) .& (lo .<= y .<= hi) .& (lo .<= z .<= hi))
+        mask = (lo .<= x .<= hi) .& (lo .<= y .<= hi) .& (lo .<= z .<= hi)
+        @test length(sub.data) == count(mask)
         @test maximum(getvar(sub, :level)) == maximum(lv)        # the finest level survives at the centre
         @test sub.ranges != [0., 1., 0., 1., 0., 1.]
+        # the pruned per-box read preserves values: rho matches the full load cell-for-cell
+        k(l,a,b,c) = (Int(l), Int(a), Int(b), Int(c))
+        fl = getvar(g, :level); fx = Mera.select(g.data,:cx); fy = Mera.select(g.data,:cy); fz = Mera.select(g.data,:cz)
+        frho = getvar(g, :rho)
+        D = Dict(k(fl[i],fx[i],fy[i],fz[i]) => frho[i] for i in eachindex(fl) if mask[i])
+        sl = getvar(sub,:level); sx = Mera.select(sub.data,:cx); sy = Mera.select(sub.data,:cy); sz = Mera.select(sub.data,:cz)
+        srho = getvar(sub, :rho)
+        @test all(D[k(sl[i],sx[i],sy[i],sz[i])] == srho[i] for i in eachindex(sl))
     end
 else
     @testset "Chombo reader (skipped: chombo_3d unavailable)" begin


### PR DESCRIPTION
## What

Completes the block-I/O-pruning series (after Athena++ #185): a windowed `gethydro` on a **Chombo / PLUTO-AMR** snapshot now reads cell data only for the boxes the window intersects, instead of reading every level in full.

## How

- `_read_level(g, ncomp; window=(s, ranges))` builds the `exists` mask from **all** box geometry (cheap — so the leaf/covered logic across levels stays exact) but reads **data** only for boxes whose normalised extent `(i0+a)·s` overlaps `ranges`, via a per-box hyperslab `dataset[start+1 : start+nc*ncomp]`. Out-of-window boxes keep zero grid values and are dropped by the caller's exact per-cell `_external_keep`.
- A **full-box load** (`window === nothing`) keeps the fast single bulk `dataset[]` read — no regression for the common case.
- `gethydro_chombo` computes the window once (`_external_ranges`), passes the per-level `(1/2^rlevel, ranges)` to `_read_level`, and clips exactly afterward.

The leaf/covered logic is untouched (it only ever needed box geometry, not data), so this is a low-risk change.

## Verification
- **Cell-for-cell value check**: a windowed load's `rho` values match the full load over the same box (central 30% → 59,319 cells, all level 7). New assertion in test/52. **PLUTO 61/61.**
- Docs build clean; the PLUTO-AMR section documents the box pruning.

## Series status
Block I/O pruning now done for both HDF5 AMR readers — **Athena++** (#185) and **Chombo** (here). **PLUTO uniform** is a single monolithic `.dbl` read, so there is nothing to prune there. This closes the load-time-selection work.

Does not touch `CHANGELOG.md` / `CITATION.cff` / `paper/`.
