### PR TITLE
fix: HDBSCAN noise-label OOB + subregion sphere/cylinder unit inversion

### DIFF
--- a/src/functions/clumpfind.jl
+++ b/src/functions/clumpfind.jl
@@ -1174,7 +1174,13 @@ function clumpfind(obj::HydroPartType, finder::AbstractFinder; pos_unit::Symbol=
                            finder.linking_length, finder.min_delta; backend=finder.backend)) : nothing
     labels, k = _label(finder, P)
     members = [Int[] for _ in 1:k]
-    @inbounds for i in eachindex(labels); push!(members[labels[i]], i); end
+    # HDBSCAN (and only it) emits noise labels == 0; skip them. Without the guard `members[0]` was
+    # an out-of-bounds write masked by `@inbounds`, corrupting an adjacent array → the cryptic
+    # ConcurrencyViolationError. (The deblend path already guards this in `_split_group`.)
+    @inbounds for i in eachindex(labels)
+        l = labels[i]
+        l > 0 && push!(members[l], i)
+    end
     if deblend !== false   # split each clump (peak/watershed, or a composed finder per group)
         members = reduce(vcat, (_split_group(deblend, mem, xs, ys, zs, ms, fs, Float64(peak_min_distance))
                                 for mem in members); init=Vector{Int}[])

