### PR TITLE
docs: link the runnable multi-code notebook from the overview

### DIFF
--- a/docs/src/multicode.md
+++ b/docs/src/multicode.md
@@ -1,5 +1,12 @@
 # Multi-code support
 
+!!! tip "Run it yourself"
+    All of the readers below are exercised in one executable **Jupyter notebook** —
+    [open / download `16_multi_OtherCodes.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/16_multi_OtherCodes.ipynb).
+    It loads PLUTO / Chombo / Athena++ / FLASH / GADGET, shows MHD / gravity / chemistry / RT
+    fields, a load-time sub-region, and a save/load round-trip — and runs end-to-end as part of
+    Mera's test suite.
+
 Mera began as a RAMSES tool, but its analysis layer is **code-blind**: every quantity
 ([`getvar`](@ref)), map ([`projection`](@ref)), region ([`subregion`](@ref)), filter
 ([`filterdata`](@ref)), profile, PDF, time-series and clump finder works on a *generic* uniform/AMR


### PR DESCRIPTION
New executable notebook **`16_multi_OtherCodes.ipynb`** (authored in the [Notebooks repo](https://github.com/ManuelBehrendt/Notebooks)) loads **PLUTO / Chombo / Athena++ / FLASH / GADGET** and shows MHD / gravity / chemistry / RT fields, a load-time sub-region, and a save/load round-trip — all the new readers in one place.

It **runs end-to-end** (verified by executing every code cell against the fixtures), and since the tutorial notebooks drive coverage (`run_coverage_with_notebooks.sh`), it closes the notebook-coverage gap for the reader code. Linked via a "Run it yourself" admonition on the multi-code overview page.

Docs build clean; the notebook link resolves. (The `.ipynb` itself lives in the separate Notebooks repo, to be committed there.)