### PR TITLE
docs(nav): conservative declutter — consolidate API pages, collapse reference groups

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -26,78 +26,49 @@ makedocs(modules = [Mera],
 		pages = Any[ "Home"                  => "index.md",
 		              "First Look"             => "report.md",
 		              "Getting Started"        => "00_multi_FirstSteps.md",
-                      
+
+                      # --- Tutorials (API moved to its own top-level section, below) ---
                       "Core Workflows" => Any[
-                          "Data Inspection"     => Any[ "Hydro"       =>  "01_hydro_First_Inspection.md",
-                                                        "Gravity"     =>  "01_gravity_First_Inspection.md",
-                                                        "Particles"   =>  "01_particles_First_Inspection.md",
-                                                        "Clumps"      =>  "01_clumps_First_Inspection.md",
-                                                        "API Reference" => "api/data_inspection.md"],
-
-                          "Load by Selection"   => Any[ "Hydro"       =>  "02_hydro_Load_Selections.md",
-                                                        "Gravity"     =>  "02_gravity_Load_Selections.md",
-                                                        "Particles"   =>  "02_particles_Load_Selections.md",
-                                                        "Clumps"      =>  "02_clumps_Load_Selections.md",
-                                                        "API Reference" => "api/data_loading.md"],
-
-                          "Get Subregions"     => Any[ "Hydro"       => "03_hydro_Get_Subregions.md",
-                                                       "Gravity"     => "03_gravity_Get_Subregions.md",
-                                                       "Particles"   => "03_particles_Get_Subregions.md",
-                                                       "Clumps"      => "03_clumps_Get_Subregions.md",
-                                                       "API Reference" => "api/subregions.md"]],
+                          "Data Inspection"   => Any[ "Hydro"     => "01_hydro_First_Inspection.md",
+                                                      "Gravity"   => "01_gravity_First_Inspection.md",
+                                                      "Particles" => "01_particles_First_Inspection.md",
+                                                      "Clumps"    => "01_clumps_First_Inspection.md"],
+                          "Load by Selection" => Any[ "Hydro"     => "02_hydro_Load_Selections.md",
+                                                      "Gravity"   => "02_gravity_Load_Selections.md",
+                                                      "Particles" => "02_particles_Load_Selections.md",
+                                                      "Clumps"    => "02_clumps_Load_Selections.md"],
+                          "Get Subregions"    => Any[ "Hydro"     => "03_hydro_Get_Subregions.md",
+                                                      "Gravity"   => "03_gravity_Get_Subregions.md",
+                                                      "Particles" => "03_particles_Get_Subregions.md",
+                                                      "Clumps"    => "03_clumps_Get_Subregions.md"]],
 
                       "Analysis & Calculations" => Any[
-                          "Basic Calculations"  => Any[ "Tutorial"    => "04_multi_Basic_Calculations.md",
-                                                        "API Reference" => "api/calculations.md"],
-
+                          "Basic Calculations"  => "04_multi_Basic_Calculations.md",
                           "Derived Fields & add_field" => "derived_fields.md",
-
                           "How Quantities Are Computed" => "computation_reference.md",
-
                           "Magnetic Fields (MHD)" => "magnetic_fields.md",
-
                           "Clump Finding"       => "clumpfind.md",
-
                           "Clump Finding — Synthetic Example" => "clumpfind_synthetic.md",
-
                           "Covering Grid / FRB" => "covering_grid.md",
-
                           "Flux Budgets"        => "fluxbudget.md",
-
                           "Star-Formation Rate" => "sfr.md",
-
                           "Time Series (multi-snapshot)" => "timeseries.md",
-
                           "Movies (getmovie)"   => "movie.md",
-
                           "Auto-Frame (center & orient)" => "galaxyframe.md",
-
                           "Mock Observations (cookbook)" => "mock_observations.md",
-
                           "Statistics (PDFs)"    => "statistics.md",
-
                           "Provenance"           => "provenance.md",
-
                           "Grid Overlay & Absorption" => "overlay_absorption.md",
-
-                          "Mask/Filter/Meta"    => Any[ "Tutorial"    => "05_multi_Masking_Filtering.md",
-                                                        "API Reference" => "api/masking_filtering.md"],
-
-                          "Profiles & Phase Diagrams" => Any[
-                                                        "Tutorial"    => "15_multi_Profiles_Phase.md",
-                                                        "API Reference" => "profiles_phase.md"],
-
+                          "Mask/Filter/Meta"    => "05_multi_Masking_Filtering.md",
+                          "Profiles & Phase Diagrams" => "15_multi_Profiles_Phase.md",
                           "Cosmological Runs"   => "09_multi_Cosmology.md",
-
                           "Radiative Transfer"  => "10_multi_RadiativeTransfer.md"],
 
                       "Projection" => Any[
-                          "Axis-aligned (x/y/z)" => Any[ "Hydro"       =>  "06_hydro_Projection.md",
-                                                         "Particles"   =>  "06_particles_Projection.md",
-                                                         "API Reference" => "api/projections.md"],
+                          "Axis-aligned (x/y/z)" => Any[ "Hydro"     => "06_hydro_Projection.md",
+                                                         "Particles" => "06_particles_Projection.md"],
                           "Off-axis"             => Any[ "Guide"              => "06_offaxis_Projection.md",
                                                          "Conservation Proof" => "offaxis_conservation_proof.md",
-                                                         "API Reference"      => "api/offaxis.md",
                                                          "Notebooks"          => Any[
                                                              "Projection basics"       => "11_multi_OffAxisProjection.md",
                                                              "LOS cubes & kinematics"  => "12_multi_LosCubes.md",
@@ -105,55 +76,58 @@ makedocs(modules = [Mera],
                                                              "Advanced LOS features"   => "14_multi_OffAxis_Features.md"]]],
 
                       "Data & Visualization" => Any[
-                          "MERA-Files"          => Any[ "Mera-Files"   =>  "07_multi_Mera_Files.md",
-                                                        "Converter"    =>  "07_1_multi_Mera_Files_Converter.md",
-                                                        "API Reference" => "api/mera_files.md"],
-
+                          "MERA-Files"          => Any[ "Mera-Files" => "07_multi_Mera_Files.md",
+                                                        "Converter"  => "07_1_multi_Mera_Files_Converter.md"],
                           "Other Simulation Codes" => Any[ "Overview" => "multicode.md",
                                                            "PLUTO"    => "pluto_reader.md",
                                                            "Athena++" => "athena_reader.md",
                                                            "FLASH"    => "flash_reader.md",
                                                            "GADGET"   => "gadget_reader.md"],
+                          "Volume Rendering"    => Any[ "Intro"     => "paraview/paraview_intro.md",
+                                                        "Hydro"     => "paraview/08_hydro_VTK_export.md",
+                                                        "Particles" => "paraview/08_particles_VTK_export.md"]],
 
-                          "Volume Rendering"    => Any[ "Intro"      =>  "paraview/paraview_intro.md",
-                                                        "Hydro"      =>  "paraview/08_hydro_VTK_export.md",
-                                                        "Particles"  =>  "paraview/08_particles_VTK_export.md",
-                                                        "API Reference" => "api/volume_rendering.md"]],
+                      # --- one home for all the formerly-scattered per-topic API pages ---
+                      "API Reference" => Any[
+                          "Data Inspection"     => "api/data_inspection.md",
+                          "Data Loading"        => "api/data_loading.md",
+                          "Subregions"          => "api/subregions.md",
+                          "Calculations"        => "api/calculations.md",
+                          "Masking & Filtering" => "api/masking_filtering.md",
+                          "Profiles & Phase"    => "profiles_phase.md",
+                          "Projections"         => "api/projections.md",
+                          "Off-axis Projection" => "api/offaxis.md",
+                          "Mera-Files"          => "api/mera_files.md",
+                          "Volume Rendering"    => "api/volume_rendering.md",
+                          "Multi-Threading"     => "api/multithreading.md",
+                          "Notifications"       => "api/notifications.md",
+                          "Complete API"        => "api.md"],
 
-                      "Advanced Features" => Any[
-                          "Bundling Arguments (myargs)" => "bundled_arguments.md",
-
-                          "Verbose & Progress Switches" => "verbose_progress_switches.md",
-
-                          "Multi-Threading"     => Any[ "Tutorial"    => "multi-threading/multi-threading_intro.md",
-                                                        "API Reference" => "api/multithreading.md"],
-
-                          "Testing Framework"   => "advanced_features/testing_guide.md",
-
-                          "Notifications"       => Any["Overview"        => "notifications/index.md",
-                                                        "Setup & Usage"   => "notifications/setup_and_usage.md",
-                                                        "Examples"        => "notifications/examples.md",
-                                                        "API Reference"   => "api/notifications.md"],
-
-                          "Benchmarks"          => Any["Server IO"                      => "benchmarks/IO/IOperformance.md",
-                                                       "Parallel RAMSES-Files Reading"      => "benchmarks/RAMSES_reading/ramses_reading.md",
-                                                       "Mera-Files Reading"                 => "benchmarks/JLD2_reading/Mera_files_reading.md",
-                                                       "Projections"                        => "benchmarks/Projection/multi_projections.md"]],
-
-                      "Quick Reference" => Any["Getting Started"           => "quickreference/01_getting_started.md",
-                                                     "From Other Languages"      => "quickreference/02_migrators.md",
-                                                     "Essential Packages"        => "quickreference/03_packages.md",
-                                                     "Julia Fundamentals"        => "quickreference/04_mera_patterns.md",
-                                                     "Performance & Debugging"   => "quickreference/05_performance.md",
-                                                     "Resources & Community"     => "quickreference/06_resources.md",
-                                                     "Julia Cheat Sheet (all-in-one)" => "quickreference/Julia_Quick_Reference.md",
-                                                     "Mera Function Reference"        => "quickreference/Mera_Quick_Reference.md"],
-
-                      "Examples & Reference" => Any[
-                          "Examples"            => "examples.md",
-                          "Miscellaneous"       => "Miscellaneous.md",
-                          "Recommended Packages" => "recommended_packages.md",
-                          "Complete API Reference" => "api.md"]
+                      # --- advanced / reference material, collapsed under one group ---
+                      "More" => Any[
+                          "Advanced Features" => Any[
+                              "Bundling Arguments (myargs)" => "bundled_arguments.md",
+                              "Verbose & Progress Switches" => "verbose_progress_switches.md",
+                              "Multi-Threading"     => "multi-threading/multi-threading_intro.md",
+                              "Testing Framework"   => "advanced_features/testing_guide.md",
+                              "Notifications"       => Any[ "Overview"      => "notifications/index.md",
+                                                            "Setup & Usage" => "notifications/setup_and_usage.md",
+                                                            "Examples"      => "notifications/examples.md"]],
+                          "Benchmarks" => Any[ "Server IO"                     => "benchmarks/IO/IOperformance.md",
+                                               "Parallel RAMSES-Files Reading" => "benchmarks/RAMSES_reading/ramses_reading.md",
+                                               "Mera-Files Reading"            => "benchmarks/JLD2_reading/Mera_files_reading.md",
+                                               "Projections"                   => "benchmarks/Projection/multi_projections.md"],
+                          "Quick Reference" => Any[ "Getting Started"         => "quickreference/01_getting_started.md",
+                                                    "From Other Languages"    => "quickreference/02_migrators.md",
+                                                    "Essential Packages"      => "quickreference/03_packages.md",
+                                                    "Julia Fundamentals"      => "quickreference/04_mera_patterns.md",
+                                                    "Performance & Debugging" => "quickreference/05_performance.md",
+                                                    "Resources & Community"   => "quickreference/06_resources.md",
+                                                    "Julia Cheat Sheet (all-in-one)" => "quickreference/Julia_Quick_Reference.md",
+                                                    "Mera Function Reference" => "quickreference/Mera_Quick_Reference.md"],
+                          "Examples & Misc" => Any[ "Examples"             => "examples.md",
+                                                    "Miscellaneous"        => "Miscellaneous.md",
+                                                    "Recommended Packages" => "recommended_packages.md"]]
                     ]
 )
 


### PR DESCRIPTION
The sidebar had **~12 "API Reference" leaf pages** scattered one-per-group, plus several top-level reference/dev groups. Conservative tidy — **no tutorial page moves**:

- All per-topic API pages + the full `api.md` now live in **one top-level `API Reference`** section.
- Single-item tutorial wrappers flattened to direct entries (Basic Calculations, Mask/Filter/Meta, Profiles & Phase) — pages stay put.
- `Advanced Features` / `Benchmarks` / `Quick Reference` / `Examples & Misc` tucked under one collapsed **`More`** group.

Top level goes from ~10 groups to **6** (+ Home / First Look / Getting Started). Every page is still referenced exactly once; docs build clean (no missing/duplicate pages).