### PR TITLE
readers: code-blind output discovery — timeseries/getmovie for Athena++/Chombo/FLASH

### DIFF
--- a/docs/src/multicode.md
+++ b/docs/src/multicode.md
@@ -27,6 +27,11 @@ Data is loaded **per type**, exactly as for RAMSES: [`gethydro`](@ref) always, a
 [`getparticles`](@ref) where the code wrote particles (PLUTO). Only what a code actually stored is
 available — e.g. an Athena++/FLASH plot file is hydro + cell-centred MHD only.
 
+**Multi-output workflows** are code-blind too: [`timeseries`](@ref) and
+[`getmovie`](@ref)/[`savemovie`](@ref) discover the output numbers in a directory per format
+(`*.NNNNN.athdf`, `*_hdf5_plt_cnt_NNNN`, PLUTO's `dbl.out`, …) and iterate them through the generic
+loader — so a time-series or movie reduction runs the same call on every supported code.
+
 ## The shared contract
 
 Whatever the source code, a loaded object obeys the same rules — this is what makes the analysis

--- a/src/functions/timeseries.jl
+++ b/src/functions/timeseries.jl
@@ -83,7 +83,7 @@ function timeseries(path::String, reducer;
                           "(mera_files=$mera_files, outputs=$outputs).")
 
     verbose && println("timeseries: $(length(sel)) snapshot(s) from \"$path\" " *
-                       "($(mera_files ? "mera files" : "RAMSES outputs"), :$datatype)")
+                       "($(mera_files ? "mera files" : "$(detect_simcode(path)) outputs"), :$datatype)")
 
     rows = Vector{NamedTuple}(undef, 0)
     for (k, n) in enumerate(sel)
@@ -113,10 +113,14 @@ end
 function _timeseries_outputs(path::String; mera_files::Bool=false, outputs=:all)
     avail = if mera_files
         _mera_output_numbers(path)
-    elseif detect_simcode(path) === :pluto      # PLUTO lists its outputs in dbl.out
-        pluto_output_numbers(path)
-    else
-        sort(checkoutputs(path; verbose=false).outputs)
+    else                                        # code-blind discovery (timeseries + getmovie)
+        code = detect_simcode(path)
+        if     code === :pluto;  pluto_output_numbers(path)        # PLUTO lists its outputs in dbl.out
+        elseif code === :athena; _athena_output_numbers(path)      # *.NNNNN.athdf
+        elseif code === :flash;  _flash_output_numbers(path)       # *_hdf5_plt_cnt_NNNN
+        elseif code === :chombo; _chombo_output_numbers(path)      # *.NNNN.*.hdf5
+        else   sort(checkoutputs(path; verbose=false).outputs)     # RAMSES
+        end
     end
     return _select_outputs(avail, outputs)
 end

