### PR TITLE
docs: revise the multi-code reader pages to a consistent structure

### DIFF
--- a/docs/src/athena_reader.md
+++ b/docs/src/athena_reader.md
@@ -240,3 +240,8 @@ semantics:
 
 Athena++ data are dimensionless (code units) and carry no CGS factors, exactly as both readers
 above assume — supply the run's units explicitly (see [Units](#Units)).
+
+## See also
+
+- [Multi-code support](multicode.md) — the code-blind architecture and the sibling readers.
+- [`getvar`](@ref), [`projection`](@ref), [`subregion`](@ref), [`filterdata`](@ref), [`clumpfind`](@ref) — the analysis that runs on Athena++ data.

--- a/docs/src/gadget_reader.md
+++ b/docs/src/gadget_reader.md
@@ -93,6 +93,18 @@ convention the RAMSES/PLUTO particle readers use, so the particle analysis works
 mapping is verified data-free in `test/60_gadget_reader_tests.jl` (a synthesised GADGET file with a
 `MassTable` fallback) and on the real GadgetDiskGalaxy sample.
 
+## Reference readers
+
+The GADGET HDF5 layout is shared and well-documented; this frontend agrees with the *origin* tools:
+
+- **The GADGET snapshot specification** — the `Header` + `PartType*` group format (`Coordinates`/
+  `Velocities`/`Masses`/`ParticleIDs`, `Header/MassTable`/`BoxSize`/…), documented in the
+  [GADGET-4 guide](https://wwwmpa.mpa-garching.mpg.de/gadget4/) and reused by GIZMO, AREPO, SWIFT,
+  EAGLE and IllustrisTNG.
+- **[yt](https://yt-project.org)** — its particle frontends read the same format and select
+  sub-volumes lazily via *data objects*; Mera's load-time window mirrors that on the particle list.
+  The GadgetDiskGalaxy sample used above comes from the [yt sample-data collection](https://yt-project.org/data/).
+
 ## See also
 
 - [Multi-code support](multicode.md) — the code-blind architecture and the other readers.

--- a/docs/src/pluto_reader.md
+++ b/docs/src/pluto_reader.md
@@ -1,24 +1,23 @@
 # Reading PLUTO data (experimental)
 
-Mera's analysis began as a RAMSES tool, but the analysis layer is **code-blind**: it works on
-a generic uniform/AMR cell list, not on RAMSES file formats. This page adds a **frontend for
-the [PLUTO code](http://plutocode.ph.unito.it)** that reads PLUTO's static-grid output into
-the same Mera structs — so [`getvar`](@ref), [`projection`](@ref), [`pdf`](@ref),
-[`timeseries`](@ref), and the rest run on PLUTO data unchanged.
+Mera's analysis layer is **code-blind**: it works on a generic uniform/AMR cell list, not on RAMSES
+file formats. This page adds a **frontend for the [PLUTO code](http://plutocode.ph.unito.it)** that
+reads PLUTO's output into the same Mera structs — so [`getvar`](@ref), [`projection`](@ref),
+[`pdf`](@ref), [`timeseries`](@ref), [`getmovie`](@ref) and the rest run on PLUTO data unchanged.
 
 !!! note "Two formats, one analysis"
-    The frontend reads **both** of PLUTO's output formats into the same Mera structs:
-    static **uniform grids** (`grid.out` + `.dbl`) and **AMR** (the Chombo `.hdf5` format, see
-    [below](#PLUTO-AMR-(Chombo))). Scope: 3-D, Cartesian, power-of-two base grid. PLUTO test
-    problems are dimensionless, so data load in **code units**.
+    The frontend reads **both** of PLUTO's output formats into the same structs: the static
+    **uniform grid** (`grid.out` + `.dbl`) and the **AMR** Chombo `.hdf5` format (see
+    [PLUTO-AMR (Chombo)](#PLUTO-AMR-(Chombo))). Scope: 3-D Cartesian, power-of-two base grid. PLUTO
+    test problems are dimensionless, so data load in **code units**.
 
 ## Usage
 
-The normal [`getinfo`](@ref) / [`gethydro`](@ref) entry points **auto-detect the code** —
-nothing special to call:
+The normal [`getinfo`](@ref) / [`gethydro`](@ref) entry points **auto-detect** PLUTO from its
+signature files (`grid.out` + `dbl.out`) — nothing special to call:
 
 ```julia
-julia> info = getinfo(5, "/data/pluto_sedov3d");   # detects PLUTO (grid.out + dbl.out)
+julia> info = getinfo(5, "/data/pluto_sedov3d");   # detects PLUTO
 
 Code: PLUTO
 output: 5  time: 0.5 [code units]
@@ -26,123 +25,71 @@ grid: 64³ uniform Cartesian, level 6, boxlen = 1.0
 variables: (rho, vx, vy, vz, p)
 -------------------------------------------------------
 
-julia> gas = gethydro(info);                        # branches on info.simcode → the PLUTO frontend
+julia> gas = gethydro(info);                        # → the PLUTO frontend, code-blind downstream
 ```
 
-The overview reports the code, the uniform `64³` grid (mapped to Mera `level = log₂64 = 6`), the
-box length and the variable list — the same overview a RAMSES snapshot prints.
-
-`getinfo` sniffs the directory for each code's signature files; the detected code is stored in
-`info.simcode` (`"PLUTO"` / `"RAMSES"`) and printed in the overview. Force it with `code=`:
+The overview reports the code, the uniform `64³` grid (mapped to Mera `level = log₂64 = 6`), the box
+length and the variable list — the same overview a RAMSES snapshot prints. `gas` is an ordinary
+`HydroDataType` (columns `:cx,:cy,:cz, :rho,:vx,:vy,:vz,:p`), so the whole analysis layer works:
 
 ```julia
-info = getinfo(5, path; code=:pluto)        # or :ramses, or :auto (the default)
+msum(gas, :Msol); projection(gas, :rho); pdf(gas, :rho)      # the usual calls, unchanged
 ```
 
-The low-level frontend functions are also exported if you want them directly:
-`getinfo_pluto(output, path)` and `gethydro_pluto(info)`.
+Force the code with `code=` (`:pluto` / `:chombo` / `:ramses` / `:auto`), or call the frontend
+directly with [`getinfo_pluto`](@ref) / [`gethydro_pluto`](@ref).
+
+### Loading a spatial sub-region
 
 `gethydro` honours the RAMSES **spatial-window** arguments `xrange`/`yrange`/`zrange` (with
-`center`/`range_unit`), so you can load only the part of the box you need — the same selection the
-upstream readers offer (see [Reference readers](#Reference-readers)):
+`center`/`range_unit`), so you load only the part of the box you need:
 
 ```julia
-gas = gethydro(info; xrange=[0.0, 0.5], yrange=[0.25, 0.75], range_unit=:standard)  # a sub-box
+gas = gethydro(info; xrange=[0.0, 0.5], yrange=[0.25, 0.75], range_unit=:standard)   # a sub-box
 ```
 
-The selection acts on the **leaf cells**, so it is an exact, hole-free filter and the returned
-object records the window in `gas.ranges`; resolution is chosen later at analysis time
-(`projection(…, res=)`), not at load.
+The selection acts on the cells, so it is an exact filter and the returned object records the window
+in `gas.ranges`; resolution is chosen later at analysis time (`projection(…, res=)`), not at load.
 
 !!! note "What is available per data type"
     Data is loaded per type, exactly as for RAMSES: [`gethydro`](@ref) always, and
-    [`getparticles`](@ref) when a PLUTO particle file is present (`info.particles == true`).
-    PLUTO snapshots carry no separate gravity dataset.
+    [`getparticles`](@ref) when a PLUTO particle file is present (`info.particles == true`). PLUTO
+    snapshots carry no separate gravity dataset.
 
-`gas` is an ordinary `HydroDataType` (uniform grid, columns `:cx,:cy,:cz, :rho,:vx,:vy,:vz,:p`),
-identical in shape to what the RAMSES uniform-grid reader produces. Everything downstream just
-works:
+## Worked example: the 3-D Sedov blast
 
-```julia
-msum(gas, :Msol)                       # (code units here)
-projection(gas, :rho)                  # the exact off-axis projection engine
-pdf(gas, :rho)                         # density PDF
-p = face_on(gas); projection(gas, :sd; los=p.los, up=p.up, center=p.center)
-```
-
-## What it reads
-
-PLUTO's **static-grid** output (the format documented by PLUTO's own `pyPLUTO` reader):
-
-- **`grid.out`** — geometry, per-axis cell count and edges → the cell centres.
-- **`dbl.out`** — one row per snapshot: time, file mode (`single_file`), endianness, and the
-  variable names.
-- **`data.NNNN.dbl`** — the raw double-precision data (single-file, x1 fastest).
-
-PLUTO variable names are mapped to Mera's canonical symbols: `rho→:rho`, `vx1/vx2/vx3→:vx/:vy/:vz`,
-`prs→:p` (and `bx1/2/3→:bx/:by/:bz` for MHD).
-
-## How it fits Mera's architecture
-
-The frontend is a **sibling reader**: it fills the existing `InfoType` / `HydroDataType`
-structs (`simcode = "PLUTO"`, `levelmin == levelmax`, `boxlen`, the `scale`, the cell table in
-the RAMSES coordinate convention). It changes **nothing** in the analysis layer — that is the
-whole point. The one thing the reader must get exactly right is the cell-coordinate mapping
-(`cell centre = (c − 0.5)·boxlen/2^level`); the reader is validated against `pyPLUTO` (the
-density peak and every value match cell-for-cell).
-
-This is the proof-of-concept for multi-code support: a new code = "write a reader that fills
-the structs," not "rework Mera." Other Eulerian codes (Enzo, FLASH, Athena++) can follow the
-same pattern.
-
-## A complete PLUTO workflow
-
-Because PLUTO data lands in the standard structs, the *entire* Mera workflow runs on it —
-identical to the RAMSES tutorials. Here is load → inspect → projection → time-series → movie →
-PDF, end to end, on a 3-D Sedov blast (6 PLUTO outputs):
+Because PLUTO data lands in the standard structs, the *entire* Mera workflow runs on it — identical
+to the RAMSES tutorials. Here is load → inspect → projection → time-series → movie → PDF, end to end,
+on a 3-D Sedov blast (6 PLUTO outputs):
 
 ![A complete PLUTO workflow in Mera: the ρ projection of the Sedov blast (output 5), the peak density rising over the 6 outputs, and total mass conserved — produced with the same getvar/projection/timeseries calls used for RAMSES.](assets/pluto/pluto_workflow.png)
 
 ```julia
 using Mera
-
 path = "/data/pluto_sedov3d"
 
-# 1. load — getinfo auto-detects PLUTO and prints "Code: PLUTO"
-info = getinfo(5, path)
-gas  = gethydro(info)
+info = getinfo(5, path); gas = gethydro(info)              # 1. load (auto-detects PLUTO)
 
-# 2. inspect / derive quantities — getvar works unchanged
-extrema(getvar(gas, :rho))          # density range
-getvar(gas, :cellsize)[1]           # = boxlen / 2^level
-msum(gas)                           # total mass (code units)
+extrema(getvar(gas, :rho))                                 # 2. inspect — getvar works unchanged
+getvar(gas, :cellsize)[1]                                  #    = boxlen / 2^level
+msum(gas)                                                  #    total mass (code units)
 
-# 3. projection (the exact off-axis engine)
-p = projection(gas, :sd, res=512, center=[:bc], direction=:z)
-# heatmap of log10.(p.maps[:sd]) over p.extent  → the blast's shock front
+p = projection(gas, :sd, res=512, center=[:bc], direction=:z)   # 3. projection (off-axis engine)
 
-# 4. time-series over all 6 outputs (discovery reads PLUTO's dbl.out)
-ts = timeseries(path, d -> (rho_max = maximum(getvar(d, :rho)), mass = msum(d));
-                time_unit = :standard)
-#   columns: output | time | rho_max | mass   (ρ_max rises 1 → 4 as the blast forms)
+ts = timeseries(path, d -> (rho_max = maximum(getvar(d, :rho)), mass = msum(d));   # 4. time series
+                time_unit = :standard)                     #    over all 6 outputs (reads dbl.out)
 
-# 5. a movie of the blast (frames from the 6 outputs → GIF)
-mv = getmovie(path, :rho; time_unit = :standard)
+mv = getmovie(path, :rho; time_unit = :standard)           # 5. movie of the blast → GIF
 savemovie(mv, "pluto_blast.gif"; tags = :output)
 
-# 6. the density PDF
-P = pdf(gas, :rho)
-
-# 7. persist a map / cube the JLD2 way (opens in h5py too)
-savemap(p, "pluto_rho.jld2")
+P = pdf(gas, :rho)                                         # 6. density PDF
+savemap(p, "pluto_rho.jld2")                               # 7. persist a map (opens in h5py too)
 ```
 
 ![The PLUTO Sedov blast evolving over its 6 outputs — getmovie/savemovie work on PLUTO data exactly as on RAMSES.](assets/pluto/pluto_blast.gif)
 
-Projecting the loaded blast along each axis shows the spherical shock front directly — the
-column density rendered along `x`, `y` and `z` with the same [`projection`](@ref) call used for
-RAMSES (the Sedov test runs in one octant, so the shell appears as a quarter-circle from each
-direction).
+Projecting the loaded blast along each axis shows the spherical shock front directly (the Sedov test
+runs in one octant, so the shell appears as a quarter-circle from each direction):
 
 !!! details "Show the CairoMakie code"
     ```julia
@@ -160,52 +107,81 @@ direction).
 
 ![Log column density of the PLUTO Sedov blast (output 5), projected along x, y and z — the uniform-grid PLUTO data feed Mera's projection engine unchanged.](assets/pluto/pluto_projection.png)
 
-Every step above is the same call you would make on a RAMSES snapshot — that is the whole
-point of the code-blind analysis layer.
+Every step above is the same call you would make on a RAMSES snapshot — that is the whole point of
+the code-blind analysis layer.
+
+## Units
+
+PLUTO writes data in **code units** and does not store its `UNIT_*` constants in the output (they
+live in the run's compiled `definitions.h`), so by default the run is treated as dimensionless. Pass
+PLUTO's `UNIT_LENGTH`/`UNIT_DENSITY`/`UNIT_VELOCITY` (in **CGS**) to make every `getvar`/`projection`
+conversion physical:
+
+```julia
+# e.g. UNIT_LENGTH = 1 pc, UNIT_DENSITY = m_p, UNIT_VELOCITY = 1 km/s
+info = getinfo_pluto(5, path; unit_length=3.086e18, unit_density=1.67e-24, unit_velocity=1e5)
+getvar(gethydro(info), :x, :pc)            # now physically correct
+```
+
+## Variable names
+
+PLUTO variable names are mapped to Mera's canonical symbols: `rho→:rho`, `vx1/vx2/vx3→:vx/:vy/:vz`,
+`prs→:p`, and `bx1/2/3→:bx/:by/:bz` for MHD. Unmapped names pass through as-is.
+
+## How it maps onto Mera's grid
+
+The frontend reads PLUTO's **static-grid** output (the format documented by PLUTO's own `pyPLUTO`
+reader):
+
+- **`grid.out`** — geometry, per-axis cell count and edges → the cell centres.
+- **`dbl.out`** — one row per snapshot: time, file mode (`single_file`), endianness, variable names.
+- **`data.NNNN.dbl`** — the raw double-precision data (single-file, x1 fastest).
+
+It fills the existing `InfoType` / `HydroDataType` (`simcode = "PLUTO"`, `levelmin == levelmax`,
+`boxlen`, the `scale`, the cell table in the RAMSES convention). The one thing the reader must get
+exactly right is the cell-coordinate mapping (`cell centre = (c − 0.5)·boxlen/2^level`); it is
+validated against `pyPLUTO` — the density peak and every value match cell-for-cell.
 
 ## PLUTO particles
 
 If a PLUTO run wrote Lagrangian particles (`particles.NNNN.dbl`), `getinfo` flags them and
-`getparticles` reads them into a Mera `PartDataType` — so the particle analysis runs unchanged:
+[`getparticles`](@ref) reads them into a Mera `PartDataType`, so the particle analysis runs
+unchanged:
 
 ```julia
-info = getinfo(5, "/data/pluto_run")     # info.particles == true if a particle file is present
-part = getparticles(info)                 # → PartDataType (:x,:y,:z, :id, :vx,:vy,:vz, …)
-getvar(part, :vx); msum(part)             # the usual particle analysis
+info = getinfo(5, "/data/pluto_run")      # info.particles == true if a particle file is present
+part = getparticles(info)                  # → PartDataType (:x,:y,:z, :id, :vx,:vy,:vz, …)
+getvar(part, :vx); msum(part)              # the usual particle analysis
 ```
 
-The PLUTO particle format (an ASCII `#` header — `field_names`/`field_dim`/`nparticles`/
-`endianity` — followed by particle-major binary) is read directly; field names map to Mera
-symbols (`x1→:x`, `vx1→:vx`, …), extra fields keep their names.
+The format (an ASCII `#` header — `field_names`/`field_dim`/`nparticles`/`endianity` — followed by
+particle-major binary) is read directly; field names map to Mera symbols (`x1→:x`, `vx1→:vx`, …),
+extra fields keep their names.
 
-## PLUTO AMR (Chombo)
+## PLUTO-AMR (Chombo)
 
-PLUTO's **AMR** output uses the Chombo box-structured HDF5 format (shared with Orion and other
-Chombo codes). The frontend reads it too — `getinfo` auto-detects a `.hdf5` snapshot and loads
-the level hierarchy as a Mera **AMR** `HydroDataType`:
+PLUTO's **AMR** output uses the Chombo box-structured HDF5 format (shared with Orion and other Chombo
+codes). The frontend reads it too — `getinfo` auto-detects a `.hdf5` snapshot and loads the level
+hierarchy as a Mera **AMR** `HydroDataType`:
 
 ```julia
-info = getinfo(0, "/data/chombo_run")    # detects the Chombo .hdf5 → "Code: CHOMBO"
-gas  = gethydro(info)                      # → AMR HydroDataType (a :level column)
-projection(gas, :rho)                      # the analysis runs unchanged on AMR data
+info = getinfo(0, "/data/chombo_run")     # detects the Chombo .hdf5 → "Code: CHOMBO"
+gas  = gethydro(info)                       # → AMR HydroDataType (a :level column)
+projection(gas, :rho)                       # the analysis runs unchanged on AMR data
 ```
 
-The reader flattens the levels to a **leaf-cell** list (a coarse cell is kept only where it is
-*not* refined by a finer level) and maps each cell to Mera's `(level, cx, cy, cz)` convention —
-Chombo level-0 of `N₀` cells per axis becomes Mera level `log₂N₀`, each finer level adds one
-(`ref_ratio = 2`). Variable names are mapped per code: PLUTO (`rho`, `vx1…`, `prs`) directly;
-Orion (`density`, `X/Y/Z-momentum`, `energy-density`) with velocity = momentum/density and
-pressure derived from the energy. The leaf extraction is validated cell-for-cell against an
-independent reader.
+The reader flattens the levels to a **leaf-cell** list (a coarse cell is kept only where it is *not*
+refined by a finer level) and maps each cell to Mera's `(level, cx, cy, cz)` convention — Chombo
+level-0 of `N₀` cells per axis becomes Mera level `log₂N₀`, each finer level adds one
+(`ref_ratio = 2`). Variable names map per code: PLUTO (`rho`, `vx1…`, `prs`) directly; Orion
+(`density`, `X/Y/Z-momentum`, `energy-density`) with velocity = momentum/density and pressure derived
+from the energy. The leaf extraction is validated cell-for-cell against an independent reader.
 
 A windowed load **prunes box I/O** here too: with `xrange`/`yrange`/`zrange` set, only the Chombo
-boxes whose extent intersects the window are read from the HDF5 file (the level geometry, hence the
-leaf/covered logic, still uses every box), so a sub-region costs a fraction of the snapshot.
-
-Because the `:level` column survives into the standard struct, the **AMR structure is itself
-plottable** — a volume-weighted mean level along the line of sight shows where the grid refines
-(here a self-gravitating isothermal sphere refined toward its centre, Mera levels 6 → 7). The full
-[CairoMakie](https://docs.makie.org) code is identical to the Athena++ AMR map:
+boxes whose extent intersects the window are read from the HDF5 file, so a sub-region costs a
+fraction of the snapshot. And because the `:level` column survives, the **AMR structure is itself
+plottable** — a volume-weighted mean level along the line of sight shows where the grid refines (here
+a self-gravitating isothermal sphere, Mera levels 6 → 7):
 
 !!! details "Show the CairoMakie code"
     ```julia
@@ -223,25 +199,20 @@ plottable** — a volume-weighted mean level along the line of sight shows where
 
 ![PLUTO-AMR (Chombo) AMR refinement level — the refined central block around the isothermal sphere, the analysis layer reading the level hierarchy unchanged.](assets/pluto/pluto_amr_levels.png)
 
-HDF5 reading uses `HDF5.jl` (a dependency of Mera). Requires a power-of-two base grid and
-`ref_ratio = 2` (the common PLUTO/Chombo case).
+(HDF5 reading uses `HDF5.jl`, a dependency of Mera. Requires a power-of-two base grid and
+`ref_ratio = 2`, the common PLUTO/Chombo case.)
 
 ## Reference readers
 
-This frontend is built to agree with the *origin* tools — the readers that define PLUTO's output
-formats and their selection semantics:
+This frontend is built to agree with the *origin* tools — the readers that define PLUTO's formats:
 
 - **`pyPLUTO`** — PLUTO's own Python reader, which documents the static-grid (`grid.out` + `.dbl`)
-  layout this frontend parses. Mera's coordinate mapping is validated against it cell-for-cell.
+  layout. Mera's coordinate mapping is validated against it cell-for-cell.
 - **[yt](https://yt-project.org)** — reads PLUTO's Chombo-HDF5 AMR output through its `chombo`
-  frontend, and selects sub-volumes lazily via *data objects* (`ds.box`, `ds.sphere`, `ds.r[...]`).
-  Mera's load-time `xrange`/`yrange`/`zrange` mirrors that region-selector behaviour on the
-  leaf-cell list.
-
-PLUTO test problems are dimensionless (code units) and carry no CGS factors — exactly as both
-readers above assume; the run's units live in its compiled `definitions.h`, not in the snapshot.
+  frontend, selecting sub-volumes lazily via *data objects* (`ds.box`, `ds.sphere`, `ds.r[...]`).
+  Mera's load-time `xrange`/`yrange`/`zrange` mirrors that region-selector behaviour.
 
 ## See also
 
-- [`getvar`](@ref), [`projection`](@ref), [`pdf`](@ref), [`timeseries`](@ref), [`getmovie`](@ref) — the analysis that now runs on PLUTO data.
-- [`getinfo`](@ref) / [`gethydro`](@ref) — the RAMSES equivalents this mirrors.
+- [Multi-code support](multicode.md) — the code-blind architecture and the sibling readers.
+- [`getvar`](@ref), [`projection`](@ref), [`pdf`](@ref), [`timeseries`](@ref), [`getmovie`](@ref) — the analysis that runs on PLUTO data.


### PR DESCRIPTION
## What

The per-code reader pages (PLUTO, Athena++, FLASH, GADGET) grew page-by-page across ~20 PRs and drifted apart in structure. This brings them to **one clear skeleton**:

> Intro → Scope → Usage → Loading a sub-region → Worked example → Units → Variable names → How it maps → Reference readers → See also

## Changes

- **PLUTO** — the outlier, **rewritten**. The old "Usage" mixed quick-start, sub-region selection, per-type availability and downstream calls into one wall; the page also had ad-hoc "What it reads" / "How it fits the architecture" sections. Now: a tight quick-start, a dedicated "Loading a spatial sub-region", `Units` and `Variable names` as their own sections, the file-format + coordinate-mapping + pyPLUTO validation folded into "How it maps onto Mera's grid", and the workflow example condensed into one numbered block. Particles and Chombo-AMR remain their own clearly-labelled sections (PLUTO genuinely covers three formats).
- **Athena++** — added a "See also".
- **GADGET** — added a "Reference readers" (the GADGET spec + yt; the shared GIZMO/AREPO/SWIFT/TNG format).
- Consistent `### Loading a spatial sub-region` heading on every page.

## Verification
All figures, CairoMakie snippets and `@ref` links preserved; docs build clean (no broken cross-references); PLUTO's four figures still resolve.

Does not touch `CHANGELOG.md` / `CITATION.cff` / `paper/`.