### PR TITLE
docs: per-page "Run it yourself" notebook link on every tutorial

### DIFF
--- a/docs/src/00_multi_FirstSteps.md
+++ b/docs/src/00_multi_FirstSteps.md
@@ -1,5 +1,9 @@
 # First Steps with Mera.jl
 
+!!! tip "Run it yourself"
+    This tutorial is also an executable **Jupyter notebook** — [open / download `00_multi_FirstSteps.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/00_multi_FirstSteps.ipynb). The notebooks run end-to-end and double as part of Mera's test suite.
+
+
 This notebook introduces the essential concepts and workflow for inspecting, loading, and analyzing RAMSES simulation outputs using Mera.jl.
 
 ## Learning Objectives

--- a/docs/src/01_clumps_First_Inspection.md
+++ b/docs/src/01_clumps_First_Inspection.md
@@ -1,5 +1,9 @@
 # Clump Data: First Inspection
 
+!!! tip "Run it yourself"
+    This tutorial is also an executable **Jupyter notebook** — [open / download `01_clumps_First_Inspection.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/01_clumps_First_Inspection.ipynb). The notebooks run end-to-end and double as part of Mera's test suite.
+
+
 This notebook provides a comprehensive introduction to loading and analyzing clump structure data using Mera.jl. You'll learn the fundamentals of working with RAMSES clump data and understanding clump hierarchies and properties.
 
 ## Learning Objectives

--- a/docs/src/01_gravity_First_Inspection.md
+++ b/docs/src/01_gravity_First_Inspection.md
@@ -1,5 +1,9 @@
 # Gravity Data: First Inspection
 
+!!! tip "Run it yourself"
+    This tutorial is also an executable **Jupyter notebook** — [open / download `01_gravity_First_Inspection.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/01_gravity_First_Inspection.ipynb). The notebooks run end-to-end and double as part of Mera's test suite.
+
+
 This notebook provides a comprehensive introduction to loading and analyzing gravitational field data using Mera.jl. You'll learn the fundamentals of working with RAMSES gravity data and its relationship to AMR (Adaptive Mesh Refinement) structures.
 
 ## Learning Objectives

--- a/docs/src/01_hydro_First_Inspection.md
+++ b/docs/src/01_hydro_First_Inspection.md
@@ -1,5 +1,9 @@
 # Hydro Data: First Inspection
 
+!!! tip "Run it yourself"
+    This tutorial is also an executable **Jupyter notebook** — [open / download `01_hydro_First_Inspection.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/01_hydro_First_Inspection.ipynb). The notebooks run end-to-end and double as part of Mera's test suite.
+
+
 This notebook provides a comprehensive introduction to loading and analyzing hydrodynamic simulation data using Mera.jl. You'll learn the fundamentals of working with RAMSES hydro data and AMR (Adaptive Mesh Refinement) structures.
 
 ## Learning Objectives

--- a/docs/src/01_particles_First_Inspection.md
+++ b/docs/src/01_particles_First_Inspection.md
@@ -1,5 +1,9 @@
 # Particle Data: First Inspection
 
+!!! tip "Run it yourself"
+    This tutorial is also an executable **Jupyter notebook** — [open / download `01_particles_First_Inspection.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/01_particles_First_Inspection.ipynb). The notebooks run end-to-end and double as part of Mera's test suite.
+
+
 This notebook provides a comprehensive introduction to loading and analyzing particle simulation data using Mera.jl. You'll learn the fundamentals of working with RAMSES particle data and its relationship to AMR (Adaptive Mesh Refinement) structures.
 
 ## Learning Objectives

--- a/docs/src/02_clumps_Load_Selections.md
+++ b/docs/src/02_clumps_Load_Selections.md
@@ -1,5 +1,9 @@
 # Clump Data: Load Selected Variables and Spatial Ranges
 
+!!! tip "Run it yourself"
+    This tutorial is also an executable **Jupyter notebook** — [open / download `02_clumps_Load_Selections.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/02_clumps_Load_Selections.ipynb). The notebooks run end-to-end and double as part of Mera's test suite.
+
+
 This notebook provides a comprehensive guide to selective clump data loading and spatial filtering in Mera.jl. You'll learn advanced techniques for efficiently loading only the clump data you need from large clump-finding simulations.
 
 ## Learning Objectives

--- a/docs/src/02_gravity_Load_Selections.md
+++ b/docs/src/02_gravity_Load_Selections.md
@@ -1,5 +1,9 @@
 # Gravity Data: Load Selected Variables and Spatial Ranges
 
