### PR TITLE
ci: drop redundant docs/deploy job from CI.yml (fixes gh-pages push race)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,21 +43,8 @@ jobs:
           MERA_SMOKE_ONLY: "1"
         run: julia --project -e 'using Pkg; Pkg.test("Mera")'
 
-  docs:
-    name: Documentation
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: '1'
-      - run: |
-          julia --project=docs -e '
-            using Pkg
-            Pkg.develop(PackageSpec(path=pwd()))
-            Pkg.instantiate()
-          '
-      - run: julia --project=docs docs/make.jl
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
+# Docs are built + deployed by the dedicated `documentation.yml` workflow
+# (which has `permissions: contents: write`, and builds on PRs too). A second
+# docs/deploy job here raced it to push gh-pages — whichever lost got a
+# non-fast-forward rejection, so master pushes failed intermittently. Removed
+# to leave a single deployer.


### PR DESCRIPTION
The intermittent red on master push was **not** from the doc-content changes — it was a **double-deploy race**.

`CI.yml` had a `Documentation` job that ran `deploydocs` → `git push … gh-pages`, duplicating the dedicated `documentation.yml` workflow. Both fired on every master push and raced to push the same branch; the loser got a non-fast-forward rejection and failed — which is why the two workflows *alternated* red across recent merges. `CI.yml`’s job also lacked `permissions: contents: write`, so its push could not authenticate even when it won the race.

Fix: remove the docs job from `CI.yml`. `documentation.yml` (which has the write permission and runs on PRs too) stays as the single docs build+deploy. `CI.yml` now runs only the smoke-test matrix (Julia 1.10/1.11/1.12 × ubuntu/macos), which was already green.

No change to tests or docs content.