### PR TITLE
coverage: add notebooks 09-16 to the suite + self-heal Mera dev path

### DIFF
--- a/scripts/run_coverage_with_notebooks.sh
+++ b/scripts/run_coverage_with_notebooks.sh
@@ -50,6 +50,17 @@ JULIA_NUM_THREADS=4 $JULIA --project=. --color=yes \
 echo ">>> [2/3] Tutorial notebooks with coverage (kernel: $COV_KERNEL)"
 # Executed copies are written under $NOTEBOOK_DIR/executed (gitignored there).
 cd "$NOTEBOOK_DIR"
+
+# Self-heal the precondition (line 19): the notebooks env must dev Mera from THIS
+# repo, else the cov kernel tracks a stale checkout and coverage is silently wrong.
+echo ">>> Ensuring notebooks env devs Mera from $REPO_ROOT"
+$JULIA --project=. -e "using Pkg
+  src = get(Dict(p.name => p.source for (_, p) in Pkg.dependencies()), \"Mera\", nothing)
+  if src === nothing || abspath(src) != abspath(\"$REPO_ROOT\")
+      @info \"re-deving Mera\" from=src to=\"$REPO_ROOT\"; Pkg.develop(path=\"$REPO_ROOT\")
+  else
+      @info \"Mera already dev'd from this repo\" src
+  end"
 mkdir -p executed/examples executed/paraview
 run_nb () {  # $1 = notebook path w/o .ipynb, $2 = output subdir
     local nb="$1" outdir="$2"
@@ -72,7 +83,14 @@ TOP_NBS=(
   04_multi_Basic_Calculations 05_multi_Masking_Filtering
   06_hydro_Projection 06_particles_Projection
   07_multi_Mera_Files
+  09_multi_Cosmology 10_multi_RadiativeTransfer
+  11_multi_OffAxisProjection 12_multi_LosCubes
+  13_multi_OffAxis_Validation 14_multi_OffAxis_Features
+  15_multi_Profiles_Phase
+  16_multi_OtherCodes
 )
+# Note: 11_caligo_OpticalDepth is intentionally excluded — it belongs to a
+# separate package (getcaligo), not Mera, and is not part of this coverage suite.
 for nb in "${TOP_NBS[@]}"; do
     [ -s "$nb.ipynb" ] && run_nb "$nb" "" || echo "    -- skip (missing/empty): $nb"
 done


### PR DESCRIPTION
Two gaps found while refreshing the tutorial notebooks for the release:

**1. Half the notebooks were missing from the coverage run.** `run_coverage_with_notebooks.sh` only executed `00`–`07`; notebooks `09`–`16` (cosmology, radiative transfer, off-axis projection, LOS cubes, off-axis validation/features, profiles & phase, and the new **multi-code readers** notebook) were never run, so their code paths were absent from the notebook-driven coverage. A smoke run of **all 27 notebooks** against current Mera confirms these eight execute clean, so they are now in the suite. `11_caligo_OpticalDepth` stays excluded (it calls `getcaligo` from a separate package, not Mera).

**2. The Mera dev-path could silently drift.** The notebook phase documented the precondition "Mera dev'd from this repo" but nothing enforced it — the env had in fact drifted to a stale checkout missing recent work. Added a self-heal step that re-devs Mera from this repo before the notebooks run, so the coverage kernel can never track the wrong source again.

Also fixed two genuine notebook bugs surfaced by the smoke run (truncated `println`s in `03_hydro`/`03_particles` Get_Subregions) — those live in the Notebooks repo and are committed there separately.