### PR TITLE
readers(GADGET/AREPO): comoving→physical a/h conversion (Phase 1b)

### DIFF
--- a/docs/src/gadget_reader.md
+++ b/docs/src/gadget_reader.md
@@ -13,8 +13,8 @@ unchanged.
     `Density→:rho`, `InternalEnergy→:u`, `ElectronAbundance→:ne`, `GFM_Metallicity→:metallicity`,
     `StarFormationRate→:sfr` — and `:volume = mass/ρ` is derived; [`getvar`](@ref) adds `:T`, `:p`,
     `:cs` (temperature from `:u`+`:ne`, with a neutral-primordial μ fallback when `:ne` is absent).
-    Base CGS units are read from the snapshot `Header`. 3-D. (Comoving→physical `a`/`h` conversion
-    is a planned next step.)
+    Base CGS units are read from the snapshot `Header`, and for cosmological runs the
+    comoving→physical `a`/`h` factors are applied automatically. 3-D.
 
 ## Usage
 
@@ -83,10 +83,15 @@ dm = getparticles_gadget(info; families=[1]); st = getparticles_gadget(info; fam
 ## Units
 
 GADGET data is in **code units** (commonly length kpc/h, mass 10¹⁰ M⊙/h, velocity km/s, with `h`
-the dimensionless Hubble parameter). The defaults treat the run as dimensionless; pass the run's CGS
-`unit_length`/`unit_density`/`unit_velocity` to [`getinfo_gadget`](@ref) for physical conversions
-(mind the `h` factors). Cosmological metadata (`Time` = scale factor, `Redshift`, `HubbleParam`,
-`Omega0`/`OmegaLambda`) is read from the `Header`.
+the dimensionless Hubble parameter). The base CGS units are read from the `Header`
+(`UnitLength/Mass/Velocity_in_*`), so `getvar(gas, :rho, :g_cm3)`, `getvar(part, :vx, :km_s)`, etc.
+return physical quantities out of the box; the `unit_length`/`unit_density`/`unit_velocity` keywords
+override them. Cosmological metadata (`Time` = scale factor, `Redshift`, `HubbleParam`,
+`Omega0`/`OmegaLambda`) is read from the `Header`, and a run is treated as **cosmological** when
+`OmegaLambda > 0`. For cosmological runs the **comoving→physical** factors are applied
+automatically: positions ∝ `a/h`, density ∝ `h²/a³`, mass ∝ `1/h`, and velocities carry the `√a`
+factor — so a code that returns physical values to `getvar` needs no manual `h`/`a` bookkeeping. (A
+non-cosmological run, `OmegaLambda = 0`, is left untouched: `a = 1`, `Time` is a physical time.)
 
 ## How it maps onto Mera's structs
 

