### PR TITLE
docs(AREPO): notebook parity — link end-to-end gas notebook, fix multi-code table

### DIFF
--- a/docs/src/gadget_reader.md
+++ b/docs/src/gadget_reader.md
@@ -1,5 +1,12 @@
 # Reading GADGET data (experimental)
 
+!!! tip "Run it yourself"
+    The GADGET particle load **and** the AREPO/IllustrisTNG gas-cell analysis below (physical
+    `getvar(:rho/:T/:metallicity)`, PDFs/profiles, point and SPH-kernel maps on a real TNG halo) are
+    exercised end-to-end in the runnable
+    [`16_multi_OtherCodes.ipynb`](https://github.com/ManuelBehrendt/Notebooks/blob/master/Mera-Docs/version_1/16_multi_OtherCodes.ipynb)
+    notebook, which also drives Mera's coverage.
+
 Mera's analysis layer is **code-blind**, so a reader only has to fill the standard structs. This
 page adds a **frontend for the [GADGET](https://wwwmpa.mpa-garching.mpg.de/gadget4/) HDF5 snapshot
 format** — also written by **GIZMO, AREPO, SWIFT, EAGLE and IllustrisTNG** — so [`getvar`](@ref),

--- a/docs/src/multicode.md
+++ b/docs/src/multicode.md
@@ -29,7 +29,7 @@ files in the directory (override with `code=`); the detected code is stored in `
 | **PLUTO-AMR / Chombo** | Chombo HDF5 | AMR | hydro | code | ✅ | ✅ (per box) | [PLUTO](pluto_reader.md#PLUTO-AMR-(Chombo)) |
 | **Athena++** | `.athdf` HDF5 | AMR | hydro · MHD | code | ✅ | ✅ (per MeshBlock) | [Athena++](athena_reader.md) |
 | **FLASH** | HDF5 PARAMESH | AMR | hydro · MHD | CGS | ✅ | ✅ (per leaf block) | [FLASH](flash_reader.md) |
-| **GADGET** (+ GIZMO/AREPO/SWIFT/TNG) | HDF5 `PartType*` | particles | particles (gas · DM · stars · …) | code | ✅ | ✅ (per type, on read) | [GADGET](gadget_reader.md) |
+| **GADGET** (+ GIZMO/AREPO/SWIFT/TNG) | HDF5 `PartType*` | particles | particles · **gas-cell physics** (ρ · T · Z · …) | physical (a/h applied) | ✅ | ✅ (per type, on read) | [GADGET](gadget_reader.md) |
 
 Data is loaded **per type**, exactly as for RAMSES: [`gethydro`](@ref) always, and
 [`getparticles`](@ref) where the code wrote particles (PLUTO). Only what a code actually stored is


### PR DESCRIPTION
Brings AREPO/TNG to documentation/notebook parity with the other codes. The multi-code notebook `16_multi_OtherCodes.ipynb` now demonstrates the **gas workflow end-to-end on a real IllustrisTNG halo** — physical `getvar(:rho/:T/:metallicity)`, reductions, and point + SPH-kernel surface-density/temperature maps (verified to run on the 4M-cell `TNGHalo` fixture).

- `gadget_reader.md` gets a **"Run it yourself"** link to the notebook (ties the gas docs to the runnable/coverage notebook, like the other pages).
- `multicode.md` overview table: the GADGET row now reads **"particles + gas-cell physics (ρ/T/Z), physical units (a/h applied)"** instead of just "particles".

(The `.ipynb` lives in the separate Notebooks repo and is committed there.)