### PR TITLE
readers(GADGET): distinguish AREPO/SWIFT from plain GADGET

### DIFF
--- a/src/read_data/GADGET/reader_gadget.jl
+++ b/src/read_data/GADGET/reader_gadget.jl
@@ -33,6 +33,16 @@ function _is_gadget_h5(fn::String)
     catch; return false; end
 end
 
+# The GADGET HDF5 layout is shared by several codes; name the actual producer from header/group
+# markers so getinfo reports the real code (AREPO ≠ plain GADGET). AREPO (incl. IllustrisTNG) writes
+# a `Config` group (yt's discriminator); SWIFT sets a `Header/Code` attribute. Falls back to GADGET.
+function _gadget_subcode(f)
+    h = attributes(f["Header"])
+    haskey(h, "Code")   && return uppercase(strip(string(read(h["Code"]))))   # SWIFT (and any code that sets it)
+    haskey(f, "Config") && return "AREPO"                                      # AREPO / IllustrisTNG
+    return "GADGET"
+end
+
 # resolve the GADGET snapshot file: a direct path, or `snap*_NNN.hdf5` in a directory
 function _gadget_file(output::Int, path::String)
     (isfile(path) && endswith(lowercase(path), ".hdf5")) && return path
@@ -69,7 +79,7 @@ function getinfo_gadget(output::Int, path::String; unit_length::Real=1.0, unit_d
         npart  = Int.(_gadget_attr(h, "NumPart_Total", zeros(Int, 6)))
         time   = Float64(_gadget_attr(h, "Time", 0.0))
         hub    = Float64(_gadget_attr(h, "HubbleParam", 1.0))
-        info.output = output; info.path = abspath(path); info.simcode = "GADGET"
+        info.output = output; info.path = abspath(path); info.simcode = _gadget_subcode(f)
         info.Narraysize = 0; info.ndim = 3
         info.levelmin = 1; info.levelmax = 1               # particle code: no grid levels
         info.boxlen = boxlen == 0 ? 1.0 : boxlen

--- a/src/read_data/RAMSES/getparticles.jl
+++ b/src/read_data/RAMSES/getparticles.jl
@@ -201,7 +201,7 @@ function getparticles( dataobject::InfoType;
     # Multi-code: a non-RAMSES info delegates to its own particle frontend.
     if dataobject.simcode == "PLUTO"
         return getparticles_pluto(dataobject; verbose=verbose)
-    elseif dataobject.simcode == "GADGET"
+    elseif dataobject.simcode in ("GADGET", "AREPO", "SWIFT", "GIZMO")   # the GADGET-HDF5 family
         return getparticles_gadget(dataobject; xrange=xrange, yrange=yrange, zrange=zrange,
                                    center=center, range_unit=range_unit, verbose=verbose)
     end

--- a/test/60_gadget_reader_tests.jl
+++ b/test/60_gadget_reader_tests.jl
@@ -102,6 +102,23 @@ end
         @test length(getparticles(info; xrange=[0.0, 0.2], center=[0., 0., 0.], range_unit=:standard, verbose=false).data) == length(sub.data)
     end
 
+    @testset "code discrimination (AREPO Config group) + family routing" begin
+        # a GADGET-HDF5 file with a `Config` group is AREPO (yt's rule); without it, plain GADGET.
+        fn = joinpath(dir, "snap_009.hdf5")
+        h5open(fn, "w") do f
+            hg = attributes(create_group(f, "Header"))
+            hg["BoxSize"] = 10.0; hg["NumPart_Total"] = UInt32[1, 0, 0, 0, 0, 0]; hg["MassTable"] = zeros(6); hg["Time"] = 1.0
+            create_group(f, "Config")                                          # ⇐ the AREPO marker
+            g0 = create_group(f, "PartType0")
+            g0["Coordinates"] = reshape(Float64[5, 5, 5], 3, 1); g0["Velocities"] = reshape(Float32[0, 0, 0], 3, 1)
+            g0["Masses"] = Float32[1.0]; g0["ParticleIDs"] = UInt32[1]
+        end
+        arepo = getinfo_gadget(9, dir, verbose=false)
+        @test arepo.simcode == "AREPO"                                         # Config ⇒ AREPO, not GADGET
+        @test length(getparticles(arepo, verbose=false).data) == 1            # AREPO still routes to the gadget frontend
+        @test getinfo_gadget(0, dir, verbose=false).simcode == "GADGET"        # the no-Config file stays plain GADGET
+    end
+
     @testset "gas-cell fields → :rho/:u/:ne/:volume/:T (+ Header units)" begin
         fn = joinpath(dir, "snap_010.hdf5"); _write_gadget_gas(fn)
         info = getinfo_gadget(10, dir, verbose=false)
@@ -253,7 +270,7 @@ end
         tng = joinpath(SIMULATION_PATH, "arepo", "TNGHalo", "TNGHalo", "halo_59.hdf5")
         if isfile(tng)
             info = getinfo_gadget(59, tng, verbose=false)
-            @test info.simcode == "GADGET" && info.particles
+            @test info.simcode == "AREPO" && info.particles                     # detected from the Config group
             @test info.scale.g_cm3 != 1.0                                       # units read from Header
             @test all(s -> s in info.particles_variable_list, (:rho, :u, :ne, :metallicity, :sfr, :volume, :T))
             gas = getparticles_gadget(info; families=[0], verbose=false)        # 4.0M gas cells


### PR DESCRIPTION
The GADGET HDF5 layout is shared by several codes, so Mera labelled *every* such file `simcode = "GADGET"` — including AREPO/IllustrisTNG. That made the AREPO samples misrepresent themselves (`getinfo` printed "Code: GADGET").

Now the actual producer is named from header/group markers (the same rule yt uses): a **`Config` group ⇒ AREPO** (incl. IllustrisTNG), a **`Header/Code` attribute ⇒ SWIFT**, otherwise **GADGET**. `getinfo` reports **"Code: AREPO"** for the `TNGHalo`/`ArepoBullet` fixtures.

The particle router (`getparticles`) now recognises the whole GADGET-HDF5 family (`GADGET`/`AREPO`/`SWIFT`/`GIZMO`) so relabelled files still dispatch to the gadget frontend.

Tests: AREPO detected from `Config`; plain GADGET (incl. the GadgetDiskGalaxy sample) unchanged; family routing verified; data-backed TNG now asserts `simcode == "AREPO"`. Cosmological handling (a/h, Phase 1b) is unaffected and confirmed (TNG `iscosmological = true`).