--- a/src/read_data/Athena/reader_athena.jl
+++ b/src/read_data/Athena/reader_athena.jl
@@ -27,6 +27,17 @@ const _ATHENA_VARMAP = Dict(
 _athena_rootlevel(n::Integer) = (l = round(Int, log2(n)); 2^l == n ? l :
     error("Athena++ reader: RootGridSize must be a power of two per axis; got $n."))
 
+# Output numbers present in a directory of Athena++ snapshots (`…NNNNN.athdf`), for timeseries/movies.
+function _athena_output_numbers(path::String)
+    nums = Int[]
+    isdir(path) || return nums
+    for f in readdir(path)
+        m = match(r"\.(\d+)\.athdf$"i, f)
+        m === nothing || push!(nums, parse(Int, m.captures[1]))
+    end
+    return sort(unique(nums))
+end
+
 # Resolve the .athdf snapshot file: accept a direct file path, or find `…NNNNN.athdf` in a dir.
 function _athena_file(output::Int, path::String)
     (isfile(path) && endswith(lowercase(path), ".athdf")) && return path

--- a/src/read_data/FLASH/reader_flash.jl
+++ b/src/read_data/FLASH/reader_flash.jl
@@ -45,6 +45,17 @@ function _flash_params(f, dname::String)
     return d
 end
 
+# Output numbers present in a directory of FLASH snapshots (`…_hdf5_{plt_cnt,chk}_NNNN`).
+function _flash_output_numbers(path::String)
+    nums = Int[]
+    isdir(path) || return nums
+    for f in readdir(path)
+        m = match(r"_hdf5_(?:plt_cnt|chk)_(\d+)$", f)
+        m === nothing || push!(nums, parse(Int, m.captures[1]))
+    end
+    return sort(unique(nums))
+end
+
 # resolve the FLASH snapshot file: a direct path, or `…_hdf5_{plt_cnt,chk}_NNNN` in a directory
 function _flash_file(output::Int, path::String)
     isfile(path) && return path

--- a/src/read_data/PLUTO/reader_chombo.jl
+++ b/src/read_data/PLUTO/reader_chombo.jl
@@ -77,7 +77,7 @@ function _covered(coarse::_Level, fine::_Level, ref::Int)
 end
 
 function getinfo_chombo(output::Int, path::String; verbose::Bool=true)
-    fn = _chombo_file(path)
+    fn = _chombo_file(output, path)
     h5open(fn, "r") do f
         a = attributes(f)
         ncomp = Int(read(a["num_components"])); nlev = Int(read(a["num_levels"]))
@@ -125,7 +125,7 @@ end
 function gethydro_chombo(info::InfoType;
                          xrange=[missing, missing], yrange=[missing, missing], zrange=[missing, missing],
                          center=[0., 0., 0.], range_unit::Symbol=:standard, verbose::Bool=true)
-    fn = _chombo_file(info.path)
+    fn = _chombo_file(round(Int, info.output), info.path)
     h5open(fn, "r") do f
         a = attributes(f)
         ncomp = Int(read(a["num_components"])); nlev = Int(read(a["num_levels"]))

--- a/src/read_data/PLUTO/reader_pluto.jl
+++ b/src/read_data/PLUTO/reader_pluto.jl
@@ -76,12 +76,28 @@ function detect_simcode(path::String)
 end
 
 # First *.hdf5 file in a directory (the Chombo/PLUTO-AMR snapshot).
-function _chombo_file(path::String)
+# Resolve the Chombo `.hdf5` snapshot: prefer a file whose name carries the output number
+# (e.g. `data.0007.3d.hdf5`); fall back to the only/first file (single-output runs ignore it).
+function _chombo_file(output::Int, path::String)
     isdir(path) || return path
-    for f in sort(readdir(path))
-        endswith(lowercase(f), ".hdf5") && return joinpath(path, f)
+    files = sort(filter(f -> endswith(lowercase(f), ".hdf5"), readdir(path)))
+    isempty(files) && error("Chombo: no .hdf5 file in $path")
+    tag = lpad(output, 4, '0')
+    for f in files; occursin("." * tag * ".", f) && return joinpath(path, f); end
+    return joinpath(path, files[1])
+end
+_chombo_file(path::String) = _chombo_file(0, path)            # back-compatible 1-arg form
+
+# Output numbers present in a directory of Chombo snapshots (`…\.NNNN\.…\.hdf5`).
+function _chombo_output_numbers(path::String)
+    nums = Int[]
+    isdir(path) || return nums
+    for f in readdir(path)
+        endswith(lowercase(f), ".hdf5") || continue
+        m = match(r"\.(\d+)\.", f)
+        m === nothing || push!(nums, parse(Int, m.captures[1]))
     end
-    error("Chombo: no .hdf5 file in $path")
+    return sort(unique(nums))
 end
 # getinfo_chombo / gethydro_chombo are defined in read_data/PLUTO/reader_chombo.jl (uses HDF5).
 

--- a/test/57_athena_reader_tests.jl
+++ b/test/57_athena_reader_tests.jl
@@ -113,6 +113,12 @@ end
             @test all(getvar(gas, :rho) .> 0) && msum(gas) > 0
             @test maximum(projection(gas, :sd, res=64, center=[:bc], verbose=false, show_progress=false).maps[:sd]) > 0
 
+            # multi-output workflow: timeseries discovers + iterates the .athdf snapshots
+            @test Mera._athena_output_numbers(am06) == [300, 400, 500]
+            ts = timeseries(am06, d -> (rmax = maximum(getvar(d, :rho)),); outputs=[300, 400],
+                            time_unit=:standard, verbose=false)
+            @test length(ts) == 2 && :rmax in Mera.IndexedTables.colnames(ts)
+
             # load-time spatial selection: a central box reduces to the refined core
             sub = gethydro(info; xrange=[-0.05, 0.05], yrange=[-0.05, 0.05], zrange=[-0.05, 0.05],
                            center=[:bc], range_unit=:standard, verbose=false)

--- a/test/58_flash_reader_tests.jl
+++ b/test/58_flash_reader_tests.jl
@@ -103,6 +103,11 @@ end
             @test all(getvar(gas, :rho) .> 0) && msum(gas) > 0
             @test sum(getvar(gas, :volume)) ≈ gas.boxlen^3 rtol=1e-12   # leaf cells tile the box (no gaps/overlaps)
             @test maximum(projection(gas, :rho, res=64, center=[:bc], verbose=false, show_progress=false).maps[:rho]) > 0
+            # multi-output workflow: timeseries discovers + iterates the FLASH plot files
+            @test Mera._flash_output_numbers(gd) == [100, 150]
+            ts = timeseries(gd, d -> (rmax = maximum(getvar(d, :rho)),); time_unit=:standard, verbose=false)
+            @test length(ts) == 2 && :rmax in Mera.IndexedTables.colnames(ts)
+
             # load-time sub-region reads only the intersecting leaf blocks
             sub = gethydro(info; xrange=[-0.1, 0.1], yrange=[-0.1, 0.1], zrange=[-0.1, 0.1],
                            center=[:bc], range_unit=:standard, verbose=false)

--- a/test/59_multicode_contract_tests.jl
+++ b/test/59_multicode_contract_tests.jl
@@ -104,3 +104,20 @@ end
         _assert_contract("FLASH (AMR)", info; uniform=false)
     end
 end
+
+# Output-number discovery (filename-only) powers timeseries/getmovie across codes.
+@testset "output-number discovery (timeseries/getmovie)" begin
+    let d = mktempdir()
+        for n in (10, 20, 5); touch(joinpath(d, "sim.out1." * lpad(n, 5, '0') * ".athdf")); end
+        @test Mera._athena_output_numbers(d) == [5, 10, 20]
+    end
+    let d = mktempdir()
+        for n in (100, 150); touch(joinpath(d, "s_hdf5_plt_cnt_" * lpad(n, 4, '0'))); end
+        touch(joinpath(d, "s_hdf5_chk_0200"))
+        @test Mera._flash_output_numbers(d) == [100, 150, 200]
+    end
+    let d = mktempdir()
+        touch(joinpath(d, "data.0003.3d.hdf5")); touch(joinpath(d, "data.0007.3d.hdf5"))
+        @test Mera._chombo_output_numbers(d) == [3, 7]
+    end
+end


### PR DESCRIPTION
## What

`timeseries`/`getmovie` worked only for RAMSES, mera-files, and PLUTO — on **Athena++/Chombo/FLASH** they failed with *"no matching outputs found"*. The load path was already code-blind (`getinfo`+`gethydro`); only **output-number discovery** was missing.

## How

- Per-code scanners: `_athena_output_numbers` (`*.NNNNN.athdf`), `_flash_output_numbers` (`*_hdf5_plt_cnt/chk_NNNN`), `_chombo_output_numbers` (`*.NNNN.*.hdf5`).
- `_timeseries_outputs` dispatches on `detect_simcode` — fixes **both** `timeseries` and `getmovie` (they share it).
- `_chombo_file` is now output-aware (prefers the file carrying the output number; back-compatible 1-arg form kept), so multi-output Chombo resolves correctly.
- `timeseries` header names the detected code instead of hardcoding "RAMSES".

## Verification

On the real multi-output fixtures, `timeseries` discovers and iterates **Athena++ AM06 [300,400,500]** and **FLASH GasSloshing [100,150]**:

```julia
ts = timeseries("/data/GasSloshing", d -> (rmax = maximum(getvar(d,:rho)),); time_unit=:standard)
# 2 snapshots, columns: output | time | rmax
```

Tests: data-free discovery (test/59) + data-backed timeseries (test/57, test/58). **Contract 42/42, Athena++ 36/36, FLASH 30/30.** Docs: the overview page notes multi-output workflows are code-blind.

Does not touch `CHANGELOG.md` / `CITATION.cff` / `paper/`.