+!!! tip "Run it yourself"
+    This tutorial is also an executable **Jupyter notebook** — [open / download `02_gravity_Load_Selections.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/02_gravity_Load_Selections.ipynb). The notebooks run end-to-end and double as part of Mera's test suite.
+
+
 This notebook provides a comprehensive guide to selective gravitational field data loading and spatial filtering in Mera.jl. You'll learn advanced techniques for efficiently loading only the gravity data you need from large gravitational field simulations.
 
 ## Learning Objectives

--- a/docs/src/02_hydro_Load_Selections.md
+++ b/docs/src/02_hydro_Load_Selections.md
@@ -1,5 +1,9 @@
 # Hydro Data: Load Selected Variables and Spatial Ranges
 
+!!! tip "Run it yourself"
+    This tutorial is also an executable **Jupyter notebook** — [open / download `02_hydro_Load_Selections.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/02_hydro_Load_Selections.ipynb). The notebooks run end-to-end and double as part of Mera's test suite.
+
+
 This notebook provides a comprehensive guide to selective data loading and spatial filtering in Mera.jl. You'll learn advanced techniques for efficiently loading only the data you need from large hydrodynamic simulations.
 
 ## Learning Objectives

--- a/docs/src/02_particles_Load_Selections.md
+++ b/docs/src/02_particles_Load_Selections.md
@@ -1,5 +1,9 @@
 # Particle Data: Load Selected Variables and Spatial Ranges
 
+!!! tip "Run it yourself"
+    This tutorial is also an executable **Jupyter notebook** — [open / download `02_particles_Load_Selections.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/02_particles_Load_Selections.ipynb). The notebooks run end-to-end and double as part of Mera's test suite.
+
+
 This notebook provides a comprehensive guide to selective particle data loading and spatial filtering in Mera.jl. You'll learn advanced techniques for efficiently loading only the particle data you need from large N-body simulations.
 
 ## Learning Objectives

--- a/docs/src/03_clumps_Get_Subregions.md
+++ b/docs/src/03_clumps_Get_Subregions.md
@@ -1,5 +1,9 @@
 # 3. Clumps: Get Sub-Regions of The Loaded Data
 
+!!! tip "Run it yourself"
+    This tutorial is also an executable **Jupyter notebook** — [open / download `03_clumps_Get_Subregions.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/03_clumps_Get_Subregions.ipynb). The notebooks run end-to-end and double as part of Mera's test suite.
+
+
 ## Learning Objectives
 
 By the end of this tutorial, you will be able to:

--- a/docs/src/03_gravity_Get_Subregions.md
+++ b/docs/src/03_gravity_Get_Subregions.md
@@ -1,5 +1,9 @@
 # 3. Gravity: Get Sub-Regions of The Loaded Data
 
