### PR TITLE
readers: savedata/loaddata round-trip for external codes (Mera-file interoperability)

### DIFF
--- a/src/functions/overview.jl
+++ b/src/functions/overview.jl
@@ -154,6 +154,12 @@ function storageoverview(dataobject::InfoType; verbose::Bool=true)
     #println(fnames)
     fnames = dataobject.fnames
 
+    # External (non-RAMSES) snapshots have no RAMSES output directory to tally — return empty.
+    if !isdefined(fnames, :output) || isempty(fnames.output) || !isdir(fnames.output)
+        verbose && println("(storage overview unavailable — no RAMSES output directory for $(dataobject.simcode))")
+        return dictoutput
+    end
+
     all_files = readdir(fnames.output)
     folder = filesize.(  fnames.output .* "/" .* all_files)
     folder_size = sum( folder )

--- a/src/read_data/Athena/reader_athena.jl
+++ b/src/read_data/Athena/reader_athena.jl
@@ -64,7 +64,7 @@ dimensionless, see [`getinfo_pluto`](@ref) for the same convention).
 function getinfo_athena(output::Int, path::String; unit_length::Real=1.0, unit_density::Real=1.0,
                         unit_velocity::Real=1.0, verbose::Bool=true)
     fn = _athena_file(output, path)
-    info = InfoType(); info.descriptor = DescriptorType()
+    info = InfoType(); info.descriptor = _external_descriptor()
     h5open(fn, "r") do f
         a = attributes(f)
         coord = lowercase(String(read(a["Coordinates"])))
