### PR TITLE
readers: expose self-gravity potential as canonical :gpot (code-blind gravity)

### DIFF
--- a/docs/src/multicode.md
+++ b/docs/src/multicode.md
@@ -27,6 +27,12 @@ Data is loaded **per type**, exactly as for RAMSES: [`gethydro`](@ref) always, a
 [`getparticles`](@ref) where the code wrote particles (PLUTO). Only what a code actually stored is
 available — e.g. an Athena++/FLASH plot file is hydro + cell-centred MHD only.
 
+**Self-gravity** rides along the same way: where a code writes a gravitational potential into its
+snapshot (Athena++ `phi`, FLASH `gpot`, Chombo `gravitational-potential`) the reader exposes it as
+a single canonical field, so `getvar(gas, :gpot)` — and `projection`, `timeseries`, … on it — runs
+identically on every code. (Particles, by contrast, exist only in PLUTO so far; the public Athena++
+has none, and FLASH particle reading is future work.)
+
 **Multi-output workflows** are code-blind too: [`timeseries`](@ref) and
 [`getmovie`](@ref)/[`savemovie`](@ref) discover the output numbers in a directory per format
 (`*.NNNNN.athdf`, `*_hdf5_plt_cnt_NNNN`, PLUTO's `dbl.out`, …) and iterate them through the generic

--- a/src/read_data/Athena/reader_athena.jl
+++ b/src/read_data/Athena/reader_athena.jl
@@ -21,7 +21,7 @@
 # Athena++ variable name → Mera canonical symbol (primitive and conserved outputs)
 const _ATHENA_VARMAP = Dict(
     "rho"=>:rho, "press"=>:p, "vel1"=>:vx, "vel2"=>:vy, "vel3"=>:vz,
-    "Bcc1"=>:bx, "Bcc2"=>:by, "Bcc3"=>:bz,
+    "Bcc1"=>:bx, "Bcc2"=>:by, "Bcc3"=>:bz, "phi"=>:gpot,        # self-gravity potential → :gpot
     "dens"=>:rho, "Etot"=>:Etot, "mom1"=>:momx, "mom2"=>:momy, "mom3"=>:momz)
 
 _athena_rootlevel(n::Integer) = (l = round(Int, log2(n)); 2^l == n ? l :

--- a/src/read_data/PLUTO/reader_chombo.jl
+++ b/src/read_data/PLUTO/reader_chombo.jl
@@ -18,6 +18,7 @@ const _CHOMBO_MAP = Dict(
     "vx1"=>(:vx,:direct), "vx2"=>(:vy,:direct), "vx3"=>(:vz,:direct),
     "X-momentum"=>(:vx,:mom), "Y-momentum"=>(:vy,:mom), "Z-momentum"=>(:vz,:mom),
     "prs"=>(:p,:direct), "energy-density"=>(:p,:energy),
+    "gravitational-potential"=>(:gpot,:direct),       # self-gravity potential → :gpot (code-blind)
 )
 
 # --- read one Chombo level: leaf mask + per-component cell grids -----------------------

--- a/test/52_pluto_reader_tests.jl
+++ b/test/52_pluto_reader_tests.jl
@@ -172,6 +172,8 @@ if DATA_AVAILABLE && isdir(CH_PATH)
         g = gethydro(info, verbose=false)
         @test g isa Mera.HydroDataType
         @test :level in Mera.IndexedTables.colnames(g.data)   # AMR table carries a level column
+        @test Mera._CHOMBO_MAP["gravitational-potential"][1] == :gpot   # potential → canonical :gpot
+        @test :gpot in info.variable_list && all(isfinite, getvar(g, :gpot))   # self-gravity field, code-blind
         @test length(g.data) == 646248                 # leaf cells — validated vs an independent reader
         @test all(getvar(g, :rho) .> 0)
         @test all(isfinite, getvar(g, :vx))            # momentum → velocity derivation

--- a/test/57_athena_reader_tests.jl
+++ b/test/57_athena_reader_tests.jl
@@ -98,6 +98,20 @@ end
         @test length(gethydro_athena(info, verbose=false).data) == 64    # full box unchanged
     end
 
+    @testset "self-gravity potential maps to :gpot (code-blind gravity-as-field)" begin
+        @test Mera._ATHENA_VARMAP["phi"] == :gpot                  # Athena `phi` → canonical :gpot
+        sg = joinpath(SIMULATION_PATH, "athena_selfgravity")       # small multigrid Jeans run
+        if isdir(sg) && any(f -> endswith(lowercase(f), ".athdf"), readdir(sg))
+            info = getinfo(2, sg, verbose=false)
+            @test :gpot in info.variable_list
+            gas = gethydro(info, verbose=false)
+            @test all(isfinite, getvar(gas, :gpot)) && extrema(getvar(gas, :gpot)) != (0.0, 0.0)
+            @test Mera._athena_output_numbers(sg) == [0, 1, 2, 3, 4]   # a self-gravity time series
+        else
+            @test_skip "athena_selfgravity fixture not present (MERA_TEST_DATA/athena_selfgravity/)"
+        end
+    end
+
     # PART B (data-backed): a REAL Athena++ snapshot — the yt AM06 sample (Cartesian AMR MHD).
     # Download AM06.tar.gz from yt-project.org/data into MERA_TEST_DATA/athena_AM06/.
     @testset "real Athena++ snapshot — yt AM06 (data-backed)" begin


### PR DESCRIPTION
## What

Closes the **gravity** depth gap with a real run. I built Athena++ with self-gravity (multigrid) and ran a 3-D Jeans problem that outputs the gravitational potential `phi`. The code-blind reader already loads it as a field; this canonicalises it across codes:

- Athena++ `phi` → `:gpot`
- Chombo `gravitational-potential` → `:gpot` (was skipped; now loaded)
- FLASH already maps `gpot` → `:gpot`

So the **same** `getvar(gas, :gpot)` / `projection` / `timeseries` call works on Athena++, Chombo and FLASH — no separate `getgravity` needed; the potential is just a field.

## Verification

- New `athena_selfgravity` fixture (5-output multigrid Jeans run, ~4 MB, regenerable) + the Chombo IsothermalSphere both expose `:gpot`.
- Tests: data-free var-map checks + gated data-backed loads. **Athena++ 40/40, PLUTO/Chombo 63/63.**
- Overview doc notes gravity-as-field.

## Particles

The other remaining gap. The **public Athena++ has no particle module** (no `src/particles`, no configure flag), so particles can't be produced there. PLUTO and FLASH have particles but need a registered download to build/run — left as future work and noted in the docs.

Does not touch `CHANGELOG.md` / `CITATION.cff` / `paper/`.