### PR TITLE
readers(GADGET/AREPO): read gas-cell fields + derive volume/T (Phase 1a)

### DIFF
--- a/docs/src/gadget_reader.md
+++ b/docs/src/gadget_reader.md
@@ -8,9 +8,13 @@ unchanged.
 
 !!! note "Scope"
     GADGET is particle-based (no Eulerian grid), so this is a **particle** reader: it loads the
-    `PartType*` groups into a Mera [`PartDataType`](@ref) via [`getparticles`](@ref). Gas SPH fields
-    (Density/InternalEnergy/…) are not yet exposed; the gas particles load as particles like the
-    rest. 3-D.
+    `PartType*` groups into a Mera [`PartDataType`](@ref) via [`getparticles`](@ref). For **gas**
+    (`PartType0`, e.g. AREPO/TNG) the cell fields present in the file are read as columns —
+    `Density→:rho`, `InternalEnergy→:u`, `ElectronAbundance→:ne`, `GFM_Metallicity→:metallicity`,
+    `StarFormationRate→:sfr` — and `:volume = mass/ρ` is derived; [`getvar`](@ref) adds `:T`, `:p`,
+    `:cs` (temperature from `:u`+`:ne`, with a neutral-primordial μ fallback when `:ne` is absent).
+    Base CGS units are read from the snapshot `Header`. 3-D. (Comoving→physical `a`/`h` conversion
+    is a planned next step.)
 
 ## Usage
 

--- a/src/functions/getvar/getvar_particles.jl
+++ b/src/functions/getvar/getvar_particles.jl
@@ -94,6 +94,29 @@ function get_data(dataobject::PartDataType,
                                   select(masked_data, :vy).^2 .+
                                   select(masked_data, :vz).^2 ) .* selected_unit .^2
 
+        # --- gas-cell thermodynamics (AREPO/GADGET PartType0), from specific internal energy :u ---
+        elseif i == :T || i == :Temp || i == :Temperature
+            # T = (γ-1)·u·μ·m_H/k_B [K]. scale.T_mu maps code (p/ρ)=(γ-1)u → T/μ; μ from the
+            # electron abundance :ne when present, else a neutral-primordial fallback (μ ≈ 1.22).
+            γ = 5/3; XH = 0.76
+            T_over_mu = (γ - 1) .* select(masked_data, :u) .* dataobject.info.scale.T_mu
+            if in(:ne, column_names)
+                ne = select(masked_data, :ne)
+                vars_dict[i] = @. T_over_mu * 4 / (1 + 3XH + 4XH * ne)         # [K]
+            else
+                vars_dict[i] = T_over_mu .* (4 / (1 + 3XH))                     # [K]
+            end
+
+        elseif i == :p || i == :pressure
+            # ideal-gas pressure p = (γ-1)·ρ·u
+            selected_unit = getunit(dataobject, i, vars, units)
+            vars_dict[i] = (5/3 - 1) .* select(masked_data, :rho) .* select(masked_data, :u) .* selected_unit
+
+        elseif i == :cs || i == :sound_speed
+            # adiabatic sound speed c_s = √(γ(γ-1)·u)
+            selected_unit = getunit(dataobject, i, vars, units)
+            vars_dict[i] = sqrt.((5/3) * (5/3 - 1) .* select(masked_data, :u)) .* selected_unit
+
        elseif i == :vϕ_cylinder
             x = getvar(filtered_dataobject, :x, center=center, mask=use_mask_in_recursion)
             y = getvar(filtered_dataobject, :y, center=center, mask=use_mask_in_recursion)

--- a/src/read_data/GADGET/reader_gadget.jl
+++ b/src/read_data/GADGET/reader_gadget.jl
@@ -11,10 +11,18 @@
 # `getparticles` — columns `(:x,:y,:z, :vx,:vy,:vz, :mass, :id, :family)` — and the particle
 # analysis (getvar / projection / msum / …) runs unchanged. `:family` is the PartType (0–5).
 #
