### PR TITLE
docs+test: multi-code capstone (overview page + cross-reader contract test + lmax warning)

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -109,9 +109,10 @@ makedocs(modules = [Mera],
                                                         "Converter"    =>  "07_1_multi_Mera_Files_Converter.md",
                                                         "API Reference" => "api/mera_files.md"],
 
-                          "Other Codes (PLUTO)" => "pluto_reader.md",
-                          "Other Codes (Athena++)" => "athena_reader.md",
-                          "Other Codes (FLASH)" => "flash_reader.md",
+                          "Other Codes" => Any[ "Overview"   => "multicode.md",
+                                                "PLUTO"      => "pluto_reader.md",
+                                                "Athena++"   => "athena_reader.md",
+                                                "FLASH"      => "flash_reader.md"],
 
                           "Volume Rendering"    => Any[ "Intro"      =>  "paraview/paraview_intro.md",
                                                         "Hydro"      =>  "paraview/08_hydro_VTK_export.md",

--- a/docs/src/multicode.md
+++ b/docs/src/multicode.md
@@ -1,0 +1,61 @@
+# Multi-code support
+
+Mera began as a RAMSES tool, but its analysis layer is **code-blind**: every quantity
+([`getvar`](@ref)), map ([`projection`](@ref)), region ([`subregion`](@ref)), filter
+([`filterdata`](@ref)), profile, PDF, time-series and clump finder works on a *generic* uniform/AMR
+cell list — not on any particular file format. A reader for another simulation code therefore only
+has to do one thing: fill the standard Mera structs (an `InfoType` + a `HydroDataType` whose cells
+follow Mera's `(:level, :cx, :cy, :cz, <vars…>)` convention). Everything downstream then runs
+unchanged.
+
+That is the whole design: **a new code = "write a reader that fills the structs", not "rework Mera".**
+
+## Supported codes
+
+The normal [`getinfo`](@ref) / [`gethydro`](@ref) entry points **auto-detect** the code from the
+files in the directory (override with `code=`); the detected code is stored in `info.simcode`.
+
+| Code | File format | Grid | Data types | Native units | Load-time window | Block I/O pruning | Reader page |
+|---|---|---|---|---|---|---|---|
+| **RAMSES** | RAMSES binary | AMR | hydro · gravity · particles · RT · clumps | physical (from `info`) | ✅ | — (native) | (the tutorials) |
+| **PLUTO** | `grid.out` + `.dbl` | uniform | hydro · particles | code (dimensionless) | ✅ | n/a (one `.dbl` read) | [PLUTO](pluto_reader.md) |
+| **PLUTO-AMR / Chombo** | Chombo HDF5 | AMR | hydro | code | ✅ | ✅ (per box) | [PLUTO](pluto_reader.md#PLUTO-AMR-(Chombo)) |
+| **Athena++** | `.athdf` HDF5 | AMR | hydro · MHD | code | ✅ | ✅ (per MeshBlock) | [Athena++](athena_reader.md) |
+| **FLASH** | HDF5 PARAMESH | AMR | hydro · MHD | CGS | ✅ | ✅ (per leaf block) | [FLASH](flash_reader.md) |
+
+Data is loaded **per type**, exactly as for RAMSES: [`gethydro`](@ref) always, and
+[`getparticles`](@ref) where the code wrote particles (PLUTO). Only what a code actually stored is
+available — e.g. an Athena++/FLASH plot file is hydro + cell-centred MHD only.
+
+## The shared contract
+
+Whatever the source code, a loaded object obeys the same rules — this is what makes the analysis
+code-blind, and what the cross-reader test (`test/59_multicode_contract_tests.jl`) checks:
+
+- **Cell convention.** A cell at `level` with integer index `cx` sits at `getvar(:x) = cx·boxlen/2^level`
+  (likewise `cy`, `cz`); its size is `boxlen/2^level`. AMR readers carry a `:level` column; uniform
+  readers have a single level.
+- **Exact tiling.** The leaf cells cover the box with no gaps or overlaps — `Σ getvar(:volume) = boxlen³`.
+  This is the decisive correctness check every reader is validated against on real data.
+- **Spatial selection.** `gethydro(info; xrange, yrange, zrange, center, range_unit)` selects a window
+  at load time (HDF5 AMR readers read only the intersecting blocks); the result equals a full load
+  filtered by `getvar(:x)`, and the window is recorded in `obj.ranges`. Level/resolution is **not** a
+  load argument — on a leaf-cell list a level cap would leave holes — it is chosen at analysis time
+  (`projection(…, res=)`).
+
+## Reference readers
+
+Each frontend is built to agree with the upstream tools that define its format — yt's per-code
+frontends and region selectors, and each code's own reader (`pyPLUTO`, Athena++'s `athena_read.py`,
+the FLASH user guide). The reader pages cite these as the *origin* the implementation is validated
+against; the yt sample-data collection supplies the real test snapshots.
+
+## Adding a reader
+
+The design doc [`docs/dev/MULTICODE_READERS.md`](https://github.com/ManuelBehrendt/Mera.jl/blob/master/docs/dev/MULTICODE_READERS.md)
+walks through it. In short: write `getinfo_X(output, path; …)` → `InfoType` (set `simcode`,
+`levelmin/max`, `boxlen`, `unit_*`, `variable_list`, then `createconstants!`/`createscales!`) and
+`gethydro_X(info; xrange, …)` → `HydroDataType`, reusing the shared `_external_ranges`/`_external_keep`
+helpers for load-time selection. Then add a `detect_simcode` branch and the `getinfo`/`gethydro`
+router branches, and export the two functions. Mirror the existing HDF5 readers (`reader_athena.jl`,
+`reader_flash.jl`) for block-structured AMR.

--- a/src/read_data/RAMSES/gethydro.jl
+++ b/src/read_data/RAMSES/gethydro.jl
@@ -333,6 +333,11 @@ function gethydro(dataobject::InfoType;
     # Multi-code: a non-RAMSES info delegates to its own frontend (the analysis stays blind).
     # The spatial-window selection (xrange/yrange/zrange/center/range_unit) is honoured by the
     # frontends; lmax/resolution is a leaf-data analysis-time choice and is not forwarded.
+    if dataobject.simcode in ("PLUTO", "CHOMBO", "Athena++", "FLASH")
+        lmax < dataobject.levelmax && @warn "gethydro: `lmax` is not applied to the " *
+            "$(dataobject.simcode) reader — external readers load all leaf cells; choose the " *
+            "resolution at analysis time instead (e.g. `projection(…, lmax=, res=)`)." maxlog=1
+    end
     if dataobject.simcode == "PLUTO"
         return gethydro_pluto(dataobject; xrange=xrange, yrange=yrange, zrange=zrange,
                               center=center, range_unit=range_unit, verbose=verbose)

--- a/test/59_multicode_contract_tests.jl
+++ b/test/59_multicode_contract_tests.jl
@@ -1,0 +1,106 @@
+# 59_multicode_contract_tests.jl  --  cross-reader contract (data-free)
+# ==============================================================================
+# Every external frontend (PLUTO / Athena++ / FLASH) must satisfy the SAME contract, which is
+# what lets the analysis layer stay code-blind. This test synthesises a tiny snapshot for each
+# code, loads it through the GENERIC getinfo/gethydro (auto-detect), and asserts the identical
+# set of universal invariants — cell convention, exact tiling, and load-time selection. A reader
+# that diverges from any sibling fails here. (Per-code specifics live in test/52/57/58.)
+# ==============================================================================
+
+import Mera.HDF5: h5open, attributes, FixedString
+
+# ---- minimal synthetic snapshots (all boxlen 1; rho = 1) ---------------------------------------
+
+# PLUTO uniform: a 4³ static grid (grid.out + dbl.out + data.0000.dbl)
+function _synth_pluto(dir)
+    gl(n) = "$n\n" * join([" $i  $((i-1)/n)  $(i/n)" for i in 1:n], "\n") * "\n"
+    write(joinpath(dir, "grid.out"), "# GEOMETRY:   CARTESIAN\n" * gl(4) * gl(4) * gl(4))
+    write(joinpath(dir, "dbl.out"), "0 0.0 1e-9 0 single_file little rho vx1 vx2 vx3 prs\n")
+    raw = zeros(Float64, 4^3 * 5); raw[1:4^3] .= 1.0                  # rho block = 1, rest 0
+    write(joinpath(dir, "data.0000.dbl"), reinterpret(UInt8, raw))
+end
+
+# Athena++ .athdf: 8 blocks of 2³ = a 4³ uniform grid at level 2
+function _synth_athena(dir)
+    nb = 2; blocks = [(0, (oi, oj, ok)) for ok in 0:1, oj in 0:1, oi in 0:1] |> vec
+    nblk = length(blocks); ll = zeros(Int, 3, nblk); levels = zeros(Int, nblk)
+    prim = ones(Float64, nb, nb, nb, nblk, 5)                         # rho=1 (all vars 1)
+    for (m, (L, loc)) in enumerate(blocks); levels[m] = L; ll[:, m] .= collect(loc); end
+    h5open(joinpath(dir, "s.out1.00000.athdf"), "w") do f
+        at = attributes(f)
+        at["Coordinates"] = "cartesian"; at["RootGridSize"] = [4, 4, 4]; at["MeshBlockSize"] = [nb, nb, nb]
+        at["MaxLevel"] = 0; at["NumMeshBlocks"] = nblk
+        at["RootGridX1"] = [0.0, 1.0, 1.0]; at["RootGridX2"] = [0.0, 1.0, 1.0]; at["RootGridX3"] = [0.0, 1.0, 1.0]
+        at["Time"] = 0.0; at["VariableNames"] = ["rho", "press", "vel1", "vel2", "vel3"]
+        at["DatasetNames"] = ["prim"]; at["NumVariables"] = [5]
+        f["Levels"] = levels; f["LogicalLocations"] = ll; f["prim"] = prim
+    end
+end
+
+# FLASH PARAMESH: a non-leaf root (level 1) refined into 8 leaf octants (level 2) = a 4³ grid
+function _synth_flash(dir)
+    FS = FixedString{80,0}; fs(s) = FS(ntuple(i -> i <= ncodeunits(s) ? codeunits(s)[i] : 0x00, 80))
+    pr(ps, T) = [(name=fs(string(k)), value=T(v)) for (k, v) in ps]
+    nb = 2; octs = [(oi, oj, ok) for ok in 0:1, oj in 0:1, oi in 0:1] |> vec
+    nblk = 1 + length(octs); bbox = zeros(Float64, 2, 3, nblk); rlev = zeros(Int32, nblk); ntyp = zeros(Int32, nblk)
+    dens = ones(Float64, nb, nb, nb, nblk)
+    bbox[1, :, 1] .= 0.0; bbox[2, :, 1] .= 1.0; rlev[1] = 1; ntyp[1] = 2; dens[:, :, :, 1] .= -1.0
+    for (bi, (oi, oj, ok)) in enumerate(octs)
+        m = bi + 1; rlev[m] = 2; ntyp[m] = 1
+        bbox[1, :, m] = [oi*0.5, oj*0.5, ok*0.5]; bbox[2, :, m] = bbox[1, :, m] .+ 0.5
+    end
+    h5open(joinpath(dir, "s_hdf5_plt_cnt_0000"), "w") do f
+        f["integer scalars"] = pr(["nxb"=>nb, "nyb"=>nb, "nzb"=>nb, "dimensionality"=>3], Int32)
+        f["integer runtime parameters"] = pr(["nblockx"=>1, "nblocky"=>1, "nblockz"=>1, "lrefine_min"=>1, "lrefine_max"=>2], Int32)
+        f["real runtime parameters"] = pr(["xmin"=>0.0, "xmax"=>1.0, "ymin"=>0.0, "ymax"=>1.0, "zmin"=>0.0, "zmax"=>1.0], Float64)
+        f["real scalars"] = pr(["time"=>0.0], Float64)
+        f["unknown names"] = reshape(["dens"], 1, 1)
+        f["bounding box"] = bbox; f["refine level"] = rlev; f["node type"] = ntyp; f["dens"] = dens
+    end
+end
+
+# ---- the universal contract every reader must satisfy ------------------------------------------
+function _assert_contract(name, info; uniform::Bool)
+    @testset "$name" begin
+        gas = gethydro(info, verbose=false)
+        @test gas isa Mera.HydroDataType
+        cn = Mera.IndexedTables.colnames(gas.data)
+        @test :cx in cn && :cy in cn && :cz in cn
+        @test (:level in cn) != uniform                          # AMR readers carry :level; uniform don't
+        @test :rho in cn
+
+        bl = gas.boxlen
+        cx = Mera.select(gas.data, :cx)
+        lvl = uniform ? fill(info.levelmin, length(cx)) : getvar(gas, :level)
+        # cell convention: getvar(:x) == cx·boxlen/2^level  (shared by every reader)
+        @test getvar(gas, :x) ≈ cx .* bl ./ 2.0 .^ lvl
+        @test getvar(gas, :cellsize)[1] ≈ bl / 2.0^Int(lvl[1])
+        # exact tiling: leaf cells cover the box with no gaps/overlaps
+        @test sum(getvar(gas, :volume)) ≈ bl^3 rtol=1e-10
+        # the analysis layer works
+        @test all(getvar(gas, :rho) .≈ 1.0) && msum(gas) > 0
+        @test maximum(projection(gas, :rho, res=8, center=[:bc], verbose=false, show_progress=false).maps[:rho]) > 0
+
+        # load-time spatial selection: lower-x half, equals a getvar(:x) filter, recorded in ranges
+        x = getvar(gas, :x)
+        sub = gethydro(info; xrange=[0.0, 0.5], center=[0., 0., 0.], range_unit=:standard, verbose=false)
+        @test length(sub.data) == count(x .<= 0.5)
+        @test sub.ranges[1:2] == [0.0, 0.5]
+        @test maximum(getvar(sub, :x)) <= 0.5 + 1e-9
+    end
+end
+
+@testset verbose=true "multi-code reader contract (data-free)" begin
+    let d = mktempdir(); _synth_pluto(d)
+        info = getinfo(0, d, verbose=false); @test info.simcode == "PLUTO"   # auto-detected
+        _assert_contract("PLUTO (uniform)", info; uniform=true)
+    end
+    let d = mktempdir(); _synth_athena(d)
+        info = getinfo(0, d, verbose=false); @test info.simcode == "Athena++"
+        _assert_contract("Athena++ (AMR)", info; uniform=false)
+    end
+    let d = mktempdir(); _synth_flash(d)
+        info = getinfo(0, d, verbose=false); @test info.simcode == "FLASH"
+        _assert_contract("FLASH (AMR)", info; uniform=false)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -76,6 +76,7 @@ if isempty(_focus)
         include("56_filterdata_tests.jl")  # data-free: value-space filtering on derived quantities (filterdata/getmask)
         include("57_athena_reader_tests.jl")  # data-free: Athena++ .athdf reader contract (synthetic HDF5)
         include("58_flash_reader_tests.jl")  # data-free: FLASH HDF5 PARAMESH reader contract (synthetic HDF5)
+        include("59_multicode_contract_tests.jl")  # data-free: cross-reader contract (PLUTO/Athena++/FLASH satisfy the same invariants)
     end
 
     # ========================================================================


### PR DESCRIPTION
## What

Capstones the four-reader multi-code work (RAMSES + PLUTO/Chombo + Athena++ + FLASH) with three consolidation pieces.

### 1. Overview page (`docs/src/multicode.md`)
A "Multi-code support" landing page tying the reader pages together:
- the code-blind architecture ("a new code = write a reader that fills the structs");
- a **comparison table** — file format, grid (uniform/AMR), data types, native units, load-time window, block I/O pruning, per code;
- the **shared contract** (cell convention, exact tiling, spatial selection);
- reference readers (yt / pyPLUTO / athena_read.py / FLASH UG) and a "how to add a reader" pointer.

Nav: `Other Codes` → Overview / PLUTO / Athena++ / FLASH.

### 2. Cross-reader contract test (`test/59`)
A data-free test that synthesises a tiny snapshot for **each** code, loads it through the generic auto-detect `getinfo`/`gethydro`, and asserts the **same** universal invariants via one `_assert_contract`:
- cell convention `getvar(:x) == cx·boxlen/2^level`;
- **exact tiling** `Σ getvar(:volume) == boxlen³` (no gaps/overlaps);
- load-time `xrange` selection equals a `getvar(:x)` filter and is recorded in `ranges`.

A reader that diverges from its siblings fails here. PLUTO/Athena++/FLASH **39/39**.

### 3. `lmax` warning
`gethydro` now `@warn`s (once) when `lmax < levelmax` is passed to a non-RAMSES reader — those load all leaf cells, so resolution is an analysis-time choice (`projection(…, lmax=, res=)`). Closes the "silently ignored kwarg" footgun.

## Verification
All reader suites green: **PLUTO 61, Athena++ 34, FLASH 28, contract 39** (162 total, no regression). Docs build clean; the overview page and nav render.

Does not touch `CHANGELOG.md` / `CITATION.cff` / `paper/`.