@@ -105,6 +105,7 @@ function getinfo_athena(output::Int, path::String; unit_length::Real=1.0, unit_d
         end
     end
     createconstants!(info); createscales!(info)
+    _fill_undefined!(info)
     return info
 end
 

--- a/src/read_data/FLASH/reader_flash.jl
+++ b/src/read_data/FLASH/reader_flash.jl
@@ -89,7 +89,7 @@ and `:kpc`/`:Msol`/… conversions are already physical. Override `unit_length`/
 function getinfo_flash(output::Int, path::String; unit_length::Real=1.0, unit_density::Real=1.0,
                        unit_velocity::Real=1.0, verbose::Bool=true)
     fn = _flash_file(output, path)
-    info = InfoType(); info.descriptor = DescriptorType()
+    info = InfoType(); info.descriptor = _external_descriptor()
     h5open(fn, "r") do f
         rp = _flash_params(f, "real runtime parameters")
         ip = _flash_params(f, "integer runtime parameters")
@@ -143,6 +143,7 @@ function getinfo_flash(output::Int, path::String; unit_length::Real=1.0, unit_de
         end
     end
     createconstants!(info); createscales!(info)
+    _fill_undefined!(info)
     return info
 end
 

--- a/src/read_data/PLUTO/reader_chombo.jl
+++ b/src/read_data/PLUTO/reader_chombo.jl
@@ -88,7 +88,7 @@ function getinfo_chombo(output::Int, path::String; verbose::Bool=true)
         2^base == n0 || error("Chombo reader: level-0 size $n0 must be a power of two.")
         dx0 = Float64(read(attributes(f["level_0"])["dx"]))
 
-        info = InfoType(); info.descriptor = DescriptorType()
+        info = InfoType(); info.descriptor = _external_descriptor()
         info.output = output; info.path = abspath(path); info.simcode = "CHOMBO"
         info.Narraysize = 0; info.ndim = 3
         info.levelmin = base; info.levelmax = base + nlev - 1
@@ -110,6 +110,7 @@ function getinfo_chombo(output::Int, path::String; verbose::Bool=true)
         info.ncpu = 1
         info.mtime = Dates.unix2datetime(round(Int, mtime(fn))); info.ctime = info.mtime
         createconstants!(info); createscales!(info)
+        _fill_undefined!(info)
         if verbose
             println("Code: CHOMBO  (PLUTO-AMR / Orion format)")
             println("output: ", output, "  time: ", round(time, sigdigits=5), " [code units]")

--- a/src/read_data/PLUTO/reader_pluto.jl
+++ b/src/read_data/PLUTO/reader_pluto.jl
@@ -175,7 +175,7 @@ function getinfo_pluto(output::Int, path::String; unit_length::Real=1.0,
     boxlen = (xc1[end] - xc1[1]) + (xc1[2] - xc1[1])     # domain length (centres + one cell)
 
     info = InfoType()
-    info.descriptor = DescriptorType()
+    info.descriptor = _external_descriptor()
     info.output = output;          info.path = abspath(path); info.simcode = "PLUTO"
     info.Narraysize = 0;           info.ndim = 3
     info.levelmin = level;         info.levelmax = level;     info.boxlen = boxlen
@@ -203,6 +203,7 @@ function getinfo_pluto(output::Int, path::String; unit_length::Real=1.0,
     info.ctime = info.mtime
     createconstants!(info)
     createscales!(info)
+    _fill_undefined!(info)
     if verbose
         printtime("", verbose)
         println("Code: ", info.simcode)
@@ -224,6 +225,37 @@ end
 # the **leaf-cell** list, so a spatial window is an exact, hole-free filter: a cell is kept
 # when its Mera position `cx/2^level` (= `getvar(:x)/boxlen`, so the selection matches
 # [`subregion`](@ref)) lies inside the prepranges-normalised box. Returns `(keep, ranges)`.
+# Fill any UNDEFINED fields of a mutable struct with type-appropriate empties (recursing into
+# nested structs). The external readers don't populate the RAMSES-only InfoType fields (`fnames`,
+# `grid_info`, `part_info`, `compilation`, …); leaving them as `new()` undefined refs breaks
+# serialization (savedata/JLD2). This defines them without clobbering anything already set.
+_blankval(::Type{<:AbstractString}) = ""
+_blankval(::Type{T}) where {T<:Integer} = zero(T)
+_blankval(::Type{T}) where {T<:AbstractFloat} = zero(T)
+_blankval(::Type{Array{S,N}}) where {S,N} = Array{S,N}(undef, ntuple(_ -> 0, N)...)
+_blankval(::Type{Dict{K,V}}) where {K,V} = Dict{K,V}()
+_blankval(::Type{T}) where {T} = _fill_undefined!(T())   # nested mutable struct (its own `new()`)
+function _fill_undefined!(x)
+    for f in fieldnames(typeof(x))
+        isdefined(x, f) || setfield!(x, f, _blankval(fieldtype(typeof(x), f)))
+    end
+    return x
+end
+
+# A fully-initialised, empty DescriptorType for the external readers. RAMSES fills the descriptor
+# from its files; the non-RAMSES codes have none, but the fields must still be DEFINED (not left as
+# `new()` undefined refs) so downstream code — e.g. savedata's `check_datasource` — can read them.
+function _external_descriptor()
+    d = DescriptorType()
+    d.hversion = 0; d.hydro = Symbol[]; d.htypes = String[]; d.usehydro = false; d.hydrofile = false
+    d.pversion = 0; d.particles = Symbol[]; d.ptypes = String[]; d.useparticles = false; d.particlesfile = false
+    d.gravity = Symbol[]; d.usegravity = false; d.gravityfile = false
+    d.rtversion = 0; d.rt = Dict{Any,Any}(); d.rtPhotonGroups = Dict{Any,Any}(); d.usert = false; d.rtfile = false
+    d.clumps = Symbol[]; d.useclumps = false; d.clumpsfile = false
+    d.sinks = Symbol[]; d.usesinks = false; d.sinksfile = false
+    return d
+end
+
 # box-normalised (0..1) selection ranges + whether they cover the whole box
 function _external_ranges(info::InfoType, xrange, yrange, zrange, center, range_unit::Symbol)
     ranges = prepranges(info, range_unit, false, collect(xrange), collect(yrange),

--- a/test/59_multicode_contract_tests.jl
+++ b/test/59_multicode_contract_tests.jl
@@ -87,6 +87,12 @@ function _assert_contract(name, info; uniform::Bool)
         @test length(sub.data) == count(x .<= 0.5)
         @test sub.ranges[1:2] == [0.0, 0.5]
         @test maximum(getvar(sub, :x)) <= 0.5 + 1e-9
+
+        # Mera-file persistence round-trips (savedata/loaddata) — converts any code to Mera's JLD2
+        tmp = mktempdir(); savedata(gas, tmp; fmode=:write, verbose=false)
+        g2 = loaddata(round(Int, info.output), tmp, :hydro; verbose=false)
+        @test length(g2.data) == length(gas.data) && getvar(g2, :rho) == getvar(gas, :rho)
+        @test g2.info.simcode == info.simcode
     end
 end
 


### PR DESCRIPTION
## What

A feature-surface probe on the new Athena++ fixture showed the analysis layer already works on non-RAMSES objects (getvar/derived quantities, regions, filterdata, pdf, projection, aggregates all ✅). **The one gap: `savedata`/`loaddata`** failed with `UndefRefError` and a `readdir("")`.

## Root causes (all from a partly-initialised `InfoType`)

The external readers produce an `InfoType` that RAMSES would fill from its files — but these codes have no such files, leaving fields undefined:

1. **`info.descriptor`** was an empty `DescriptorType()` (undefined fields) → `savedata`'s `check_datasource` read undef refs. → `_external_descriptor()` (all `use*=false`, empty arrays), used in all 4 external `getinfo`.
2. **6 nested `InfoType` fields** (`fnames`/`grid_info`/`part_info`/`compilation`/`files_content`/`namelist_content`) were undefined → JLD2 can't serialize. → `_fill_undefined!`/`_blankval` (generic empty-init, recurses into nested structs), called at the end of each external `getinfo`.
3. **`storageoverview`** did `readdir(fnames.output)` on an empty path → guard returns an empty overview when there's no RAMSES output directory.

## Result

`gethydro → savedata → loaddata` now round-trips **bit-identically** for **Athena++, FLASH, PLUTO, Chombo**, and a saved series feeds `timeseries(...; mera_files=true)`. This lets users convert any supported code into Mera's portable JLD2 format and use the full toolchain.

## Verification
Round-trip added to the cross-reader contract (`test/59`). **Contract 48/48, PLUTO 61/61.**

Does not touch `CHANGELOG.md` / `CITATION.cff` / `paper/`.