-# Scope (v1): the particles. Gas SPH fields (Density/InternalEnergy/…) are not yet exposed.
+# Gas (PartType0): the Voronoi/SPH cell fields present in the file are read as columns —
+# Density→:rho, InternalEnergy→:u, ElectronAbundance→:ne, GFM_Metallicity→:metallicity,
+# StarFormationRate→:sfr — and :volume = mass/ρ is derived; getvar adds :T, :p, :cs. Base CGS
+# units are read from the Header. (a/h comoving→physical conversion is a later phase.)
 # ====================================================================================
 
 const _GADGET_FAMILY = Dict(0=>"gas", 1=>"halo/DM", 2=>"disk", 3=>"bulge", 4=>"stars", 5=>"bndry/BH")
+
+# 1-D gas-cell fields (AREPO/TNG PartType0) exposed as columns: HDF5 dataset => Mera symbol.
+# Only those actually present in a given snapshot are read (illustris_python-style field selection).
+const _GADGET_GAS_FIELDS = (("Density", :rho), ("InternalEnergy", :u), ("ElectronAbundance", :ne),
+                            ("GFM_Metallicity", :metallicity), ("StarFormationRate", :sfr))
 
 # does this HDF5 file look like GADGET? (a Header group carrying NumPart_Total)
 function _is_gadget_h5(fn::String)