--- a/src/functions/prepranges.jl
+++ b/src/functions/prepranges.jl
@@ -176,24 +176,31 @@ function prepranges(    dataobject::InfoType,
 
     else
         selected_unit = getunit(dataobject, range_unit)
-        xmin = (-radius + center[1]) * selected_unit /dataobject.boxlen
-        xmax = ( radius + center[1]) * selected_unit /dataobject.boxlen
-        ymin = (-radius + center[2]) * selected_unit /dataobject.boxlen
-        ymax = ( radius + center[2]) * selected_unit /dataobject.boxlen
+        # Convert physical units → fractional box coordinates by dividing by boxlen·selected_unit.
+        # (selected_unit is the value of one code length in `range_unit`, so code = unit/selected_unit
+        # and fraction = unit/(boxlen·selected_unit) — the same form as `center` below.) These shifts
+        # previously multiplied by selected_unit/boxlen, inverted by a factor selected_unit², which
+        # collapsed the sphere/cylinder to a ~zero-radius ball at the origin (0 cells). Cuboids used
+        # the correct form, so the bug stayed hidden.
+        conv = dataobject.boxlen * selected_unit
+        xmin = (-radius + center[1]) / conv
+        xmax = ( radius + center[1]) / conv
+        ymin = (-radius + center[2]) / conv
+        ymax = ( radius + center[2]) / conv
         if height != 0.
-            zmin = ( -height + center[3]) * selected_unit /dataobject.boxlen
-            zmax = (  height + center[3]) * selected_unit /dataobject.boxlen
+            zmin = ( -height + center[3]) / conv
+            zmax = (  height + center[3]) / conv
         else
-            zmin = ( -radius + center[3]) * selected_unit /dataobject.boxlen
-            zmax = (  radius + center[3]) * selected_unit /dataobject.boxlen
+            zmin = ( -radius + center[3]) / conv
+            zmax = (  radius + center[3]) / conv
         end
         # given center relative to the data range in units: cell centers
-        cx_shift = center[1] * selected_unit /dataobject.boxlen
-        cy_shift = center[2] * selected_unit /dataobject.boxlen
-        cz_shift = center[3] * selected_unit /dataobject.boxlen
-    radius_shift = radius * selected_unit /dataobject.boxlen
-    if height != 0. height_shift = height * selected_unit /dataobject.boxlen end
-        center  =  center / (dataobject.boxlen * selected_unit )
+        cx_shift = center[1] / conv
+        cy_shift = center[2] / conv
+        cz_shift = center[3] / conv
+        radius_shift = radius / conv
+        if height != 0. height_shift = height / conv end
+        center  =  center / conv
     end
 
     if verbose

--- a/test/54_clumpfind_synthetic_tests.jl
+++ b/test/54_clumpfind_synthetic_tests.jl
@@ -196,4 +196,14 @@
         # the reloaded object behaves identically under clumpfind
         @test clumpfind(D.gas, fof()).nclumps == clumpfind(gas, fof()).nclumps
     end
+
+    @testset "HDBSCAN runs with noise labels (no out-of-bounds)" begin
+        # HDBSCAN is the only finder that emits noise labels (== 0). The main labelling loop must
+        # skip them — otherwise `members[0]` was an out-of-bounds write masked by `@inbounds`,
+        # corrupting an adjacent array → a cryptic ConcurrencyViolationError. Guard the regression.
+        cat = clumpfind(gas, HDBSCANFinder(:rho; threshold=thr, linking_length=ll, min_cluster_size=8))
+        @test cat isa ClumpCatalog                           # returns a catalog instead of throwing
+        @test all(c -> c.n_members >= 1, cat.clumps)         # member lists well-formed (no corruption)
+        @test cat.nclumps >= 1                               # finds at least one cluster on the synthetic field
+    end
 end

--- a/test/55_region_algebra_tests.jl
+++ b/test/55_region_algebra_tests.jl
@@ -196,4 +196,25 @@
         @test isempty(out2)
         Mera._REGION_HINT_SHOWN[] = false                   # reset so other tests/sessions can see it
     end
+
+    @testset "symbol-form subregion: physical units match :standard" begin
+        # Regression: subregion(:sphere/:cylinder; range_unit≠:standard) collapsed to 0 cells because
+        # prepranges multiplied by selected_unit/boxlen instead of dividing by boxlen·selected_unit
+        # (cuboids used the correct form, so the bug hid). A physical-unit selection must match the
+        # equivalent :standard one cell-for-cell. The value-type Sphere(...) path (above) was fine;
+        # this guards the legacy symbol path.
+        sph_std = subregion(gas, :sphere; center=[:bc], radius=0.3,      range_unit=:standard, verbose=false)
+        sph_kpc = subregion(gas, :sphere; center=[:bc], radius=0.3box,   range_unit=:kpc,      verbose=false)
+        @test length(sph_kpc.data) > 0                      # was 0 before the fix
+        @test length(sph_kpc.data) == length(sph_std.data)  # physical == standard, cell-for-cell
+
+        cyl_std = subregion(gas, :cylinder; center=[:bc], radius=0.3,    height=0.2,    range_unit=:standard, verbose=false)
+        cyl_kpc = subregion(gas, :cylinder; center=[:bc], radius=0.3box, height=0.2box, range_unit=:kpc,      verbose=false)
+        @test length(cyl_kpc.data) > 0 && length(cyl_kpc.data) == length(cyl_std.data)
+
+        # an off-centre sphere exercises the cx/cy/cz shift conversion too
+        off_std = subregion(gas, :sphere; center=[0.6, 0.6, 0.6],          radius=0.15,    range_unit=:standard, verbose=false)
+        off_kpc = subregion(gas, :sphere; center=[0.6box, 0.6box, 0.6box], radius=0.15box, range_unit=:kpc,      verbose=false)
+        @test length(off_kpc.data) == length(off_std.data) > 0
+    end
 end


### PR DESCRIPTION
Two correctness bugs (precisely diagnosed) + regression tests so they cannot recur.

**Bug 1 — HDBSCAN `ConcurrencyViolationError`** (`clumpfind.jl`). HDBSCAN is the only finder that emits **noise labels == 0**. The main labelling loop did `@inbounds push!(members[labels[i]], i)`, so a noise point wrote to `members[0]` — out of bounds, **masked by `@inbounds`**, corrupting an adjacent array’s header → the cryptic concurrency error (at *any* thread count, since the loop is serial). Fix: skip noise (`l > 0`). The deblend path (`_split_group`) already guarded this.

**Bug 2 — `subregion(:sphere/:cylinder)` returns 0 cells with `range_unit ≠ :standard`** (`prepranges.jl`). The radius branch converted units by `* selected_unit / boxlen` instead of `/ (boxlen * selected_unit)` — **inverted by a factor `selected_unit²`** (~1.6e-9 for pc), collapsing the region to a ~zero-radius ball at the origin. Cuboids and the `center` line used the correct form, so it stayed hidden. Fix: mirror that form (`conv = boxlen·selected_unit`).

**Regression tests (data-free, CI):**
- `test/54`: `HDBSCANFinder` now in the finder coverage — returns a valid catalog (well-formed member lists) instead of throwing.
- `test/55`: legacy symbol-form `subregion(:sphere/:cylinder; range_unit=:kpc)` must match `:standard` cell-for-cell, incl. an off-centre case for the shift conversion.

Verified: sphere `:kpc` == `:standard` (4561 cells, was 0); HDBSCAN returns 6 clumps without throwing.