### PR TITLE
test: relink fixtures to code-wise test-data layout

### DIFF
--- a/test/27_data_conversion_tests.jl
+++ b/test/27_data_conversion_tests.jl
@@ -1003,7 +1003,7 @@ else
         # Guards against silent struct-layout breakage of the serialized scale/info types: an OLD
         # JLD2 mera file (written by an earlier Mera) must still load. Adding a field to ScalesType002
         # once broke exactly this — old files reconstructed to a mismatched layout and threw on load.
-        jdir = joinpath(SIMULATION_PATH, "JLD2_files")
+        jdir = joinpath(SIMULATION_PATH, "MERA-FILES/JLD2_files")
         if isfile(joinpath(jdir, "output_00300.jld2"))
             gas = loaddata(300, jdir, :hydro, verbose=false)
             @test gas isa HydroDataType && length(gas.data) > 0
@@ -1019,7 +1019,7 @@ else
         # (getvar), not just loadable. JLD2_complete holds an old hydro+particles+gravity file.
         # NOTE: we cannot WRITE an older JLD2 version from within one test run (only one JLD2 is
         # loaded), so backward-compat is verified by reading committed old-format fixtures.
-        cdir = joinpath(SIMULATION_PATH, "JLD2_complete")
+        cdir = joinpath(SIMULATION_PATH, "MERA-FILES/JLD2_complete")
         if isfile(joinpath(cdir, "output_00300.jld2"))
             @test (viewdata(300, path=cdir, verbose=false); true)  # metadata read of an LZ4 old file doesn't throw
 

--- a/test/46_timeseries_tests.jl
+++ b/test/46_timeseries_tests.jl
@@ -14,10 +14,10 @@
 # Fully-qualified accessor so the test needs only `using Mera`.
 _cols(t) = Mera.IndexedTables.columns(t)
 
-const TS_RAMSES = joinpath(SIMULATION_PATH, "timeseries_sedov3d")
-const TS_MERA   = joinpath(SIMULATION_PATH, "timeseries_sedov3d_mera")
-const RT_RAMSES = joinpath(SIMULATION_PATH, "rt_stromgren")
-const RT_MERA   = joinpath(SIMULATION_PATH, "rt_stromgren_mera")
+const TS_RAMSES = joinpath(SIMULATION_PATH, "RAMSES/timeseries_sedov3d")
+const TS_MERA   = joinpath(SIMULATION_PATH, "MERA-FILES/timeseries_sedov3d_mera")
+const RT_RAMSES = joinpath(SIMULATION_PATH, "RAMSES/rt_stromgren")
+const RT_MERA   = joinpath(SIMULATION_PATH, "MERA-FILES/rt_stromgren_mera")
 
 @testset "timeseries()" begin
 
