### PR TITLE
docs: 17 feature pages get runnable, coverage-driving notebooks

### DIFF
--- a/docs/src/06_offaxis_Projection.md
+++ b/docs/src/06_offaxis_Projection.md
@@ -1,5 +1,8 @@
 # Off-axis Projection
 
+!!! tip "Run it yourself"
+    This page is also an executable **Jupyter notebook** — [open / download `06_offaxis_Projection.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/06_offaxis_Projection.ipynb). The notebooks run end-to-end and double as part of Mera's test suite.
+
 !!! tip "New to off-axis projection?"
     Start with the runnable walk-through — [Projection basics](11_multi_OffAxisProjection.md) —
     then come back here for the reference details. The notebook series is: basics →

--- a/docs/src/07_1_multi_Mera_Files_Converter.md
+++ b/docs/src/07_1_multi_Mera_Files_Converter.md
@@ -1,5 +1,8 @@
 # MERA/JLD2 File Converter - Multithreaded
 
+!!! tip "Run it yourself"
+    This page is also an executable **Jupyter notebook** — [open / download `07_1_multi_Mera_Files_Converter.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/07_1_multi_Mera_Files_Converter.ipynb). The notebooks run end-to-end and double as part of Mera's test suite.
+
 ## Overview
 
 `batch_convert_mera` is a safe, multithreaded tool to **re-save older Mera.jl data files in the

--- a/docs/src/clumpfind.md
+++ b/docs/src/clumpfind.md
@@ -1,5 +1,8 @@
 # Clump Finding
 
+!!! tip "Run it yourself"
+    This page is also an executable **Jupyter notebook** — [open / download `clumpfind.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/clumpfind.ipynb). The notebooks run end-to-end and double as part of Mera's test suite.
+
 `clumpfind` locates **connected over-dense structures** and returns a per-clump catalog. It works
 two ways:
 

--- a/docs/src/clumpfind_synthetic.md
+++ b/docs/src/clumpfind_synthetic.md
@@ -1,5 +1,8 @@
 # Clump Finding — a synthetic, ground-truth example
 
+!!! tip "Run it yourself"
+    This page is also an executable **Jupyter notebook** — [open / download `clumpfind_synthetic.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/clumpfind_synthetic.ipynb). The notebooks run end-to-end and double as part of Mera's test suite.
+
 This page is a self-contained, **data-free** worked example for the structure finder
 ([`clumpfind`](@ref)). It builds a small Mera simulation *from scratch* — a real
 `HydroDataType` + `PartDataType` on a self-consistent unit system, no RAMSES files — whose

--- a/docs/src/covering_grid.md
+++ b/docs/src/covering_grid.md
@@ -1,5 +1,8 @@
 # Covering Grid / Fixed-Resolution Buffer
 
+!!! tip "Run it yourself"
+    This page is also an executable **Jupyter notebook** — [open / download `covering_grid.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/covering_grid.ipynb). The notebooks run end-to-end and double as part of Mera's test suite.
+
 [`covering_grid`](@ref) resamples the sparse AMR leaf cells onto a **dense, uniform `Nx×Ny×Nz`
 array** at a chosen refinement level — every output cell sampled, *not* integrated (unlike
 [`projection`](@ref), which sums along a line of sight). [`slice`](@ref) is the 2-D, single-cell-thick

--- a/docs/src/derived_fields.md
+++ b/docs/src/derived_fields.md
@@ -1,5 +1,8 @@
 # Derived Fields & `add_field`
 
+!!! tip "Run it yourself"
+    This page is also an executable **Jupyter notebook** — [open / download `derived_fields.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/derived_fields.ipynb). The notebooks run end-to-end and double as part of Mera's test suite.
+
 Mera computes a large catalogue of **derived quantities** on demand through
 [`getvar`](@ref) — temperature, sound speed, Mach number, cylindrical/spherical velocities,
 specific angular momentum, Jeans length, kinetic/thermal energy, and many more. You ask for

--- a/docs/src/fluxbudget.md
+++ b/docs/src/fluxbudget.md
@@ -1,5 +1,8 @@
 # Flux Budgets (inflow / outflow)
 
