### PR TITLE
readers: canonical chemistry/RT species naming for external codes (code-blind)

### DIFF
--- a/docs/src/multicode.md
+++ b/docs/src/multicode.md
@@ -30,8 +30,17 @@ available — e.g. an Athena++/FLASH plot file is hydro + cell-centred MHD only.
 **Self-gravity** rides along the same way: where a code writes a gravitational potential into its
 snapshot (Athena++ `phi`, FLASH `gpot`, Chombo `gravitational-potential`) the reader exposes it as
 a single canonical field, so `getvar(gas, :gpot)` — and `projection`, `timeseries`, … on it — runs
-identically on every code. (Particles, by contrast, exist only in PLUTO so far; the public Athena++
-has none, and FLASH particle reading is future work.)
+identically on every code.
+
+**Chemistry & radiative transfer** follow suit. A code's species abundances (Athena++ writes its
+chemistry networks as `rH`/`rH2`/`rCO`/`rH+`/…) are mapped to **canonical fractions** — `:xHI`,
+`:xH2`, `:xCO`, `:xHII`, … — and radiation-transport fields to `:Erad`/`:Frad_*`. Because these land
+as direct columns, `getvar(gas, :xH2)`, a `projection` of it, or a `timeseries` of an abundance runs
+the same on every code that writes them (e.g. an H–H₂ formation series, or a CO map). RAMSES RT runs
+keep their own descriptor-based `getvar` species; the canonical names are the shared vocabulary.
+
+(**Particles**, by contrast, exist only in PLUTO so far — the public Athena++ has none, and
+FLASH/PLUTO particle reading needs a registered-download run.)
 
 **Multi-output workflows** are code-blind too: [`timeseries`](@ref) and
 [`getmovie`](@ref)/[`savemovie`](@ref) discover the output numbers in a directory per format

--- a/src/read_data/Athena/reader_athena.jl
+++ b/src/read_data/Athena/reader_athena.jl
@@ -22,7 +22,14 @@
 const _ATHENA_VARMAP = Dict(
     "rho"=>:rho, "press"=>:p, "vel1"=>:vx, "vel2"=>:vy, "vel3"=>:vz,
     "Bcc1"=>:bx, "Bcc2"=>:by, "Bcc3"=>:bz, "phi"=>:gpot,        # self-gravity potential → :gpot
-    "dens"=>:rho, "Etot"=>:Etot, "mom1"=>:momx, "mom2"=>:momy, "mom3"=>:momz)
+    "dens"=>:rho, "Etot"=>:Etot, "mom1"=>:momx, "mom2"=>:momy, "mom3"=>:momz,
+    # --- chemistry species abundances (Athena writes them as `r<species>`) → canonical x-fractions.
+    #     They land as direct columns, so getvar(:xHI)/:xH2/:xCO/… return them across codes.
+    "rH"=>:xHI, "rH2"=>:xH2, "rH+"=>:xHII, "rH2+"=>:xH2II, "rH3+"=>:xH3II, "re"=>:xe, "r*e"=>:xe,
+    "rHe+"=>:xHeII, "rC+"=>:xCII, "rCO"=>:xCO, "rCHx"=>:xCHx, "rOHx"=>:xOHx,
+    "rHCO+"=>:xHCOII, "rO+"=>:xOII, "rSi+"=>:xSiII,
+    # --- radiative-transfer fields (six-ray / nr_radiation), when a run writes them.
+    "Er"=>:Erad, "Fr1"=>:Frad_x, "Fr2"=>:Frad_y, "Fr3"=>:Frad_z)
 
 _athena_rootlevel(n::Integer) = (l = round(Int, log2(n)); 2^l == n ? l :
     error("Athena++ reader: RootGridSize must be a power of two per axis; got $n."))

--- a/test/57_athena_reader_tests.jl
+++ b/test/57_athena_reader_tests.jl
@@ -112,6 +112,24 @@ end
         end
     end
 
+    @testset "chemistry species map to canonical fractions (:xHI/:xH2/…)" begin
+        @test Mera._ATHENA_VARMAP["rH"] == :xHI && Mera._ATHENA_VARMAP["rH2"] == :xH2
+        @test Mera._ATHENA_VARMAP["rCO"] == :xCO && Mera._ATHENA_VARMAP["rH+"] == :xHII
+        @test Mera._ATHENA_VARMAP["Er"] == :Erad            # RT-transport field naming (framework)
+        ch = joinpath(SIMULATION_PATH, "athena_chemistry")  # small H–H2 chemistry run
+        if isdir(ch) && any(f -> endswith(lowercase(f), ".athdf"), readdir(ch))
+            info = getinfo(5, ch, verbose=false)
+            @test :xHI in info.variable_list && :xH2 in info.variable_list   # rH/rH2 → canonical
+            gas = gethydro(info, verbose=false)
+            @test all(0 .<= getvar(gas, :xH2) .<= 1)        # a sensible molecular fraction
+            g0 = gethydro(getinfo(0, ch, verbose=false), verbose=false)
+            @test getvar(gas, :xH2)[1] > getvar(g0, :xH2)[1]               # H2 forms over the run
+            @test Mera._athena_output_numbers(ch) == [0, 1, 2, 3, 4, 5]     # a chemistry time series
+        else
+            @test_skip "athena_chemistry fixture not present (MERA_TEST_DATA/athena_chemistry/)"
+        end
+    end
+
     # PART B (data-backed): a REAL Athena++ snapshot — the yt AM06 sample (Cartesian AMR MHD).
     # Download AM06.tar.gz from yt-project.org/data into MERA_TEST_DATA/athena_AM06/.
     @testset "real Athena++ snapshot — yt AM06 (data-backed)" begin


### PR DESCRIPTION
## What

The chemistry+RT run + the *future work* (canonical species naming, RT-aware fields).

I built Athena++ with the **H₂ chemistry network** (forward-Euler solver — no CVODE needed) and ran a 3-D **H→H₂ formation** time series. The species abundances come out as `rH`/`rH2`, which the code-blind reader already loads.

## The deliverable: canonical species naming

Map each code's chemistry-network field names to **canonical x-fraction symbols** in `_ATHENA_VARMAP`:
- `rH`→`:xHI`, `rH2`→`:xH2`, `rH+`→`:xHII`, `rCO`→`:xCO`, `rC+`→`:xCII`, `rHCO+`→`:xHCOII`, … (the H₂ **and** gow17 C/O networks);
- RT-transport fields: `Er`→`:Erad`, `Fr1/2/3`→`:Frad_x/y/z`.

They land as **direct columns**, so `getvar(:xH2)`, `projection(:xH2)`, and `timeseries` of an abundance run the same on every code that writes them. `getvar` resolves a stored column before any derived path, so there's **no clash** with the RAMSES descriptor-based `:xHI`/`:xH2` — RAMSES RT keeps its own machinery; the canonical names are the shared vocabulary.

## Verification

New `athena_chemistry/` fixture (H–H₂ run, 6 outputs, ~0.6 MB, regenerable): `getvar(:xH2)` rises **0 → 0.45 over 50 Myr** (H₂ formation, conserved). Tests: data-free var-map checks + gated load/timeseries. Athena++ reader suite green; the overview doc gains a chemistry/RT note.

## Scope note

The H₂ run exercises chemistry-as-fields and the naming machinery end-to-end. Richer networks (gow17 → CO/C⁺/HCO⁺) and **RT-transport** runs (six-ray / nr_radiation, which need the gow17 network + radiation config) map through the same table — their mappings are in place but a six-ray fixture is left as a follow-up.

Does not touch `CHANGELOG.md` / `CITATION.cff` / `paper/`.