@@ -139,7 +139,7 @@ if DATA_AVAILABLE && isdir(RT_RAMSES) && !isempty(checkoutputs(RT_RAMSES, verbos
 end
 
 # cosmological run → automatic redshift / aexp columns, time as the age in Myr
-let cp = joinpath(SIMULATION_PATH, "yt_cosmo")
+let cp = joinpath(SIMULATION_PATH, "RAMSES/yt_cosmo")
     if DATA_AVAILABLE && isdir(cp)
         @testset "cosmological run → redshift / aexp columns" begin
             ic = getinfo(80, cp, verbose=false)

--- a/test/47_galaxyframe_tests.jl
+++ b/test/47_galaxyframe_tests.jl
@@ -7,7 +7,7 @@
 #   PART B (data-free)   — vector helpers + GalaxyFrame.
 # ============================================================================
 
-const GF_PATH = joinpath(SIMULATION_PATH, "spiral_clumps")
+const GF_PATH = joinpath(SIMULATION_PATH, "RAMSES/spiral_clumps")
 
 @testset "auto-frame (center_of / face_on / edge_on)" begin
 

--- a/test/48_mockobs_tests.jl
+++ b/test/48_mockobs_tests.jl
@@ -9,7 +9,7 @@
 
 using Random
 
-const MO_PATH = joinpath(SIMULATION_PATH, "spiral_clumps")
+const MO_PATH = joinpath(SIMULATION_PATH, "RAMSES/spiral_clumps")
 
 @testset "mock observations" begin
 

--- a/test/49_statistics_tests.jl
+++ b/test/49_statistics_tests.jl
@@ -6,7 +6,7 @@
 #   PART B (data-backed) — density PDF of spiral_clumps (mass vs volume weighting).
 # ============================================================================
 
-const ST_PATH = joinpath(SIMULATION_PATH, "spiral_clumps")
+const ST_PATH = joinpath(SIMULATION_PATH, "RAMSES/spiral_clumps")
 
 @testset "pdf (statistics)" begin
 
@@ -93,7 +93,7 @@ else
 end
 
 # pdf is generic over data types — particles and RT live in other fixtures
-let pp = joinpath(SIMULATION_PATH, "spiral_ugrid")
+let pp = joinpath(SIMULATION_PATH, "RAMSES/spiral_ugrid")
     if DATA_AVAILABLE && isdir(pp)
         @testset "particles" begin
             part = getparticles(getinfo(1, pp, verbose=false), verbose=false, show_progress=false)
@@ -101,7 +101,7 @@ let pp = joinpath(SIMULATION_PATH, "spiral_ugrid")
         end
     end
 end
-let rp = joinpath(SIMULATION_PATH, "rt_stromgren")
+let rp = joinpath(SIMULATION_PATH, "RAMSES/rt_stromgren")
     if DATA_AVAILABLE && isdir(rp)
         @testset "RT" begin
             rt = getrt(getinfo(4, rp, verbose=false), verbose=false, show_progress=false)

--- a/test/50_provenance_tests.jl
+++ b/test/50_provenance_tests.jl
@@ -9,7 +9,7 @@
 
 using Dates
 
-const PV_PATH = joinpath(SIMULATION_PATH, "spiral_clumps")
+const PV_PATH = joinpath(SIMULATION_PATH, "RAMSES/spiral_clumps")
 
 @testset "provenance" begin
 
@@ -80,7 +80,7 @@ else
 end
 
 # cosmological snapshot → redshift comes through
-let cp = joinpath(SIMULATION_PATH, "yt_cosmo")
+let cp = joinpath(SIMULATION_PATH, "RAMSES/yt_cosmo")
     if DATA_AVAILABLE && isdir(cp)
         @testset "cosmological snapshot → redshift" begin
             ic = getinfo(80, cp, verbose=false)

--- a/test/51_movie_tests.jl
+++ b/test/51_movie_tests.jl
@@ -6,7 +6,7 @@
 #   PART B (data-backed) — frames from the 3-D Sedov series + GIF round-trip.
 # ============================================================================
 
-const MV_PATH = joinpath(SIMULATION_PATH, "timeseries_sedov3d")
+const MV_PATH = joinpath(SIMULATION_PATH, "RAMSES/timeseries_sedov3d")
 
 @testset "getmovie / savemovie" begin
 

--- a/test/52_pluto_reader_tests.jl
+++ b/test/52_pluto_reader_tests.jl
@@ -9,8 +9,8 @@
 #           convention, and confirm getvar/projection/pdf work unchanged.
 # ============================================================================
 
-const PL_PATH = joinpath(SIMULATION_PATH, "pluto_sedov3d")
-const CH_PATH = joinpath(SIMULATION_PATH, "chombo_3d", "IsothermalSphere")
+const PL_PATH = joinpath(SIMULATION_PATH, "PLUTO/pluto_sedov3d")
+const CH_PATH = joinpath(SIMULATION_PATH, "CHOMBO/chombo_3d", "IsothermalSphere")
 
 @testset "PLUTO reader" begin
 

--- a/test/53_overlay_absorption_tests.jl
+++ b/test/53_overlay_absorption_tests.jl
@@ -6,8 +6,8 @@
 # on the Chombo AMR fixture for the multi-level case.
 # ============================================================================
 
-const OA_PATH = joinpath(SIMULATION_PATH, "spiral_clumps")
-const OA_CHOMBO = joinpath(SIMULATION_PATH, "chombo_3d", "IsothermalSphere")
+const OA_PATH = joinpath(SIMULATION_PATH, "RAMSES/spiral_clumps")
+const OA_CHOMBO = joinpath(SIMULATION_PATH, "CHOMBO/chombo_3d", "IsothermalSphere")
 
 @testset "gridoverlay + absorption_map" begin
 

--- a/test/57_athena_reader_tests.jl
+++ b/test/57_athena_reader_tests.jl
@@ -100,7 +100,7 @@ end
 
     @testset "self-gravity potential maps to :gpot (code-blind gravity-as-field)" begin
         @test Mera._ATHENA_VARMAP["phi"] == :gpot                  # Athena `phi` → canonical :gpot
-        sg = joinpath(SIMULATION_PATH, "athena_selfgravity")       # small multigrid Jeans run
+        sg = joinpath(SIMULATION_PATH, "ATHENA/athena_selfgravity")       # small multigrid Jeans run
         if isdir(sg) && any(f -> endswith(lowercase(f), ".athdf"), readdir(sg))
             info = getinfo(2, sg, verbose=false)
             @test :gpot in info.variable_list
@@ -116,7 +116,7 @@ end
         @test Mera._ATHENA_VARMAP["rH"] == :xHI && Mera._ATHENA_VARMAP["rH2"] == :xH2
         @test Mera._ATHENA_VARMAP["rCO"] == :xCO && Mera._ATHENA_VARMAP["rH+"] == :xHII
         @test Mera._ATHENA_VARMAP["Er"] == :Erad            # RT-transport field naming (framework)
-        ch = joinpath(SIMULATION_PATH, "athena_chemistry")  # small H–H2 chemistry run
+        ch = joinpath(SIMULATION_PATH, "ATHENA/athena_chemistry")  # small H–H2 chemistry run
         if isdir(ch) && any(f -> endswith(lowercase(f), ".athdf"), readdir(ch))
             info = getinfo(5, ch, verbose=false)
             @test :xHI in info.variable_list && :xH2 in info.variable_list   # rH/rH2 → canonical
@@ -133,7 +133,7 @@ end
     @testset "six-ray RT: radiation bins → photon groups, gow17 species (code-blind)" begin
         @test Mera._ATHENA_VARMAP["ir_avg0"] == :Np1 && Mera._ATHENA_VARMAP["ir_avg7"] == :Np8
         @test Mera._ATHENA_VARMAP["rCO"] == :xCO && Mera._ATHENA_VARMAP["rC+"] == :xCII   # gow17 set
-        sr = joinpath(SIMULATION_PATH, "athena_sixray")     # gow17 + six-ray PDR (24 fields, evolving)
+        sr = joinpath(SIMULATION_PATH, "ATHENA/athena_sixray")     # gow17 + six-ray PDR (24 fields, evolving)
         if isdir(sr) && any(f -> endswith(lowercase(f), ".athdf"), readdir(sr))
             info = getinfo(5, sr, verbose=false)
             @test all(g -> g in info.variable_list, (:Np1, :Np8))           # 8 radiation photon groups
@@ -151,7 +151,7 @@ end
     # PART B (data-backed): a REAL Athena++ snapshot — the yt AM06 sample (Cartesian AMR MHD).
     # Download AM06.tar.gz from yt-project.org/data into MERA_TEST_DATA/athena_AM06/.
     @testset "real Athena++ snapshot — yt AM06 (data-backed)" begin
-        am06 = joinpath(SIMULATION_PATH, "athena_AM06", "AM06")
+        am06 = joinpath(SIMULATION_PATH, "ATHENA/athena_AM06", "AM06")
         if isdir(am06) && any(f -> endswith(lowercase(f), ".athdf"), readdir(am06))
             info = getinfo(400, am06, verbose=false)            # auto-detect from the .athdf file
             @test info.simcode == "Athena++"

--- a/test/58_flash_reader_tests.jl
+++ b/test/58_flash_reader_tests.jl
@@ -92,7 +92,7 @@ end
 
     # PART B (data-backed): the real yt GasSloshing FLASH sample (3-D AMR, CGS).
     @testset "real FLASH snapshot — yt GasSloshing (data-backed)" begin
-        gd = joinpath(SIMULATION_PATH, "flash_gassloshing", "GasSloshing")
+        gd = joinpath(SIMULATION_PATH, "FLASH/flash_gassloshing", "GasSloshing")
         if isdir(gd) && any(f -> occursin("_hdf5_plt_cnt_", f), readdir(gd))
             info = getinfo(150, gd, verbose=false)              # auto-detect (extensionless file)
             @test info.simcode == "FLASH"

--- a/test/60_gadget_reader_tests.jl
+++ b/test/60_gadget_reader_tests.jl
@@ -290,7 +290,7 @@ end
 
     # PART B (data-backed): the real yt GadgetDiskGalaxy sample.
     @testset "real GADGET snapshot — yt GadgetDiskGalaxy (data-backed)" begin
-        gd = joinpath(SIMULATION_PATH, "gadget_diskgalaxy", "GadgetDiskGalaxy")
+        gd = joinpath(SIMULATION_PATH, "GADGET/gadget_diskgalaxy", "GadgetDiskGalaxy")
         if isdir(gd) && any(f -> endswith(lowercase(f), ".hdf5"), readdir(gd))
             info = getinfo(200, gd, verbose=false)                    # auto-detect
             @test info.simcode == "GADGET" && info.particles
@@ -307,13 +307,13 @@ end
             @test length(sub.data) == count((lo .<= x .<= hi) .& (lo .<= y .<= hi) .& (lo .<= z .<= hi))
             @test 0 < length(sub.data) < length(stars.data) && sub.ranges != [0., 1., 0., 1., 0., 1.]
         else
-            @test_skip "GadgetDiskGalaxy fixture not present (MERA_TEST_DATA/gadget_diskgalaxy/)"
+            @test_skip "GadgetDiskGalaxy fixture not present (MERA_TEST_DATA/GADGET/gadget_diskgalaxy/)"
         end
     end
 
     # PART C (data-backed): real AREPO/TNG snapshots — gas-cell physics (Phase 1a).
     @testset "real AREPO/TNG snapshots — gas fields (data-backed)" begin
-        tng = joinpath(SIMULATION_PATH, "arepo", "TNGHalo", "TNGHalo", "halo_59.hdf5")
+        tng = joinpath(SIMULATION_PATH, "AREPO", "TNGHalo", "TNGHalo", "halo_59.hdf5")
         if isfile(tng)
             info = getinfo_gadget(59, tng, verbose=false)
             @test info.simcode == "AREPO" && info.particles                     # detected from the Config group
@@ -328,10 +328,10 @@ end
             @test 1e3 < sort(T)[length(T) ÷ 2] < 1e9                            # median in the warm/hot range
             @test msum(gas) > 0
         else
-            @test_skip "TNGHalo fixture not present (MERA_TEST_DATA/arepo/TNGHalo/)"
+            @test_skip "TNGHalo fixture not present (MERA_TEST_DATA/AREPO/TNGHalo/)"
         end
 
-        bullet = joinpath(SIMULATION_PATH, "arepo", "ArepoBullet", "ArepoBullet", "snapshot_150.hdf5")
+        bullet = joinpath(SIMULATION_PATH, "AREPO", "ArepoBullet", "ArepoBullet", "snapshot_150.hdf5")
         if isfile(bullet)
             info = getinfo_gadget(150, bullet, verbose=false)
             @test info.scale.g_cm3 != 1.0
@@ -345,7 +345,7 @@ end
             @test length(gas.data) > 0
             @test all(isfinite, getvar(gas, :T)) && all(getvar(gas, :volume) .> 0)
         else
-            @test_skip "ArepoBullet fixture not present (MERA_TEST_DATA/arepo/ArepoBullet/)"
+            @test_skip "ArepoBullet fixture not present (MERA_TEST_DATA/AREPO/ArepoBullet/)"
         end
     end
 end

--- a/test/test_config.jl
+++ b/test/test_config.jl
@@ -33,7 +33,7 @@ end
 const DATASETS = Dict(
     # Primary test dataset - has hydro, gravity, clumps, cooling (4 CPUs, L3-L7)
     :spiral_clumps => (
-        path = joinpath(SIMULATION_PATH, "spiral_clumps"),
+        path = joinpath(SIMULATION_PATH, "RAMSES/spiral_clumps"),
         output = 100,
         has_hydro = true,
         has_gravity = true,
@@ -42,7 +42,7 @@ const DATASETS = Dict(
     ),
     # Uniform grid simulation with particles - good for projection tests
     :spiral_ugrid => (
-        path = joinpath(SIMULATION_PATH, "spiral_ugrid"),
+        path = joinpath(SIMULATION_PATH, "RAMSES/spiral_ugrid"),
         output = 1,
         has_hydro = true,
         has_gravity = true,
@@ -51,7 +51,7 @@ const DATASETS = Dict(
     ),
     # Milky Way simulation - multi-CPU for parallelization tests
     :mw_L10 => (
-        path = joinpath(SIMULATION_PATH, "mw_L10"),
+        path = joinpath(SIMULATION_PATH, "RAMSES/mw_L10"),
         output = 300,
         has_hydro = false,
         has_gravity = false,
@@ -61,7 +61,7 @@ const DATASETS = Dict(
     # Star formation simulation with clumps and *legacy-format* particles
     # (RAMSES output without part_file_descriptor.txt → pversion = 0)
     :manu_sf => (
-        path = joinpath(SIMULATION_PATH, "manu_sim_sf_L14"),
+        path = joinpath(SIMULATION_PATH, "RAMSES/manu_sim_sf_L14"),
         output = 400,
         has_hydro = false,
         has_gravity = false,
@@ -70,7 +70,7 @@ const DATASETS = Dict(
     ),
     # Simulation with gravity data
     :mlike => (
-        path = joinpath(SIMULATION_PATH, "mlike"),
+        path = joinpath(SIMULATION_PATH, "RAMSES/mlike"),
         output = 500,
         has_hydro = false,
         has_gravity = true,
@@ -79,7 +79,7 @@ const DATASETS = Dict(
     ),
     # Stable disk simulation with particles
     :manu_stable => (
-        path = joinpath(SIMULATION_PATH, "manu_stable_2019"),
+        path = joinpath(SIMULATION_PATH, "RAMSES/manu_stable_2019"),
         output = 1,
         has_hydro = true,
         has_gravity = false,
@@ -90,7 +90,7 @@ const DATASETS = Dict(
     # cosmological run in the suite; used to exercise the cosmology accessors.
     # z ≈ 0.143 (aexp ≈ 0.875), H0 = 70.3, Ωm = 0.276, ΩΛ = 0.724, flat (Ωk = 0).
     :yt_cosmo => (
-        path = joinpath(SIMULATION_PATH, "yt_cosmo"),
+        path = joinpath(SIMULATION_PATH, "RAMSES/yt_cosmo"),
         output = 80,
         has_hydro = true,
         has_gravity = false,
@@ -102,7 +102,7 @@ const DATASETS = Dict(
     # the ionization fractions are passive hydro scalars located via the RT
     # descriptor (info_rt → iIons). Used to exercise getrt/RT getvar/projection.
     :rt_stromgren => (
-        path = joinpath(SIMULATION_PATH, "rt_stromgren"),
+        path = joinpath(SIMULATION_PATH, "RAMSES/rt_stromgren"),
         output = 4,
         has_hydro = true,
         has_gravity = false,
@@ -116,7 +116,7 @@ const DATASETS = Dict(
     # face-centred B components give cell-centred :bx/:by/:bz = ½(left+right).
     # Download: https://yt-project.org/data/ramses_mhd_128.tar.gz (extract output_00027 here)
     :ramses_mhd => (
-        path = joinpath(SIMULATION_PATH, "ramses_mhd_128"),
+        path = joinpath(SIMULATION_PATH, "RAMSES/ramses_mhd_128"),
         output = 27,
         has_hydro = true,
         has_gravity = false,
@@ -129,7 +129,7 @@ const DATASETS = Dict(
     # no-descriptor MHD heuristic on the AMR (not uniform-grid) reader path.
     # Download: https://yt-project.org/data/ramses_mhd_amr.tar.gz (extract output_00019 here)
     :ramses_mhd_amr => (
-        path = joinpath(SIMULATION_PATH, "ramses_mhd_amr"),
+        path = joinpath(SIMULATION_PATH, "RAMSES/ramses_mhd_amr"),
         output = 19,
         has_hydro = true,
         has_gravity = false,
@@ -142,8 +142,8 @@ const DATASETS = Dict(
     # `timeseries_sedov3d_mera` holds the same outputs converted to mera (.jld2) files,
     # so both the RAMSES and mera-file code paths are exercised.
     :timeseries_sedov3d => (
-        path = joinpath(SIMULATION_PATH, "timeseries_sedov3d"),
-        mera_path = joinpath(SIMULATION_PATH, "timeseries_sedov3d_mera"),
+        path = joinpath(SIMULATION_PATH, "RAMSES/timeseries_sedov3d"),
+        mera_path = joinpath(SIMULATION_PATH, "MERA-FILES/timeseries_sedov3d_mera"),
         output = 1,
         has_hydro = true,
         has_gravity = false,
@@ -156,7 +156,7 @@ const DATASETS = Dict(
     # the multi-code reader: getinfo_pluto/gethydro_pluto fill the standard structs so the
     # analysis layer (getvar/projection/pdf) runs unchanged. (52_pluto_reader_tests.jl)
     :pluto_sedov3d => (
-        path = joinpath(SIMULATION_PATH, "pluto_sedov3d"),
+        path = joinpath(SIMULATION_PATH, "PLUTO/pluto_sedov3d"),
         output = 5,
         has_hydro = true,
         has_gravity = false,
@@ -169,7 +169,7 @@ const DATASETS = Dict(
     # density/momentum/energy → derived velocity/pressure). Exercises the multi-level leaf-cell
     # reader. (Chombo section of 52_pluto_reader_tests.jl)
     :chombo_3d => (
-        path = joinpath(SIMULATION_PATH, "chombo_3d", "IsothermalSphere"),
+        path = joinpath(SIMULATION_PATH, "CHOMBO/chombo_3d", "IsothermalSphere"),
         output = 0,
         has_hydro = true,
         has_gravity = false,


### PR DESCRIPTION
The external test-data drive (`MERA_TEST_DATA`) is reorganised **by simulation code** so fixtures are identifiable at a glance instead of a flat 39-entry list:

```
Mera-Tests/
├── RAMSES/      mw_L10 · manu_sim_sf_L14 · manu_stable_2019 · mlike · gd_L14 · AV5CDhr ·
│                L13_SN5_CD_only · ramses_mhd_128 · ramses_mhd_amr · rt_stromgren ·
│                spiral_clumps · spiral_ugrid · timeseries_sedov3d · yt_cosmo · caligo_cloud
├── AREPO/       TNGHalo · ArepoBullet
├── GADGET/      gadget_diskgalaxy
├── PLUTO/       pluto_sedov3d · pluto_KH
├── CHOMBO/      chombo_3d
├── ATHENA/      athena_AM06 · athena_blast · athena_chemistry · athena_selfgravity · athena_sixray
├── FLASH/       flash_gassloshing
├── MERA-FILES/  JLD2_complete · JLD2_files · timeseries_sedov3d_mera · rt_stromgren_mera
├── _archives/   simulation_clumps.tar · simulation_ugrid.tar
└── benchmarks/
```

Every old top-level name is preserved as a **backward-compat symlink** on the drive, so old absolute paths (e.g. in the tutorial notebooks) keep working — this PR relinks the in-repo references to the new canonical paths for clarity.

**Changes:** every `joinpath(SIMULATION_PATH, …)` in `test_config.jl` (the `DATASETS` dict) and the per-reader tests now carries its code-dir prefix. `arepo/` was *renamed* to `AREPO/` (it already grouped the two AREPO sims), so the substitution is `"arepo" → "AREPO"`, not nested.

**Verified** against the reorganised drive: GADGET `GadgetDiskGalaxy` 7/7, AREPO/TNG gas fields 14/14, PLUTO/Chombo readers all pass (data actually loaded, not skipped).

Notebooks are intentionally left on the symlinks and will be relinked separately when re-committed.