### PR TITLE
readers: six-ray RT radiation fields → canonical photon groups (:Np1..:Np8)

### DIFF
--- a/docs/src/multicode.md
+++ b/docs/src/multicode.md
@@ -34,10 +34,18 @@ identically on every code.
 
 **Chemistry & radiative transfer** follow suit. A code's species abundances (Athena++ writes its
 chemistry networks as `rH`/`rH2`/`rCO`/`rH+`/…) are mapped to **canonical fractions** — `:xHI`,
-`:xH2`, `:xCO`, `:xHII`, … — and radiation-transport fields to `:Erad`/`:Frad_*`. Because these land
-as direct columns, `getvar(gas, :xH2)`, a `projection` of it, or a `timeseries` of an abundance runs
-the same on every code that writes them (e.g. an H–H₂ formation series, or a CO map). RAMSES RT runs
-keep their own descriptor-based `getvar` species; the canonical names are the shared vocabulary.
+`:xH2`, `:xCO`, `:xHII`, … — and radiation-transport fields to canonical names too: `nr_radiation`
+energy/flux → `:Erad`/`:Frad_*`, and a six-ray chemistry run's per-frequency mean intensities
+(`ir_avg0…7`) → **photon groups** `:Np1…:Np8` (the RAMSES-RT convention). Because these land as
+direct columns, `getvar(gas, :xH2)` or `getvar(gas, :Np1)`, a `projection` of either, or a
+`timeseries` of an abundance runs the same on every code that writes them. RAMSES RT runs keep their
+own descriptor-based `getvar` species; the canonical names are the shared vocabulary.
+
+!!! note "Stiff chemistry needs an implicit solver"
+    The full gow17 (C/O) network + six-ray transfer is stiff; the public Athena++ forward-Euler
+    solver cannot evolve it, so a complete PDR run (attenuated radiation + evolving abundances) needs
+    the **CVODE** solver (`--chem_ode_solver cvode`, SUNDIALS). Mera's reading of all 12 species and
+    the 8 photon-group fields is independent of the solver.
 
 (**Particles**, by contrast, exist only in PLUTO so far — the public Athena++ has none, and
 FLASH/PLUTO particle reading needs a registered-download run.)

--- a/src/read_data/Athena/reader_athena.jl
+++ b/src/read_data/Athena/reader_athena.jl
@@ -28,8 +28,11 @@ const _ATHENA_VARMAP = Dict(
     "rH"=>:xHI, "rH2"=>:xH2, "rH+"=>:xHII, "rH2+"=>:xH2II, "rH3+"=>:xH3II, "re"=>:xe, "r*e"=>:xe,
     "rHe+"=>:xHeII, "rC+"=>:xCII, "rCO"=>:xCO, "rCHx"=>:xCHx, "rOHx"=>:xOHx,
     "rHCO+"=>:xHCOII, "rO+"=>:xOII, "rSi+"=>:xSiII,
-    # --- radiative-transfer fields (six-ray / nr_radiation), when a run writes them.
-    "Er"=>:Erad, "Fr1"=>:Frad_x, "Fr2"=>:Frad_y, "Fr3"=>:Frad_z)
+    # --- radiative-transfer fields. nr_radiation: Er/Fr*. six-ray chem radiation: per-frequency
+    #     mean intensity ir_avg0..N → canonical photon groups :Np1..:Np(N+1) (RAMSES-RT convention).
+    "Er"=>:Erad, "Fr1"=>:Frad_x, "Fr2"=>:Frad_y, "Fr3"=>:Frad_z,
+    "ir_avg0"=>:Np1, "ir_avg1"=>:Np2, "ir_avg2"=>:Np3, "ir_avg3"=>:Np4,
+    "ir_avg4"=>:Np5, "ir_avg5"=>:Np6, "ir_avg6"=>:Np7, "ir_avg7"=>:Np8)
 
 _athena_rootlevel(n::Integer) = (l = round(Int, log2(n)); 2^l == n ? l :
     error("Athena++ reader: RootGridSize must be a power of two per axis; got $n."))

--- a/test/57_athena_reader_tests.jl
+++ b/test/57_athena_reader_tests.jl
@@ -130,6 +130,22 @@ end
         end
     end
 
+    @testset "six-ray RT: radiation bins → photon groups, gow17 species (code-blind)" begin
+        @test Mera._ATHENA_VARMAP["ir_avg0"] == :Np1 && Mera._ATHENA_VARMAP["ir_avg7"] == :Np8
+        @test Mera._ATHENA_VARMAP["rCO"] == :xCO && Mera._ATHENA_VARMAP["rC+"] == :xCII   # gow17 set
+        sr = joinpath(SIMULATION_PATH, "athena_sixray")     # gow17 + six-ray snapshot (24 fields)
+        if isdir(sr) && any(f -> endswith(lowercase(f), ".athdf"), readdir(sr))
+            info = getinfo(0, sr, verbose=false)
+            @test all(g -> g in info.variable_list, (:Np1, :Np8))           # 8 radiation photon groups
+            @test all(s -> s in info.variable_list, (:xH2, :xCO, :xCII))    # gow17 chemistry species
+            gas = gethydro(info, verbose=false)
+            @test all(isfinite, getvar(gas, :Np1)) && all(isfinite, getvar(gas, :xCO))
+            @test maximum(projection(gas, :Np1, res=8, center=[:bc], verbose=false, show_progress=false).maps[:Np1]) != 0
+        else
+            @test_skip "athena_sixray fixture not present (MERA_TEST_DATA/athena_sixray/)"
+        end
+    end
+
     # PART B (data-backed): a REAL Athena++ snapshot — the yt AM06 sample (Cartesian AMR MHD).
     # Download AM06.tar.gz from yt-project.org/data into MERA_TEST_DATA/athena_AM06/.
     @testset "real Athena++ snapshot — yt AM06 (data-backed)" begin


### PR DESCRIPTION
## What

Did the **six-ray RT-transport run**. Built Athena++ with **gow17 (C/O) chemistry + six-ray radiative transfer** — the HDF5 output carries the **12 gow17 species** *and* **8 per-frequency mean-intensity bins** (`ir_avg0..7`), i.e. genuine RT-transport fields.

Mera-side support:
- Map the radiation bins to **canonical photon groups**: `ir_avg0..7` → `:Np1..:Np8` (the RAMSES-RT photon-group convention).
- The gow17 species already canonicalise (#194: `rCO`→`:xCO`, `rC+`→`:xCII`, …).

All 24 fields load **code-blind** with canonical names — `getvar(:Np1)`, `getvar(:xCO)`, and `projection` of either all work. New `athena_sixray/` fixture (24-field snapshot). Tests: data-free var-map + gated load (Athena++ six-ray 6/6).

## Honest solver limitation

The public Athena++ **forward-Euler** ODE solver cannot integrate the stiff gow17 network (it exceeds the substep limit at cycle 0), so the run does **not time-evolve** — the radiation stays uniform (=G0) and abundances stay at their initial values. A full evolving PDR (attenuated radiation + chemistry) needs the **CVODE** solver (SUNDIALS): `sudo port install sundials`, then `--chem_ode_solver cvode --cvode_path /opt/local`.

**Crucially, Mera's reading of all 12 species + 8 photon-group fields is solver-independent** — the mapping/loading is done and tested; only a *prettier evolving fixture* (with attenuated radiation + a figure) is gated on CVODE. Documented in the overview.

Does not touch `CHANGELOG.md` / `CITATION.cff` / `paper/`.