--- a/src/read_data/GADGET/reader_gadget.jl
+++ b/src/read_data/GADGET/reader_gadget.jl
@@ -74,22 +74,31 @@ function getinfo_gadget(output::Int, path::String; unit_length::Real=1.0, unit_d
         info.levelmin = 1; info.levelmax = 1               # particle code: no grid levels
         info.boxlen = boxlen == 0 ? 1.0 : boxlen
         info.time = time
-        info.aexp = haskey(h, "Redshift") ? time : 1.0     # cosmological GADGET: Time = scale factor
-        info.H0 = hub * 100; info.omega_m = Float64(_gadget_attr(h, "Omega0", 1.0))
-        info.omega_l = Float64(_gadget_attr(h, "OmegaLambda", 0.0))
+        # cosmological? — real cosmological runs carry ΩΛ > 0 and use Time as the scale factor a;
+        # idealised/non-cosmological AREPO runs set Ω = 0 and use Time as a physical time (a = 1).
+        om = Float64(_gadget_attr(h, "Omega0", 0.0)); ol = Float64(_gadget_attr(h, "OmegaLambda", 0.0))
+        cosmo = ol > 0.0
+        a = cosmo ? (time == 0.0 ? 1.0 : time) : 1.0
+        info.aexp = a
+        info.H0 = hub * 100; info.omega_m = om; info.omega_l = ol
         info.omega_k = 0.0; info.omega_b = Float64(_gadget_attr(h, "OmegaBaryon", 0.0))
-        # base CGS units: prefer the snapshot Header (UnitLength/Mass/Velocity_in_*), which
-        # AREPO/GADGET/TNG all store, so physical conversions work out of the box; a caller-set
-        # kwarg (≠ the 1.0 default) still wins.
+        # base CGS units from the Header (UnitLength/Mass/Velocity_in_*; a kwarg ≠ 1.0 overrides),
+        # then apply the comoving→physical factors so getvar returns *physical* quantities:
+        #   length ∝ a/h,  density ∝ h²/a³,  mass = ρ·l³ ∝ 1/h.
+        # The velocity √a factor is applied to the velocity columns at read instead — InternalEnergy
+        # is also a velocity² but is stored a-free, so it must not inherit an a from unit_v here.
         hul = Float64(_gadget_attr(h, "UnitLength_in_cm", 0.0))
         huv = Float64(_gadget_attr(h, "UnitVelocity_in_cm_per_s", 0.0))
         hum = Float64(_gadget_attr(h, "UnitMass_in_g", 0.0))
-        ul = (unit_length   == 1.0 && hul > 0)             ? hul        : Float64(unit_length)
-        uv = (unit_velocity == 1.0 && huv > 0)             ? huv        : Float64(unit_velocity)
-        ud = (unit_density  == 1.0 && hum > 0 && hul > 0)  ? hum / hul^3 : Float64(unit_density)
-        info.unit_l = ul; info.unit_d = ud; info.unit_v = uv
-        info.unit_t = info.unit_l / info.unit_v
+        hfac = hub > 0 ? hub : 1.0
+        ul0 = (unit_length   == 1.0 && hul > 0)            ? hul         : Float64(unit_length)
+        uv0 = (unit_velocity == 1.0 && huv > 0)            ? huv         : Float64(unit_velocity)
+        ud0 = (unit_density  == 1.0 && hum > 0 && hul > 0) ? hum / hul^3 : Float64(unit_density)
+        info.unit_l = ul0 * a / hfac
+        info.unit_v = uv0
+        info.unit_d = ud0 * hfac^2 / a^3
         info.unit_m = info.unit_d * info.unit_l^3
+        info.unit_t = info.unit_l / info.unit_v
         info.hydro = false; info.gravity = false; info.particles = true
         info.rt = false; info.clumps = false; info.sinks = false
         info.variable_list = Symbol[]; info.nvarh = 0
@@ -187,6 +196,11 @@ function getparticles_gadget(info::InfoType; families=:all,
                 append!(gas[sym], (pt == 0 && haskey(f[grp], ds)) ? _gadget_col(read(f[grp][ds]), keep) : fill(NaN, nkeep))
             end
         end
+    end
+    # GADGET cosmological velocity convention: the stored value is v_peculiar/√a, so multiply by
+    # √a to recover the physical peculiar velocity (no-op for non-cosmological runs, a = 1).
+    if info.aexp != 1.0
+        sqa = sqrt(info.aexp); vx .*= sqa; vy .*= sqa; vz .*= sqa
     end
     # per-cell volume V = m/ρ (NaN where ρ is absent or zero: non-gas rows, empty cells)
     if haskey(gas, :rho)

--- a/test/60_gadget_reader_tests.jl
+++ b/test/60_gadget_reader_tests.jl
@@ -37,7 +37,7 @@ function _write_gadget_gas(fn)
         attributes(hg)["BoxSize"] = 100.0
         attributes(hg)["NumPart_Total"] = UInt32[3, 2, 0, 0, 0, 0]      # 3 gas + 2 DM
         attributes(hg)["MassTable"] = [0.0, 2.0, 0.0, 0.0, 0.0, 0.0]    # DM mass 2.0
-        attributes(hg)["Time"] = 1.0; attributes(hg)["HubbleParam"] = 0.7
+        attributes(hg)["Time"] = 1.0                                    # h defaults to 1 (no a/h folding here)
         attributes(hg)["UnitLength_in_cm"] = 3.085678e21               # kpc — reader auto-reads these
         attributes(hg)["UnitMass_in_g"] = 1.989e43                     # 1e10 M⊙
         attributes(hg)["UnitVelocity_in_cm_per_s"] = 1.0e5             # km/s
@@ -129,6 +129,49 @@ end
         both = getparticles_gadget(info; families=[0, 1], verbose=false)
         rho = Mera.select(both.data, :rho); fam = Mera.select(both.data, :family)   # raw column (getvar maps NaN→0)
         @test all(.!isnan.(rho[fam .== 0])) && all(isnan.(rho[fam .== 1]))
+    end
+
+    @testset "comoving→physical a/h conversion (cosmological run)" begin
+        # cosmological gas snapshot: ΩΛ>0, Time = scale factor a, h<1
+        fn = joinpath(dir, "snap_005.hdf5")
+        h5open(fn, "w") do f
+            hg = attributes(create_group(f, "Header"))
+            hg["BoxSize"] = 1000.0; hg["NumPart_Total"] = UInt32[2, 0, 0, 0, 0, 0]; hg["MassTable"] = zeros(6)
+            hg["Time"] = 0.5; hg["HubbleParam"] = 0.7; hg["Omega0"] = 0.3; hg["OmegaLambda"] = 0.7
+            hg["UnitLength_in_cm"] = 3.0e21; hg["UnitMass_in_g"] = 2.0e43; hg["UnitVelocity_in_cm_per_s"] = 1.0e5
+            g0 = create_group(f, "PartType0")
+            g0["Coordinates"]    = Float64[100 200; 100 200; 100 200]
+            g0["Velocities"]     = Float32[10 20; 0 0; 0 0]
+            g0["Masses"]         = Float32[1.0, 1.0]
+            g0["Density"]        = Float32[1.0, 1.0]
+            g0["InternalEnergy"] = Float32[100.0, 100.0]
+            g0["ParticleIDs"]    = UInt32[1, 2]
+        end
+        info = getinfo_gadget(5, dir, verbose=false)
+        a = 0.5; h = 0.7
+        @test info.aexp == a && Mera.iscosmological(info)            # cosmo flag from ΩΛ, a from Time
+        @test info.unit_l ≈ 3.0e21 * a / h                           # length  ∝ a/h
+        @test info.unit_d ≈ (2.0e43 / 3.0e21^3) * h^2 / a^3          # density ∝ h²/a³
+        @test info.unit_m ≈ info.unit_d * info.unit_l^3              # mass = ρ·l³  (∝ 1/h)
+        gas = getparticles_gadget(info; families=[0], verbose=false)
+        @test getvar(gas, :vx) ≈ [10.0, 20.0] .* sqrt(a)            # velocity √a applied at read
+        @test getvar(gas, :T)[1] ≈ getvar(gas, :T)[2] > 0           # T is a/h-free (same u ⇒ same T)
+
+        # a non-cosmological twin (ΩΛ=0) gets a=1 and no √a / a-factor
+        fn2 = joinpath(dir, "snap_006.hdf5")
+        h5open(fn2, "w") do f
+            hg = attributes(create_group(f, "Header"))
+            hg["BoxSize"] = 1000.0; hg["NumPart_Total"] = UInt32[2, 0, 0, 0, 0, 0]; hg["MassTable"] = zeros(6)
+            hg["Time"] = 0.5; hg["HubbleParam"] = 0.7; hg["Omega0"] = 0.0; hg["OmegaLambda"] = 0.0
+            hg["UnitLength_in_cm"] = 3.0e21; hg["UnitMass_in_g"] = 2.0e43; hg["UnitVelocity_in_cm_per_s"] = 1.0e5
+            g0 = create_group(f, "PartType0")
+            g0["Coordinates"] = Float64[100 200; 100 200; 100 200]; g0["Velocities"] = Float32[10 20; 0 0; 0 0]
+            g0["Masses"] = Float32[1.0, 1.0]; g0["Density"] = Float32[1.0, 1.0]
+            g0["InternalEnergy"] = Float32[100.0, 100.0]; g0["ParticleIDs"] = UInt32[1, 2]
+        end
+        info2 = getinfo_gadget(6, dir, verbose=false)
+        @test info2.aexp == 1.0 && !Mera.iscosmological(info2)       # ΩΛ=0 ⇒ non-cosmological, a=1
+        @test getvar(getparticles_gadget(info2; families=[0], verbose=false), :vx) == [10.0, 20.0]  # no √a
     end
 
     # PART B (data-backed): the real yt GadgetDiskGalaxy sample.


### PR DESCRIPTION
Completes the AREPO/TNG units story: `getvar` now returns **physical** quantities for cosmological runs.

- **Robust cosmological flag** from `ΩΛ > 0` — replaces the fragile `Redshift`-key heuristic (which mis-flagged the non-cosmological `ArepoBullet`). Cosmological ⇒ `Time` = scale factor `a`; else `a = 1` and `Time` is a physical time.
- **a/h folded into the base units** in `getinfo`, so every scale-based conversion is physical with **no getvar changes**: length ∝ `a/h`, density ∝ `h²/a³`, mass = ρ·l³ ∝ `1/h`.
- **Velocity `√a` applied to the velocity columns at read** (not via `unit_v`) — because `InternalEnergy` is *also* a velocity² but stored a-free, so it must not inherit an `a`; this keeps `:u`/`:T`/`:cs` correct.

**Validated:** `TNGHalo` ρ now carries `h²` (3.1e-22 vs 6.77e-22 base; T unchanged since it is a/h-free); `ArepoBullet` correctly non-cosmological. A **synthetic z=1** (a=0.5, h=0.7) test checks every factor — a/h length, h²/a³ density, √a velocity — plus a non-cosmological twin. `60_gadget_reader_tests`: **58/58**.

The design keeps the table in code units and lets the unit layer do the physics — consistent with how RAMSES scales work — so it is one small, self-documenting change rather than a per-field correction sprinkled through getvar.