+!!! tip "Run it yourself"
+    This page is also an executable **Jupyter notebook** — [open / download `fluxbudget.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/fluxbudget.ipynb). The notebooks run end-to-end and double as part of Mera's test suite.
+
 [`fluxbudget`](@ref) measures the **flux of mass, momentum, energy and metals through a surface**
 (a sphere at radius R, or a cylinder wall), with the surface-normal velocity split into separate
 **inflow** and **outflow** rates — the thin-shell estimator that galactic-feedback and gas-cycle

--- a/docs/src/galaxyframe.md
+++ b/docs/src/galaxyframe.md
@@ -1,5 +1,8 @@
 # Auto-Frame: centering & orientation
 
+!!! tip "Run it yourself"
+    This page is also an executable **Jupyter notebook** — [open / download `galaxyframe.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/galaxyframe.ipynb). The notebooks run end-to-end and double as part of Mera's test suite.
+
 "Find the centre, then rotate to face-on / edge-on" is a ritual every disk-galaxy analysis
 repeats by hand. [`center_of`](@ref) and [`face_on`](@ref) / [`edge_on`](@ref) do it from
 the data: the centre from the mass distribution, the orientation from the **gas angular

--- a/docs/src/magnetic_fields.md
+++ b/docs/src/magnetic_fields.md
@@ -1,5 +1,8 @@
 # Magnetic Fields (MHD)
 
+!!! tip "Run it yourself"
+    This page is also an executable **Jupyter notebook** — [open / download `magnetic_fields.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/magnetic_fields.ipynb). The notebooks run end-to-end and double as part of Mera's test suite.
+
 Mera reads **RAMSES MHD** (ideal magnetohydrodynamics) outputs and exposes the magnetic field for
 analysis. RAMSES evolves **B** with a *constrained-transport* scheme, so the field is stored as the
 **six face-centred components** `B_{x,y,z}_left` and `B_{x,y,z}_right` in the ordinary hydro files

--- a/docs/src/mock_observations.md
+++ b/docs/src/mock_observations.md
@@ -1,5 +1,8 @@
 # Mock Observations (cookbook)
 
+!!! tip "Run it yourself"
+    This page is also an executable **Jupyter notebook** — [open / download `mock_observations.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/mock_observations.ipynb). The notebooks run end-to-end and double as part of Mera's test suite.
+
 Mera ships a full mock-observation toolkit — beam/PSF convolution, velocity cubes and moment
 maps, position–velocity diagrams, spectra, emission maps, and FITS export. This page ties
 them together with the [auto-frame](galaxyframe.md): orient the galaxy **once**, then reuse

--- a/docs/src/movie.md
+++ b/docs/src/movie.md
@@ -1,5 +1,8 @@
 # Movies (`getmovie` / `savemovie`)
 
+!!! tip "Run it yourself"
+    This page is also an executable **Jupyter notebook** — [open / download `movie.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/movie.ipynb). The notebooks run end-to-end and double as part of Mera's test suite.
+
 [`getmovie`](@ref) projects a quantity for **every output** of a simulation and collects the
 maps into the frames of a movie; [`savemovie`](@ref) writes them to an animated GIF. It
 builds on the same machinery as [`timeseries`](@ref) (one snapshot resident at a time,

--- a/docs/src/offaxis_conservation_proof.md
+++ b/docs/src/offaxis_conservation_proof.md
@@ -1,5 +1,8 @@
 # Off-axis Conservation Proof
 
+!!! tip "Run it yourself"
+    This page is also an executable **Jupyter notebook** — [open / download `offaxis_conservation_proof.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/offaxis_conservation_proof.ipynb). The notebooks run end-to-end and double as part of Mera's test suite.
+
 A projection only changes the **viewing geometry** of the data — it must not change the
 physical content. For an *extensive* quantity (one whose pixel values sum to a physical
 total, e.g. mass) the sum over the projected map must equal the geometry-independent ground

--- a/docs/src/overlay_absorption.md
+++ b/docs/src/overlay_absorption.md
@@ -1,5 +1,8 @@
 # AMR Grid Overlay & Absorption
 
+!!! tip "Run it yourself"
+    This page is also an executable **Jupyter notebook** — [open / download `overlay_absorption.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/overlay_absorption.ipynb). The notebooks run end-to-end and double as part of Mera's test suite.
+
 Two analysis additions inspired by features in PLUTO's `pyPLUTO` and `yt`: drawing the AMR
 grid structure over a map, and a line-of-sight **absorption** (optical-depth / transmission)
 map.

--- a/docs/src/provenance.md
+++ b/docs/src/provenance.md
@@ -1,5 +1,8 @@
 # Provenance (reproducibility)
 
+!!! tip "Run it yourself"
+    This page is also an executable **Jupyter notebook** — [open / download `provenance.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/provenance.ipynb). The notebooks run end-to-end and double as part of Mera's test suite.
+
 Six months after you make a figure, the question is always the same: *which snapshot, which
 Mera version, what units produced this?* [`provenance`](@ref) answers it. It reads the
 metadata every Mera result already carries (its `InfoType`) and returns a compact,