+!!! tip "Run it yourself"
+    This tutorial is also an executable **Jupyter notebook** — [open / download `03_gravity_Get_Subregions.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/03_gravity_Get_Subregions.ipynb). The notebooks run end-to-end and double as part of Mera's test suite.
+
+
 ## Load the Data
 
 ```julia

--- a/docs/src/03_hydro_Get_Subregions.md
+++ b/docs/src/03_hydro_Get_Subregions.md
@@ -1,5 +1,9 @@
 # 3. Hydro: Sub-Regions and Spatial Selections
 
+!!! tip "Run it yourself"
+    This tutorial is also an executable **Jupyter notebook** — [open / download `03_hydro_Get_Subregions.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/03_hydro_Get_Subregions.ipynb). The notebooks run end-to-end and double as part of Mera's test suite.
+
+
 ## Learning Objectives
 
 This notebook provides comprehensive coverage of spatial selection techniques for hydrodynamic simulation data analysis. You will learn to:

--- a/docs/src/03_particles_Get_Subregions.md
+++ b/docs/src/03_particles_Get_Subregions.md
@@ -1,5 +1,9 @@
 # 3. Particles: Spatial Sub-Region Selection and Analysis
 
+!!! tip "Run it yourself"
+    This tutorial is also an executable **Jupyter notebook** — [open / download `03_particles_Get_Subregions.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/03_particles_Get_Subregions.ipynb). The notebooks run end-to-end and double as part of Mera's test suite.
+
+
 This tutorial provides comprehensive guidance for selecting and analyzing spatial sub-regions from particle simulation data using Mera.jl. Learn to extract cuboid, cylindrical, spherical, and shell regions with practical visualization examples and advanced spatial filtering techniques.
 
 ## Learning Objectives

--- a/docs/src/04_multi_Basic_Calculations.md
+++ b/docs/src/04_multi_Basic_Calculations.md
@@ -1,5 +1,9 @@
 # 4. Multi-Physics Basic Calculations and Statistical Analysis
 
+!!! tip "Run it yourself"
+    This tutorial is also an executable **Jupyter notebook** — [open / download `04_multi_Basic_Calculations.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/04_multi_Basic_Calculations.ipynb). The notebooks run end-to-end and double as part of Mera's test suite.
+
+
 This comprehensive tutorial demonstrates essential computational methods for analyzing multi-physics simulation data using MERA.jl. Learn to calculate fundamental quantities, statistical measures, and derived properties across hydro, particle, and clump datasets with proper unit handling and weighting schemes.
 
 ## Learning Objectives

--- a/docs/src/05_multi_Masking_Filtering.md
+++ b/docs/src/05_multi_Masking_Filtering.md
@@ -1,5 +1,9 @@
 # Data Masking, Filtering, and Metaprogramming
 
+!!! tip "Run it yourself"
+    This tutorial is also an executable **Jupyter notebook** — [open / download `05_multi_Masking_Filtering.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/05_multi_Masking_Filtering.ipynb). The notebooks run end-to-end and double as part of Mera's test suite.
+
+
 ## Advanced Data Manipulation and Selection Techniques
 
 ### Tutorial Overview

--- a/docs/src/06_hydro_Projection.md
+++ b/docs/src/06_hydro_Projection.md
@@ -1,5 +1,9 @@
 # Hydro Data Projections
 
+!!! tip "Run it yourself"
+    This tutorial is also an executable **Jupyter notebook** — [open / download `06_hydro_Projection.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/06_hydro_Projection.ipynb). The notebooks run end-to-end and double as part of Mera's test suite.
+
+
 This tutorial demonstrates advanced projection techniques for hydrodynamical simulation data using MERA.jl. Learn how to create 2D projections from 3D data, handle different coordinate systems, and visualize complex astrophysical datasets.
 
 ## Quick Reference

--- a/docs/src/06_particles_Projection.md
+++ b/docs/src/06_particles_Projection.md
@@ -1,5 +1,9 @@
 # Particle Data Projections
 
+!!! tip "Run it yourself"
+    This tutorial is also an executable **Jupyter notebook** — [open / download `06_particles_Projection.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/06_particles_Projection.ipynb). The notebooks run end-to-end and double as part of Mera's test suite.
+
+
 This tutorial demonstrates advanced projection techniques for stellar and dark matter particle data using MERA.jl. Learn how to create 2D projections from N-body simulations, analyze stellar populations, and investigate galactic structure through particle-based analysis.
 
 ## Quick Reference

--- a/docs/src/07_multi_Mera_Files.md
+++ b/docs/src/07_multi_Mera_Files.md
@@ -1,4 +1,8 @@
 # Save/Convert/Load MERA-Files
+
+!!! tip "Run it yourself"
+    This tutorial is also an executable **Jupyter notebook** — [open / download `07_multi_Mera_Files.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/07_multi_Mera_Files.ipynb). The notebooks run end-to-end and double as part of Mera's test suite.
+
 The RAMSES simulation data is stored in JLD2 file format and can be accessed from these files. Our high-resolution galaxy simulations, run on over 5,000 cores, show that using compressed Mera files greatly decreases storage requirements and accelerates data loading compared to standard RAMSES files. Refer to the Benchmarks section.
 
 ## Quick Reference

--- a/docs/src/09_multi_Cosmology.md
+++ b/docs/src/09_multi_Cosmology.md
@@ -1,5 +1,9 @@
 # 9. Cosmological Simulations
 
+!!! tip "Run it yourself"
+    This tutorial is also an executable **Jupyter notebook** — [open / download `09_multi_Cosmology.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/09_multi_Cosmology.ipynb). The notebooks run end-to-end and double as part of Mera's test suite.
+
+
 RAMSES writes the *same* info-file fields for every run, so Mera reads them for
 both idealised and cosmological simulations. A **non-cosmological** run carries
 sentinel values (`aexp = 1`, `H0 = 1`, `omega_m = 1`, `omega_l = 0`); a

--- a/docs/src/10_multi_RadiativeTransfer.md
+++ b/docs/src/10_multi_RadiativeTransfer.md
@@ -1,5 +1,9 @@
 # 10. Radiative Transfer (RT)
 
+!!! tip "Run it yourself"
+    This tutorial is also an executable **Jupyter notebook** — [open / download `10_multi_RadiativeTransfer.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/10_multi_RadiativeTransfer.ipynb). The notebooks run end-to-end and double as part of Mera's test suite.
+
+
 RAMSES can run with **radiative transfer** (`RT=1`): on top of the gas it transports, per
 photon group `g`, a photon number density `Np`g` and the photon flux `Fx`g`/`Fy`g`/`Fz`g`
 (an **M1 moment** field, so `nvarrt = 4·nGroups`). Mera reads it with **`getrt`**, exactly

--- a/docs/src/11_multi_OffAxisProjection.md
+++ b/docs/src/11_multi_OffAxisProjection.md
@@ -1,5 +1,9 @@
 # Off-axis projection with Mera
 
+!!! tip "Run it yourself"
+    This tutorial is also an executable **Jupyter notebook** — [open / download `11_multi_OffAxisProjection.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/11_multi_OffAxisProjection.ipynb). The notebooks run end-to-end and double as part of Mera's test suite.
+
+
 Project hydro / RT / gravity / particle data along **any line of sight**, not just the box
 axes. An off-axis projection is **orthographic**: the observer is at infinity, so all sightlines
 are parallel; each cell is carried along the line of sight onto the image plane.

--- a/docs/src/12_multi_LosCubes.md
+++ b/docs/src/12_multi_LosCubes.md
@@ -1,5 +1,9 @@
 # Line-of-sight cubes, kinematics & mock observations
 
+!!! tip "Run it yourself"
+    This tutorial is also an executable **Jupyter notebook** — [open / download `12_multi_LosCubes.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/12_multi_LosCubes.ipynb). The notebooks run end-to-end and double as part of Mera's test suite.
+
+
 A projection gives **one** value per pixel (a sum or weighted average down the sightline).
 Here we go further: the **distribution** of a quantity along each sightline (a per-pixel
 spectrum), line-of-sight velocity fields, position–velocity diagrams, and beam+noise mock

--- a/docs/src/13_multi_OffAxis_Validation.md
+++ b/docs/src/13_multi_OffAxis_Validation.md
@@ -1,5 +1,9 @@
 # Off-axis projection: validation & error analysis
 
+!!! tip "Run it yourself"
+    This tutorial is also an executable **Jupyter notebook** — [open / download `13_multi_OffAxis_Validation.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/13_multi_OffAxis_Validation.ipynb). The notebooks run end-to-end and double as part of Mera's test suite.
+
+
 Two questions every projection must answer: **does it conserve** (nothing lost), and **is it
 accurate** (mass in the right place)? This notebook reproduces both, plus the parallel speed-up.
 Follows the *Conservation proof* and *binning fidelity* docs.

--- a/docs/src/14_multi_OffAxis_Features.md
+++ b/docs/src/14_multi_OffAxis_Features.md
@@ -1,5 +1,9 @@
 # Off-axis: advanced LOS features & mock observations
 
+!!! tip "Run it yourself"
+    This tutorial is also an executable **Jupyter notebook** — [open / download `14_multi_OffAxis_Features.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/14_multi_OffAxis_Features.ipynb). The notebooks run end-to-end and double as part of Mera's test suite.
+
+
 This tutorial walks through the line-of-sight analysis tools built on top of Mera's off-axis
 projection — **velocity/field dispersion (`moment2`)**, the **integrated spectrum**, **off-axis
 slices**, the **column integral**, **emission + absorption (`emission_map`)**, a telescope **beam

--- a/docs/src/15_multi_Profiles_Phase.md
+++ b/docs/src/15_multi_Profiles_Phase.md
@@ -1,5 +1,9 @@
 # Profiles & phase diagrams — a step-by-step guide
 
+!!! tip "Run it yourself"
+    This tutorial is also an executable **Jupyter notebook** — [open / download `15_multi_Profiles_Phase.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/15_multi_Profiles_Phase.ipynb). The notebooks run end-to-end and double as part of Mera's test suite.
+
+
 `profile`, `phase`, `profile3d`, `rotationcurve` and `profiletimeseries` are **general, weighted
 reductions** over any Mera field — a *profile* bins by one quantity (often a **radius**) and reports
 per-bin **statistics** of another; a *phase diagram* is a 2-D weighted histogram. They work on


### PR DESCRIPTION
First piece of the notebook pipeline. Each numbered tutorial page now links its executable Jupyter notebook (the matching file in the [Notebooks repo](https://github.com/ManuelBehrendt/Notebooks), `master`) via a consistent **"Run it yourself"** admonition under the title — **25 pages**.

The notebooks run end-to-end and double as part of Mera's test suite/coverage (`scripts/run_coverage_with_notebooks.sh` executes them via a coverage-enabled kernel), so this makes the docs↔notebook correspondence explicit and gives readers a one-click runnable version of every tutorial.

Injection is idempotent (re-runnable). Docs build clean; all 25 links resolve in the built HTML.

Does not touch `CHANGELOG.md` / `CITATION.cff` / `paper/`.