### PR TITLE
docs(nav): promote LOS Cubes & Kinematics to a visible Projection & Maps entry

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -78,9 +78,11 @@ makedocs(modules = [Mera],
                                                          "Conservation Proof" => "offaxis_conservation_proof.md",
                                                          "Notebooks"          => Any[
                                                              "Projection basics"       => "11_multi_OffAxisProjection.md",
-                                                             "LOS cubes & kinematics"  => "12_multi_LosCubes.md",
                                                              "Validation & accuracy"   => "13_multi_OffAxis_Validation.md",
                                                              "Advanced LOS features"   => "14_multi_OffAxis_Features.md"]],
+                          # LOS / position-velocity cubes are a headline capability — promoted out
+                          # of the off-axis notebook bundle to a visible entry of its own.
+                          "LOS Cubes & Kinematics"       => "12_multi_LosCubes.md",
                           "Grid Overlay & Absorption"    => "overlay_absorption.md",
                           "Mock Observations (cookbook)" => "mock_observations.md"],
 


### PR DESCRIPTION
PPV / line-of-sight cubes were buried 4 levels deep (Projection & Maps → Off-axis → Notebooks → "LOS cubes & kinematics"), despite being a headline capability. Promoted to a direct, visible **"LOS Cubes & Kinematics"** entry under **Projection & Maps**, beside Mock Observations (both produce observable data products). The off-axis Notebooks bundle retains basics / validation / advanced. No pages added or removed.