@@ -70,14 +78,32 @@ function getinfo_gadget(output::Int, path::String; unit_length::Real=1.0, unit_d
         info.H0 = hub * 100; info.omega_m = Float64(_gadget_attr(h, "Omega0", 1.0))
         info.omega_l = Float64(_gadget_attr(h, "OmegaLambda", 0.0))
         info.omega_k = 0.0; info.omega_b = Float64(_gadget_attr(h, "OmegaBaryon", 0.0))
-        info.unit_l = Float64(unit_length); info.unit_d = Float64(unit_density)
-        info.unit_v = Float64(unit_velocity); info.unit_t = info.unit_l / info.unit_v
+        # base CGS units: prefer the snapshot Header (UnitLength/Mass/Velocity_in_*), which
+        # AREPO/GADGET/TNG all store, so physical conversions work out of the box; a caller-set
+        # kwarg (≠ the 1.0 default) still wins.
+        hul = Float64(_gadget_attr(h, "UnitLength_in_cm", 0.0))
+        huv = Float64(_gadget_attr(h, "UnitVelocity_in_cm_per_s", 0.0))
+        hum = Float64(_gadget_attr(h, "UnitMass_in_g", 0.0))
+        ul = (unit_length   == 1.0 && hul > 0)             ? hul        : Float64(unit_length)
+        uv = (unit_velocity == 1.0 && huv > 0)             ? huv        : Float64(unit_velocity)
+        ud = (unit_density  == 1.0 && hum > 0 && hul > 0)  ? hum / hul^3 : Float64(unit_density)
+        info.unit_l = ul; info.unit_d = ud; info.unit_v = uv
+        info.unit_t = info.unit_l / info.unit_v
         info.unit_m = info.unit_d * info.unit_l^3
         info.hydro = false; info.gravity = false; info.particles = true
         info.rt = false; info.clumps = false; info.sinks = false
         info.variable_list = Symbol[]; info.nvarh = 0
         info.gravity_variable_list = Symbol[]
         info.particles_variable_list = [:vx, :vy, :vz, :mass, :id, :family]
+        # advertise the gas-cell fields actually present in PartType0 (+ derived :volume, :T)
+        if haskey(f, "PartType0")
+            g0 = f["PartType0"]
+            for (ds, sym) in _GADGET_GAS_FIELDS
+                haskey(g0, ds) && push!(info.particles_variable_list, sym)
+            end
+            haskey(g0, "Density")        && push!(info.particles_variable_list, :volume)
+            haskey(g0, "InternalEnergy") && push!(info.particles_variable_list, :T)
+        end
         info.rt_variable_list = Symbol[]; info.clumps_variable_list = Symbol[]; info.sinks_variable_list = Symbol[]
         info.ncpu = 1
         info.mtime = Dates.unix2datetime(round(Int, mtime(fn))); info.ctime = info.mtime
@@ -99,6 +125,9 @@ end
 
 # read selected columns of a (3,N) row (function barrier: HDF5 read is boxed `Any`)
 _gadget_row(a::AbstractArray{<:Real,2}, r::Int, keep) = Float64.(@view a[r, keep])
+
+# read selected entries of a 1-D dataset (function barrier, as above)
+_gadget_col(a::AbstractVector{<:Real}, keep) = Float64.(@view a[keep])
 
 # indices of particles whose position lies in the (box-normalised) `ranges`
 function _gadget_keep(coords::AbstractArray{<:Real,2}, bl::Float64, ranges)
@@ -132,28 +161,54 @@ function getparticles_gadget(info::InfoType; families=:all,
     bl = info.boxlen
     x = Float64[]; y = Float64[]; z = Float64[]; vx = Float64[]; vy = Float64[]; vz = Float64[]
     mass = Float64[]; id = Int64[]; fam = Int32[]
+    gas = Dict{Symbol,Vector{Float64}}()    # gas-cell columns; NaN for non-gas families, kept aligned
     h5open(fn, "r") do f
         masstable = Float64.(_gadget_attr(attributes(f["Header"]), "MassTable", zeros(6)))
+        # which gas-cell fields to expose: gas is requested AND the dataset is in this snapshot
+        gascols = Tuple{String,Symbol}[]
+        if (0 in want) && haskey(f, "PartType0")
+            for (ds, sym) in _GADGET_GAS_FIELDS
+                haskey(f["PartType0"], ds) && (push!(gascols, (ds, sym)); gas[sym] = Float64[])
+            end
+        end
         for pt in want
             grp = "PartType$pt"
             (haskey(f, grp) && haskey(f[grp], "Coordinates")) || continue
             coords = read(f[grp]["Coordinates"]); vels = read(f[grp]["Velocities"])   # (3, N)
             keep = fullbox ? (1:size(coords, 2)) : _gadget_keep(coords, bl, ranges)    # spatial window
             isempty(keep) && continue
+            nkeep = length(keep)
             append!(x, _gadget_row(coords, 1, keep)); append!(y, _gadget_row(coords, 2, keep)); append!(z, _gadget_row(coords, 3, keep))
             append!(vx, _gadget_row(vels, 1, keep)); append!(vy, _gadget_row(vels, 2, keep)); append!(vz, _gadget_row(vels, 3, keep))
-            m = haskey(f[grp], "Masses") ? Float64.(@view read(f[grp]["Masses"])[keep]) : fill(masstable[pt+1], length(keep))
-            append!(mass, m); append!(id, Int64.(@view read(f[grp]["ParticleIDs"])[keep])); append!(fam, fill(Int32(pt), length(keep)))
+            m = haskey(f[grp], "Masses") ? Float64.(@view read(f[grp]["Masses"])[keep]) : fill(masstable[pt+1], nkeep)
+            append!(mass, m); append!(id, Int64.(@view read(f[grp]["ParticleIDs"])[keep])); append!(fam, fill(Int32(pt), nkeep))
+            # gas-cell fields: real values for gas, NaN for every other family (columns stay aligned)
+            for (ds, sym) in gascols
+                append!(gas[sym], (pt == 0 && haskey(f[grp], ds)) ? _gadget_col(read(f[grp][ds]), keep) : fill(NaN, nkeep))
+            end
         end
     end
-    data = table(x, y, z, vx, vy, vz, mass, id, fam;
-                 names=(:x, :y, :z, :vx, :vy, :vz, :mass, :id, :family), presorted=false, copy=false)
+    # per-cell volume V = m/ρ (NaN where ρ is absent or zero: non-gas rows, empty cells)
+    if haskey(gas, :rho)
+        rho = gas[:rho]; vol = similar(rho)
+        @inbounds @simd for k in eachindex(rho)
+            vol[k] = rho[k] > 0 ? mass[k] / rho[k] : NaN
+        end
+        gas[:volume] = vol
+    end
+    # deterministic column order: base columns, then gas fields in catalogue order, then :volume
+    gasnames = Symbol[]
+    for (_, sym) in _GADGET_GAS_FIELDS; haskey(gas, sym) && push!(gasnames, sym); end
+    haskey(gas, :volume) && push!(gasnames, :volume)
+    cols  = Any[x, y, z, vx, vy, vz, mass, id, fam]; append!(cols, (gas[s] for s in gasnames))
+    names = (:x, :y, :z, :vx, :vy, :vz, :mass, :id, :family, gasnames...)
+    data = table(cols...; names=names, presorted=false, copy=false)
     p = PartDataType()
     p.data = data; p.info = info; p.lmin = info.levelmin; p.lmax = info.levelmax; p.boxlen = info.boxlen
     p.ranges = ranges
-    p.selected_partvars = [:x, :y, :z, :vx, :vy, :vz, :mass, :id, :family]
+    p.selected_partvars = collect(names)
     p.used_descriptors = Dict{Any,Any}(); p.scale = info.scale
     verbose && println("[Mera]: GADGET particles = $(length(x)), families ",
-                       join(sort(unique(fam)), ","), "  (:x,:y,:z,:vx,:vy,:vz,:mass,:id,:family)")
+                       join(sort(unique(fam)), ","), "  (", join(names, ","), ")")
     return p
 end

--- a/test/60_gadget_reader_tests.jl
+++ b/test/60_gadget_reader_tests.jl
@@ -29,6 +29,33 @@ function _write_gadget(fn)
     end
 end
 
+# write a GADGET HDF5 with gas (PartType0: Density/InternalEnergy/ElectronAbundance) + DM, and
+# base CGS units in the Header — exercises the AREPO/TNG gas-cell path (Phase 1a).
+function _write_gadget_gas(fn)
+    h5open(fn, "w") do f
+        hg = create_group(f, "Header")
+        attributes(hg)["BoxSize"] = 100.0
+        attributes(hg)["NumPart_Total"] = UInt32[3, 2, 0, 0, 0, 0]      # 3 gas + 2 DM
+        attributes(hg)["MassTable"] = [0.0, 2.0, 0.0, 0.0, 0.0, 0.0]    # DM mass 2.0
+        attributes(hg)["Time"] = 1.0; attributes(hg)["HubbleParam"] = 0.7
+        attributes(hg)["UnitLength_in_cm"] = 3.085678e21               # kpc — reader auto-reads these
+        attributes(hg)["UnitMass_in_g"] = 1.989e43                     # 1e10 M⊙
+        attributes(hg)["UnitVelocity_in_cm_per_s"] = 1.0e5             # km/s
+        g0 = create_group(f, "PartType0")                              # gas (Float64 coords, like TNG)
+        g0["Coordinates"]       = Float64[10 50 90; 10 50 90; 10 50 90]   # (3,3)
+        g0["Velocities"]        = Float32[0 0 0; 0 0 0; 0 0 0]
+        g0["Masses"]            = Float32[1.0, 2.0, 4.0]
+        g0["Density"]           = Float32[0.5, 1.0, 2.0]               # ⇒ volume = m/ρ = 2,2,2
+        g0["InternalEnergy"]    = Float32[100.0, 200.0, 400.0]
+        g0["ElectronAbundance"] = Float32[1.0, 1.0, 1.0]
+        g0["ParticleIDs"]       = UInt32[1, 2, 3]
+        g1 = create_group(f, "PartType1")                              # DM (no gas datasets)
+        g1["Coordinates"] = Float32[20 80; 20 80; 20 80]
+        g1["Velocities"]  = Float32[0 0; 0 0; 0 0]
+        g1["ParticleIDs"] = UInt32[4, 5]
+    end
+end
+
 @testset verbose=true "GADGET reader (HDF5 particles, data-free contract)" begin
     dir = mktempdir()
 
@@ -75,6 +102,35 @@ end
         @test length(getparticles(info; xrange=[0.0, 0.2], center=[0., 0., 0.], range_unit=:standard, verbose=false).data) == length(sub.data)
     end
 
+    @testset "gas-cell fields → :rho/:u/:ne/:volume/:T (+ Header units)" begin
+        fn = joinpath(dir, "snap_010.hdf5"); _write_gadget_gas(fn)
+        info = getinfo_gadget(10, dir, verbose=false)
+        # base CGS units are read from the Header (no longer the identity default)
+        @test info.unit_l ≈ 3.085678e21 && info.unit_v ≈ 1.0e5
+        @test info.unit_d ≈ 1.989e43 / 3.085678e21^3 && info.scale.g_cm3 != 1.0
+        # getinfo advertises the gas fields present (+ derived :volume, :T), and only those
+        @test all(s -> s in info.particles_variable_list, (:rho, :u, :ne, :volume, :T))
+        @test !(:metallicity in info.particles_variable_list) && !(:sfr in info.particles_variable_list)
+
+        gas = getparticles_gadget(info; families=[0], verbose=false)
+        cn = Mera.IndexedTables.colnames(gas.data)
+        @test all(c -> c in cn, (:rho, :u, :ne, :volume))
+        @test getvar(gas, :rho) == [0.5, 1.0, 2.0]
+        @test getvar(gas, :volume) == [2.0, 2.0, 2.0]                  # m/ρ
+        # T = (γ-1)·u·T_mu·μ, μ = 4/(1+3·X_H+4·X_H·ne)  — compare to the closed form
+        γ = 5/3; XH = 0.76; ne = 1.0; μ = 4 / (1 + 3XH + 4XH*ne)
+        @test getvar(gas, :T) ≈ (γ-1) .* [100.0, 200.0, 400.0] .* info.scale.T_mu .* μ
+        @test all(getvar(gas, :T) .> 0)
+
+        # loading only DM ⇒ no gas columns at all
+        dm = getparticles_gadget(info; families=[1], verbose=false)
+        @test !(:rho in Mera.IndexedTables.colnames(dm.data))
+        # mixed gas+DM load ⇒ gas columns are NaN on the DM rows, real on the gas rows
+        both = getparticles_gadget(info; families=[0, 1], verbose=false)
+        rho = Mera.select(both.data, :rho); fam = Mera.select(both.data, :family)   # raw column (getvar maps NaN→0)
+        @test all(.!isnan.(rho[fam .== 0])) && all(isnan.(rho[fam .== 1]))
+    end
+
     # PART B (data-backed): the real yt GadgetDiskGalaxy sample.
     @testset "real GADGET snapshot — yt GadgetDiskGalaxy (data-backed)" begin
         gd = joinpath(SIMULATION_PATH, "gadget_diskgalaxy", "GadgetDiskGalaxy")
@@ -95,6 +151,44 @@ end
             @test 0 < length(sub.data) < length(stars.data) && sub.ranges != [0., 1., 0., 1., 0., 1.]
         else
             @test_skip "GadgetDiskGalaxy fixture not present (MERA_TEST_DATA/gadget_diskgalaxy/)"
+        end
+    end
+
+    # PART C (data-backed): real AREPO/TNG snapshots — gas-cell physics (Phase 1a).
+    @testset "real AREPO/TNG snapshots — gas fields (data-backed)" begin
+        tng = joinpath(SIMULATION_PATH, "arepo", "TNGHalo", "TNGHalo", "halo_59.hdf5")
+        if isfile(tng)
+            info = getinfo_gadget(59, tng, verbose=false)
+            @test info.simcode == "GADGET" && info.particles
+            @test info.scale.g_cm3 != 1.0                                       # units read from Header
+            @test all(s -> s in info.particles_variable_list, (:rho, :u, :ne, :metallicity, :sfr, :volume, :T))
+            gas = getparticles_gadget(info; families=[0], verbose=false)        # 4.0M gas cells
+            cn = Mera.IndexedTables.colnames(gas.data)
+            @test all(c -> c in cn, (:rho, :u, :ne, :metallicity, :sfr, :volume))
+            rho = getvar(gas, :rho); vol = getvar(gas, :volume); T = getvar(gas, :T)
+            @test all(rho .> 0) && all(vol .> 0) && all(isfinite, T)
+            @test minimum(T) > 1.0 && maximum(T) < 1e10                         # physical gas temperatures
+            @test 1e3 < sort(T)[length(T) ÷ 2] < 1e9                            # median in the warm/hot range
+            @test msum(gas) > 0
+        else
+            @test_skip "TNGHalo fixture not present (MERA_TEST_DATA/arepo/TNGHalo/)"
+        end
+
+        bullet = joinpath(SIMULATION_PATH, "arepo", "ArepoBullet", "ArepoBullet", "snapshot_150.hdf5")
+        if isfile(bullet)
+            info = getinfo_gadget(150, bullet, verbose=false)
+            @test info.scale.g_cm3 != 1.0
+            # minimal gas (no GFM / no ElectronAbundance): only :rho/:u/:volume/:T advertised
+            @test all(s -> s in info.particles_variable_list, (:rho, :u, :volume, :T))
+            @test !(:ne in info.particles_variable_list) && !(:metallicity in info.particles_variable_list)
+            # a central window keeps the load light; the T fallback (no :ne) still yields finite K
+            gas = getparticles_gadget(info; families=[0], xrange=[-0.25, 0.25], yrange=[-0.25, 0.25],
+                                      zrange=[-0.25, 0.25], center=[:bc], range_unit=:standard, verbose=false)
+            @test !(:ne in Mera.IndexedTables.colnames(gas.data))
+            @test length(gas.data) > 0
+            @test all(isfinite, getvar(gas, :T)) && all(getvar(gas, :volume) .> 0)
+        else
+            @test_skip "ArepoBullet fixture not present (MERA_TEST_DATA/arepo/ArepoBullet/)"
         end
     end
 end


### PR DESCRIPTION
AREPO / IllustrisTNG ship the GADGET HDF5 layout, so Mera’s existing reader already loaded their **particles**. This exposes the `PartType0` **gas-cell physics** — the first phase of native AREPO support (see the roadmap produced by the expert panel).

**What it does**
- **Field-selective gas reads** (illustris_python’s lesson, in a few lines): a declarative `const _GADGET_GAS_FIELDS` maps `Density→:rho`, `InternalEnergy→:u`, `ElectronAbundance→:ne`, `GFM_Metallicity→:metallicity`, `StarFormationRate→:sfr`; only datasets *present* are read.
- **`:volume = mass/ρ`** derived (NaN-guarded, `@inbounds @simd`). Non-gas families get `NaN` so a mixed load stays aligned; a gas-free load adds no columns.
- **`getvar` `:T`/`:p`/`:cs`** — `:T` reuses `scale.T_mu` (same path as hydro) with μ from `:ne` when present, neutral-primordial fallback otherwise.
- **Units auto-read from the Header** (`UnitLength/Mass/Velocity_in_*`) — fixes the identity-unit no-op; kwargs still override.
- `getinfo` advertises the gas fields actually present (+ derived `:volume`, `:T`).

**Validated on real data** (two free yt samples): `TNGHalo` (cosmological, MHD, full GFM — T spans cold ISM → ~10⁸ K hot halo, ρ ~10⁻³⁰–10⁻²² g/cm³) and `ArepoBullet` (non-cosmological, no `ElectronAbundance` — T via the μ fallback). Mass conservation intact; non-gas (stars/DM) loads unchanged (plain 9 columns).

**Tests:** a data-free **synthetic gas contract test** (runs in CI — checks field reads, `:volume=m/ρ`, the `:T` closed form, Header units, mixed-load NaN alignment) + a **data-backed AREPO/TNG test** (skips without fixtures). `60_gadget_reader_tests`: **50/50**.

**Not yet (next phase):** comoving→physical `a`/`h` conversion + the velocity `√a` factor — so ρ is currently physical *modulo* h²/a³ (T is a/h-free, hence exact).

Idiomatic, efficient Julia throughout: declarative field map, function-barrier HDF5 reads, single file open, broadcasting — cleaner than the per-field h5py boilerplate.