### PR TITLE
fix(projection): correct volume-weighting of intensive particle fields

### DIFF
--- a/src/functions/projection/projection_particles.jl
+++ b/src/functions/projection/projection_particles.jl
@@ -843,24 +843,41 @@ function create_projection(   dataobject::PartDataType, vars::Array{Symbol,1};
                         maps_unit[Symbol( string(i_var)  )] = unit_name
                         maps_mode[Symbol( string(i_var)  )] = :volume_weighted
                     else
+                        # volume-weighted mean of an intensive quantity: Σ(q·V) / Σ(V).
+                        # Mirrors the mass-weighted branch (with :volume as the weight); needs a
+                        # :volume column, e.g. AREPO/GADGET gas cells. (The previous code deposited
+                        # Σq and divided by a volume constant — neither a mean nor conserved.)
+                        in(:volume, propertynames(filtered_data.columns)) || throw(ArgumentError(
+                            "projection (particles): weighting=:volume on '$(i_var)' needs a :volume column " *
+                            "(e.g. AREPO/GADGET gas); use weighting=:mass for particles without one."))
                         if length(mask) == 1
                             h = fit(Histogram, (select(filtered_data, var_a) ,
                                                 select(filtered_data, var_b) ),
-                                                weights( getvar(dataobject, i_var, filtered_db=filtered_data, center=data_centerm, direction=direction, ref_time=ref_time)  ),
+                                                weights( getvar(dataobject, i_var, filtered_db=filtered_data, center=data_centerm, direction=direction, ref_time=ref_time) .* select(filtered_data, :volume) ),
+                                                closed=closed,
+                                                (newrange1, newrange2) )
+                            h_vol = fit(Histogram, (select(filtered_data, var_a) ,
+                                                select(filtered_data, var_b) ),
+                                                weights( select(filtered_data, :volume) ),
                                                 closed=closed,
                                                 (newrange1, newrange2) )
                         else
                             h = fit(Histogram, (select(filtered_data, var_a) ,
                                                 select(filtered_data, var_b) ),
-                                                weights( getvar(dataobject, i_var, filtered_db=filtered_data, center=data_centerm, direction=direction, ref_time=ref_time)  .* select(filtered_data, :mask)  ),
+                                                weights( getvar(dataobject, i_var, filtered_db=filtered_data, center=data_centerm, direction=direction, ref_time=ref_time) .* select(filtered_data, :volume) .* select(filtered_data, :mask) ),
+                                                closed=closed,
+                                                (newrange1, newrange2) )
+                            h_vol = fit(Histogram, (select(filtered_data, var_a) ,
+                                                select(filtered_data, var_b) ),
+                                                weights( select(filtered_data, :volume) .* select(filtered_data, :mask) ),
                                                 closed=closed,
                                                 (newrange1, newrange2) )
                         end
                         selected_unit, unit_name= getunit(dataobject, i_var, selected_vars, units, uname=true)
                         if selected_unit != 1.
-                            maps[Symbol(i_var)] = h.weights ./ ( (dataobject.info.boxlen / res )^3 * res) .* selected_unit
+                            maps[Symbol(i_var)] = h.weights ./ h_vol.weights .* selected_unit
                         else
-                            maps[Symbol(i_var)] = h.weights ./ ( (dataobject.info.boxlen / res )^3 * res)
+                            maps[Symbol(i_var)] = h.weights ./ h_vol.weights
                         end
                         maps_unit[Symbol( string(i_var)  )] = unit_name
                         maps_mode[Symbol( string(i_var)  )] = :volume_weighted

--- a/test/60_gadget_reader_tests.jl
+++ b/test/60_gadget_reader_tests.jl
@@ -174,6 +174,28 @@ end
         @test getvar(getparticles_gadget(info2; families=[0], verbose=false), :vx) == [10.0, 20.0]  # no √a
     end
 
+    @testset "volume-weighted particle projection Σ(qV)/ΣV (gas)" begin
+        # two gas cells at the same position ⇒ one filled pixel = the weighted mean of their T
+        fn = joinpath(dir, "snap_007.hdf5")
+        h5open(fn, "w") do f
+            hg = attributes(create_group(f, "Header"))
+            hg["BoxSize"] = 100.0; hg["NumPart_Total"] = UInt32[2, 0, 0, 0, 0, 0]; hg["MassTable"] = zeros(6); hg["Time"] = 1.0
+            hg["UnitLength_in_cm"] = 3.0e21; hg["UnitMass_in_g"] = 2.0e43; hg["UnitVelocity_in_cm_per_s"] = 1.0e5
+            g0 = create_group(f, "PartType0")
+            g0["Coordinates"] = Float64[50 50; 50 50; 50 50]; g0["Velocities"] = Float32[0 0; 0 0; 0 0]
+            g0["Masses"] = Float32[1.0, 1.0]; g0["Density"] = Float32[1.0, 0.5]      # ⇒ V = 1, 2
+            g0["InternalEnergy"] = Float32[100.0, 400.0]; g0["ParticleIDs"] = UInt32[1, 2]
+        end
+        info = getinfo_gadget(7, dir, verbose=false)
+        gas = getparticles_gadget(info; families=[0], verbose=false)
+        T = getvar(gas, :T); V = getvar(gas, :volume); m = getvar(gas, :mass)
+        pv = projection(gas, :T, weighting=:volume, res=8, verbose=false, show_progress=false)
+        pm = projection(gas, :T, weighting=:mass,   res=8, verbose=false, show_progress=false)
+        @test maximum(filter(isfinite, pv.maps[:T])) ≈ sum(T .* V) / sum(V)     # Σ(T·V)/ΣV (the fix)
+        @test maximum(filter(isfinite, pm.maps[:T])) ≈ sum(T .* m) / sum(m)     # Σ(T·m)/Σm
+        @test !(sum(T .* V) / sum(V) ≈ sum(T .* m) / sum(m))                    # the two genuinely differ
+    end
+
     # PART B (data-backed): the real yt GadgetDiskGalaxy sample.
     @testset "real GADGET snapshot — yt GadgetDiskGalaxy (data-backed)" begin
         gd = joinpath(SIMULATION_PATH, "gadget_diskgalaxy", "GadgetDiskGalaxy")


### PR DESCRIPTION
A standalone bug (surfaced by the AREPO expert-panel review) in `projection_particles.jl`.

`projection(...; weighting=:volume)` on an **intensive** quantity (e.g. gas `:T`) deposited `Σq` and divided by a volume constant — **neither a weighted mean nor conserved**. It now computes the proper **volume-weighted mean `Σ(q·V)/Σ(V)`**, mirroring the mass-weighted branch with the `:volume` column as the weight, and raises a clear error when there is no `:volume` column (use `weighting=:mass`).

The surface-density / density sub-cases were already correct (those are inherently mass-based, so their `:volume` mode legitimately matches `:mass`).

**Test:** two gas cells at one position ⇒ the filled pixel equals `Σ(T·V)/ΣV` for `:volume` and `Σ(T·m)/Σm` for `:mass`, and the two genuinely differ (29325 vs 24438 in the fixture). Independent of AREPO, but most naturally exercised with AREPO/GADGET gas (which now carries `:volume`).