--- a/docs/src/sfr.md
+++ b/docs/src/sfr.md
@@ -1,5 +1,8 @@
 # Star-Formation Rate
 
+!!! tip "Run it yourself"
+    This page is also an executable **Jupyter notebook** — [open / download `sfr.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/sfr.ipynb). The notebooks run end-to-end and double as part of Mera's test suite.
+
 Mera measures star formation directly from the star particles, in two complementary ways:
 
 * [`sfr`](@ref) — the **star-formation history** SFR(t): stellar mass formed per time bin, in M⊙/yr.

--- a/docs/src/statistics.md
+++ b/docs/src/statistics.md
@@ -1,5 +1,8 @@
 # Statistics: PDFs
 
+!!! tip "Run it yourself"
+    This page is also an executable **Jupyter notebook** — [open / download `statistics.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/statistics.ipynb). The notebooks run end-to-end and double as part of Mera's test suite.
+
 [`pdf`](@ref) computes the **probability distribution function** of any [`getvar`](@ref)
 quantity over the cells (or particles) of a snapshot. The canonical use is the **density
 PDF** — the log-normal core (with a power-law high-density tail) that supersonic turbulence

--- a/docs/src/timeseries.md
+++ b/docs/src/timeseries.md
@@ -1,5 +1,8 @@
 # Time Series (multi-snapshot analysis)
 
+!!! tip "Run it yourself"
+    This page is also an executable **Jupyter notebook** — [open / download `timeseries.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/timeseries.ipynb). The notebooks run end-to-end and double as part of Mera's test suite.
+
 Most post-processing is not about one snapshot — it is about *evolution*: how a mass, a
 peak density, a star-formation rate, or a profile changes across the outputs of a run.
 Writing that loop by hand (find the outputs, load each one, handle a missing snapshot,

--- a/scripts/run_coverage_with_notebooks.sh
+++ b/scripts/run_coverage_with_notebooks.sh
@@ -91,7 +91,19 @@ TOP_NBS=(
 )
 # Note: 11_caligo_OpticalDepth is intentionally excluded — it belongs to a
 # separate package (getcaligo), not Mera, and is not part of this coverage suite.
-for nb in "${TOP_NBS[@]}"; do
+
+# Feature notebooks: one runnable .ipynb per analysis-feature doc page (named to match
+# the docs/src/<page>.md basename). Each was execution-verified against the fixtures.
+# clumpfind caps lmax/window so its finders run in ~100s (not the whole lmax=14 galaxy).
+FEATURE_NBS=(
+  magnetic_fields derived_fields statistics sfr fluxbudget
+  covering_grid galaxyframe mock_observations overlay_absorption
+  clumpfind clumpfind_synthetic provenance
+  timeseries movie 07_1_multi_Mera_Files_Converter
+  06_offaxis_Projection offaxis_conservation_proof
+)
+
+for nb in "${TOP_NBS[@]}" "${FEATURE_NBS[@]}"; do
     [ -s "$nb.ipynb" ] && run_nb "$nb" "" || echo "    -- skip (missing/empty): $nb"
 done
 for nb in examples/ExportImportData examples/LoadFromExistingOutputs examples/Miscellaneous; do


### PR DESCRIPTION
Closes the notebook gap for the **analysis-feature** doc pages. Previously only the numbered tutorials (`00`–`16`) had runnable notebooks; the feature/how-to pages had code blocks but nothing executable.

Now every such page has an executable companion `.ipynb` (named to match the page basename), authored against real test-data fixtures and written to **surface function printouts on screen**:

`magnetic_fields`, `derived_fields`, `statistics`, `sfr`, `fluxbudget`, `covering_grid`, `galaxyframe`, `mock_observations`, `overlay_absorption`, `clumpfind`, `clumpfind_synthetic`, `provenance`, `timeseries`, `movie`, `07_1…Converter`, `06_offaxis_Projection`, `offaxis_conservation_proof`.

**All 17 execution-verified end-to-end** against the fixtures via a watchdog batch run (each notebook capped so no runaway can hang the run), and added to `run_coverage_with_notebooks.sh` so they also drive coverage. Each `.md` page gets a "Run it yourself" link.

Fixes worth noting:
- `clumpfind` caps `lmax=10` + windows the load → its finder passes run in **~100 s** instead of **2+ hours** on the full `lmax=14` galaxy.
- `fluxbudget`/`overlay_absorption` avoid the `:metals` path (`mw_L10` has no metallicity column).
- `covering_grid`/`mock_observations` floor `log10` of non-positive (interpolation/noise) pixels.

The `.ipynb` files live in the separate Notebooks repo and are committed there.