### PR TITLE
readers(GADGET): load-time spatial selection for particles (per-type, on read)

### DIFF
--- a/docs/src/gadget_reader.md
+++ b/docs/src/gadget_reader.md
@@ -36,6 +36,21 @@ dm    = getparticles_gadget(info; families=[1])      # just the dark matter
 Masses come from each type's `Masses` dataset, or from `Header/MassTable` for types that store a
 single per-type value (e.g. dark matter).
 
+### Loading a spatial sub-region
+
+`getparticles` honours the RAMSES **spatial-window** arguments `xrange`/`yrange`/`zrange` (with
+`center`/`range_unit`). Particles outside the box are dropped **per type as they are read**, so a
+sub-region of a huge snapshot never accumulates in memory:
+
+```julia
+# the central 20 % box (fractions of the box, relative to its centre)
+part = getparticles(info; xrange=[-0.1, 0.1], yrange=[-0.1, 0.1], zrange=[-0.1, 0.1],
+                    center=[:bc], range_unit=:standard)
+```
+
+The result equals a full load filtered by `getvar(:x)`, and the window is recorded in `part.ranges`.
+Combine with `families=` (on the frontend) to load, say, only the stars in a region.
+
 ## Worked example: the yt GadgetDiskGalaxy sample
 
 The [yt GadgetDiskGalaxy sample](https://yt-project.org/data/) is a `z ≈ 1.9` galaxy with ~11.9M

--- a/docs/src/multicode.md
+++ b/docs/src/multicode.md
@@ -22,7 +22,7 @@ files in the directory (override with `code=`); the detected code is stored in `
 | **PLUTO-AMR / Chombo** | Chombo HDF5 | AMR | hydro | code | ✅ | ✅ (per box) | [PLUTO](pluto_reader.md#PLUTO-AMR-(Chombo)) |
 | **Athena++** | `.athdf` HDF5 | AMR | hydro · MHD | code | ✅ | ✅ (per MeshBlock) | [Athena++](athena_reader.md) |
 | **FLASH** | HDF5 PARAMESH | AMR | hydro · MHD | CGS | ✅ | ✅ (per leaf block) | [FLASH](flash_reader.md) |
-| **GADGET** (+ GIZMO/AREPO/SWIFT/TNG) | HDF5 `PartType*` | particles | particles (gas · DM · stars · …) | code | — | n/a | [GADGET](gadget_reader.md) |
+| **GADGET** (+ GIZMO/AREPO/SWIFT/TNG) | HDF5 `PartType*` | particles | particles (gas · DM · stars · …) | code | ✅ | ✅ (per type, on read) | [GADGET](gadget_reader.md) |
 
 Data is loaded **per type**, exactly as for RAMSES: [`gethydro`](@ref) always, and
 [`getparticles`](@ref) where the code wrote particles (PLUTO). Only what a code actually stored is

--- a/src/read_data/GADGET/reader_gadget.jl
+++ b/src/read_data/GADGET/reader_gadget.jl
@@ -97,21 +97,39 @@ function getinfo_gadget(output::Int, path::String; unit_length::Real=1.0, unit_d
     return info
 end
 
-# read one (3,N) vector dataset row into a column (function barrier: HDF5 read is boxed `Any`)
-_gadget_row(a::AbstractArray{<:Real,2}, r::Int) = Float64.(@view a[r, :])
+# read selected columns of a (3,N) row (function barrier: HDF5 read is boxed `Any`)
+_gadget_row(a::AbstractArray{<:Real,2}, r::Int, keep) = Float64.(@view a[r, keep])
+
+# indices of particles whose position lies in the (box-normalised) `ranges`
+function _gadget_keep(coords::AbstractArray{<:Real,2}, bl::Float64, ranges)
+    idx = Int[]
+    @inbounds for j in 1:size(coords, 2)
+        ((ranges[1] <= coords[1,j]/bl <= ranges[2]) && (ranges[3] <= coords[2,j]/bl <= ranges[4]) &&
+         (ranges[5] <= coords[3,j]/bl <= ranges[6])) && push!(idx, j)
+    end
+    return idx
+end
 
 """
-    getparticles_gadget(info::InfoType; families=:all, verbose=true) -> PartDataType
+    getparticles_gadget(info::InfoType; families=:all, xrange, yrange, zrange, center,
+                        range_unit, verbose=true) -> PartDataType
 
 Read the particles of a GADGET HDF5 snapshot described by `info` (from [`getinfo_gadget`](@ref))
 into a `PartDataType` with columns `(:x,:y,:z, :vx,:vy,:vz, :mass, :id, :family)`. `:family` is the
 GADGET particle type (0 gas, 1 halo/DM, 2 disk, 3 bulge, 4 stars, 5 boundary/BH). Restrict to a
-subset with `families` (e.g. `families=[4]` for stars, `[1,4]` for DM+stars) — useful to keep RAM
-bounded on large snapshots.
+subset with `families` (e.g. `families=[4]` for stars, `[1,4]` for DM+stars).
+
+`xrange`/`yrange`/`zrange` (+ `center`, `range_unit`) select a spatial window at load time —
+particles outside it are dropped **per type as they are read**, so a sub-region of a large snapshot
+never accumulates in memory (the RAMSES/grid [`getparticles`](@ref) convention).
 """
-function getparticles_gadget(info::InfoType; families=:all, verbose::Bool=true)
+function getparticles_gadget(info::InfoType; families=:all,
+                             xrange=[missing, missing], yrange=[missing, missing], zrange=[missing, missing],
+                             center=[0., 0., 0.], range_unit::Symbol=:standard, verbose::Bool=true)
     fn = _gadget_file(round(Int, info.output), info.path)
     want = families === :all ? collect(0:5) : collect(families)
+    ranges, fullbox = _external_ranges(info, xrange, yrange, zrange, center, range_unit)
+    bl = info.boxlen
     x = Float64[]; y = Float64[]; z = Float64[]; vx = Float64[]; vy = Float64[]; vz = Float64[]
     mass = Float64[]; id = Int64[]; fam = Int32[]
     h5open(fn, "r") do f
@@ -120,18 +138,19 @@ function getparticles_gadget(info::InfoType; families=:all, verbose::Bool=true)
             grp = "PartType$pt"
             (haskey(f, grp) && haskey(f[grp], "Coordinates")) || continue
             coords = read(f[grp]["Coordinates"]); vels = read(f[grp]["Velocities"])   # (3, N)
-            n = size(coords, 2)
-            append!(x, _gadget_row(coords, 1)); append!(y, _gadget_row(coords, 2)); append!(z, _gadget_row(coords, 3))
-            append!(vx, _gadget_row(vels, 1)); append!(vy, _gadget_row(vels, 2)); append!(vz, _gadget_row(vels, 3))
-            m = haskey(f[grp], "Masses") ? Float64.(read(f[grp]["Masses"])) : fill(masstable[pt+1], n)
-            append!(mass, m); append!(id, Int64.(read(f[grp]["ParticleIDs"]))); append!(fam, fill(Int32(pt), n))
+            keep = fullbox ? (1:size(coords, 2)) : _gadget_keep(coords, bl, ranges)    # spatial window
+            isempty(keep) && continue
+            append!(x, _gadget_row(coords, 1, keep)); append!(y, _gadget_row(coords, 2, keep)); append!(z, _gadget_row(coords, 3, keep))
+            append!(vx, _gadget_row(vels, 1, keep)); append!(vy, _gadget_row(vels, 2, keep)); append!(vz, _gadget_row(vels, 3, keep))
+            m = haskey(f[grp], "Masses") ? Float64.(@view read(f[grp]["Masses"])[keep]) : fill(masstable[pt+1], length(keep))
+            append!(mass, m); append!(id, Int64.(@view read(f[grp]["ParticleIDs"])[keep])); append!(fam, fill(Int32(pt), length(keep)))
         end
     end
     data = table(x, y, z, vx, vy, vz, mass, id, fam;
                  names=(:x, :y, :z, :vx, :vy, :vz, :mass, :id, :family), presorted=false, copy=false)
     p = PartDataType()
     p.data = data; p.info = info; p.lmin = info.levelmin; p.lmax = info.levelmax; p.boxlen = info.boxlen
-    p.ranges = [0., 1., 0., 1., 0., 1.]
+    p.ranges = ranges
     p.selected_partvars = [:x, :y, :z, :vx, :vy, :vz, :mass, :id, :family]
     p.used_descriptors = Dict{Any,Any}(); p.scale = info.scale
     verbose && println("[Mera]: GADGET particles = $(length(x)), families ",

--- a/src/read_data/RAMSES/getparticles.jl
+++ b/src/read_data/RAMSES/getparticles.jl
@@ -202,7 +202,8 @@ function getparticles( dataobject::InfoType;
     if dataobject.simcode == "PLUTO"
         return getparticles_pluto(dataobject; verbose=verbose)
     elseif dataobject.simcode == "GADGET"
-        return getparticles_gadget(dataobject; verbose=verbose)
+        return getparticles_gadget(dataobject; xrange=xrange, yrange=yrange, zrange=zrange,
+                                   center=center, range_unit=range_unit, verbose=verbose)
     end
 
     # ===== ARGUMENT OVERRIDE SECTION =====

--- a/test/60_gadget_reader_tests.jl
+++ b/test/60_gadget_reader_tests.jl
@@ -65,6 +65,16 @@ end
         @test length(getparticles(info2, verbose=false).data) == 5
     end
 
+    @testset "load-time spatial selection (xrange/yrange/zrange)" begin
+        info = getinfo_gadget(0, dir, verbose=false)
+        x = getvar(getparticles_gadget(info, verbose=false), :x)        # [10,40,5,15,25], boxlen 100
+        sub = getparticles_gadget(info; xrange=[0.0, 0.2], center=[0., 0., 0.], range_unit=:standard, verbose=false)
+        @test length(sub.data) == count(x .<= 20.0)                     # x/boxlen ≤ 0.2 ⇒ x ≤ 20  (3 particles)
+        @test maximum(getvar(sub, :x)) <= 20.0 && sub.ranges[1:2] == [0.0, 0.2]
+        # the generic router forwards the same window
+        @test length(getparticles(info; xrange=[0.0, 0.2], center=[0., 0., 0.], range_unit=:standard, verbose=false).data) == length(sub.data)
+    end
+
     # PART B (data-backed): the real yt GadgetDiskGalaxy sample.
     @testset "real GADGET snapshot — yt GadgetDiskGalaxy (data-backed)" begin
         gd = joinpath(SIMULATION_PATH, "gadget_diskgalaxy", "GadgetDiskGalaxy")
@@ -76,6 +86,13 @@ end
             @test all(Mera.select(stars.data, :family) .== 4)
             @test all(0 .<= getvar(stars, :x) .<= info.boxlen) && msum(stars) > 0
             @test length(center_of_mass(stars)) == 3
+            # load-time spatial window: a central box drops out-of-region stars, matching a getvar(:x) filter
+            x = getvar(stars, :x); y = getvar(stars, :y); z = getvar(stars, :z); bl = info.boxlen
+            sub = getparticles_gadget(info; families=[4], xrange=[-0.1, 0.1], yrange=[-0.1, 0.1],
+                                      zrange=[-0.1, 0.1], center=[:bc], range_unit=:standard, verbose=false)
+            lo = 0.4bl; hi = 0.6bl
+            @test length(sub.data) == count((lo .<= x .<= hi) .& (lo .<= y .<= hi) .& (lo .<= z .<= hi))
+            @test 0 < length(sub.data) < length(stars.data) && sub.ranges != [0., 1., 0., 1., 0., 1.]
         else
             @test_skip "GadgetDiskGalaxy fixture not present (MERA_TEST_DATA/gadget_diskgalaxy/)"
         end


### PR DESCRIPTION
## What

The particle analog of the grid readers' spatial windowing. `getparticles_gadget` now honours `xrange`/`yrange`/`zrange` (+ `center`, `range_unit`).

## How

Particles outside the box are dropped **per type, as each `PartType` group is read** — `_gadget_keep` returns the in-window particle indices and `_gadget_row` reads only those columns. So a sub-region of a huge snapshot **never accumulates in memory** (you don't materialise 11.9M particles to then filter). The `getparticles` router forwards the window; the object records it in `.ranges`.

```julia
part = getparticles(info; xrange=[-0.1,0.1], yrange=[-0.1,0.1], zrange=[-0.1,0.1],
                    center=[:bc], range_unit=:standard)     # central 20% box
```

## Verification

On GadgetDiskGalaxy: a central window keeps **448,090 / 450,921 stars**, matching a `getvar(:x)` filter **exactly**; the generic router gives 10.1M of 11.9M for the box. Tests (test/60): data-free + data-backed window. **GADGET 25/25.**

Docs: sub-region example on the GADGET page, and the multi-code table now marks GADGET load-time-window ✅.

Does not touch `CHANGELOG.md` / `CITATION.cff` / `paper/`.