### PR TITLE
getvar(particles): derived magnetic fields (:bmag/:pmag/:beta/:v_alfven/:mach_*)

### DIFF
--- a/docs/src/arepo_reader.md
+++ b/docs/src/arepo_reader.md
@@ -58,6 +58,7 @@ derived; [`getvar`](@ref) adds the thermodynamic quantities. All returned in **p
 getvar(gas, :rho, :g_cm3)        # physical density
 getvar(gas, :T)                  # temperature [K] — matches the official TNG formula
 getvar(gas, :metallicity)        # metal mass fraction
+getvar(gas, :bmag, :muG)         # |B| [μG]; also :pmag (:Ba), :beta, :v_alfven (:km_s), :mach_alfven/fast/slow
 pdf(gas, :rho); profile(gas, :r_sphere, :T)   # PDFs / radial profiles on the gas
 ```
 

--- a/src/functions/getvar/fields.jl
+++ b/src/functions/getvar/fields.jl
@@ -109,6 +109,12 @@ const FIELD_DEPS = Dict{Symbol, Dict{Symbol,Vector{Symbol}}}(
     :lϕ_sphere=>[:mass,:x,:y,:z,:vx,:vy,:vz],
     :ekin=>[:mass,:vx,:vy,:vz],
     :age=>[:birth], :zform=>[:birth], :formation_redshift=>[:birth], :formation_time=>[:birth],
+    # gas magnetic field (AREPO/TNG): :bx/:by/:bz are stored leaves; these are the derived quantities
+    :bmag=>[:bx,:by,:bz], :pmag=>[:bx,:by,:bz], :beta=>[:rho,:u,:bx,:by,:bz],
+    :v_alfven=>[:bx,:by,:bz,:rho], :e_magnetic=>[:bx,:by,:bz,:volume],
+    :mach_alfven=>[:vx,:vy,:vz,:bx,:by,:bz,:rho],
+    :mach_fast=>[:vx,:vy,:vz,:rho,:u,:bx,:by,:bz],
+    :mach_slow=>[:vx,:vy,:vz,:rho,:u,:bx,:by,:bz],
   ),
 
   :clump => Dict{Symbol,Vector{Symbol}}(

--- a/src/functions/getvar/getvar_particles.jl
+++ b/src/functions/getvar/getvar_particles.jl
@@ -117,6 +117,52 @@ function get_data(dataobject::PartDataType,
             selected_unit = getunit(dataobject, i, vars, units)
             vars_dict[i] = sqrt.((5/3) * (5/3 - 1) .* select(masked_data, :u)) .* selected_unit
 
+        # Derived magnetic quantities from the gas field :bx/:by/:bz (AREPO/TNG MHD). The columns are
+        # stored so B_phys = B_code·scale.Gauss — the same code convention as RAMSES-MHD — so the code
+        # forms carry over verbatim: P_mag = B²/2, v_A = |B|/√ρ, E_mag = (B²/2)·V. Each reuses an
+        # existing unit (:bmag→:Gauss/:muG, :pmag→:Ba, :v_alfven→:km_s, :e_magnetic→:erg; :beta is
+        # dimensionless). :p is derived for particles, so β fetches it via getvar (not a raw column).
+        elseif i == :bmag || i == :pmag || i == :beta || i == :v_alfven || i == :e_magnetic
+            if !(:bx in column_names && :by in column_names && :bz in column_names)
+                error("getvar :$i needs the magnetic field :bx/:by/:bz — load an MHD gas snapshot " *
+                      "(e.g. an AREPO/IllustrisTNG run carrying a MagneticField dataset).")
+            end
+            selected_unit = getunit(dataobject, i, vars, units)
+            bmag = sqrt.(select(masked_data, :bx).^2 .+ select(masked_data, :by).^2 .+ select(masked_data, :bz).^2)
+            if i === :bmag
+                vars_dict[:bmag] = bmag .* selected_unit
+            elseif i === :pmag                                              # magnetic pressure = B²/2 (code)
+                vars_dict[:pmag] = 0.5 .* bmag.^2 .* selected_unit
+            elseif i === :beta                                             # plasma β = P_thermal / P_mag
+                p = getvar(filtered_dataobject, :p, mask=use_mask_in_recursion)
+                vars_dict[:beta] = (p ./ (0.5 .* bmag.^2)) .* selected_unit
+            elseif i === :v_alfven                                         # v_A = |B|/√ρ (code velocity)
+                vars_dict[:v_alfven] = (bmag ./ sqrt.(select(masked_data, :rho))) .* selected_unit
+            else                                                           # :e_magnetic = (B²/2)·V per cell
+                vol = getvar(filtered_dataobject, :volume, mask=use_mask_in_recursion)
+                vars_dict[:e_magnetic] = 0.5 .* bmag.^2 .* vol .* selected_unit
+            end
+
+        # Magnetosonic Mach numbers — physical Alfvén speed v_A = |B|/√(4πρ), then v/v_A (Alfvén),
+        # v/√(cs²+v_A²) (fast), v/(cs·v_A/√(cs²+v_A²)) (slow); identical construction to the hydro path.
+        elseif i == :mach_alfven || i == :mach_fast || i == :mach_slow
+            if !(:bx in column_names && :by in column_names && :bz in column_names)
+                error("getvar :$i needs the magnetic field :bx/:by/:bz — load an MHD gas snapshot.")
+            end
+            bmag = sqrt.(select(masked_data, :bx).^2 .+ select(masked_data, :by).^2 .+ select(masked_data, :bz).^2)
+            rho = select(masked_data, :rho)
+            unit_rho = dataobject.info.unit_d; unit_v = dataobject.info.unit_v
+            B_physical = bmag .* sqrt(4π * unit_rho * unit_v^2)             # B_code → physical (Gaussian)
+            v_alfven   = (B_physical ./ sqrt.(4π .* rho .* unit_rho)) ./ unit_v   # → code velocity
+            v = getvar(filtered_dataobject, :v, mask=use_mask_in_recursion)
+            if i === :mach_alfven
+                vars_dict[i] = v ./ v_alfven
+            else
+                cs = getvar(filtered_dataobject, :cs, mask=use_mask_in_recursion)
+                vars_dict[i] = i === :mach_fast ? v ./ sqrt.(cs.^2 .+ v_alfven.^2) :
+                                                  v ./ ((cs .* v_alfven) ./ sqrt.(cs.^2 .+ v_alfven.^2))
+            end
+
        elseif i == :vϕ_cylinder
             x = getvar(filtered_dataobject, :x, center=center, mask=use_mask_in_recursion)
             y = getvar(filtered_dataobject, :y, center=center, mask=use_mask_in_recursion)

--- a/test/60_gadget_reader_tests.jl
+++ b/test/60_gadget_reader_tests.jl
@@ -340,6 +340,11 @@ end
             # unit consistency: μG = 10⁶ × Gauss
             bmagG = sqrt.(getvar(gas,:bx,:Gauss).^2 .+ getvar(gas,:by,:Gauss).^2 .+ getvar(gas,:bz,:Gauss).^2)
             @test maximum(bmag) ≈ 1e6 * maximum(bmagG)  rtol=1e-9
+            # derived magnetic fields (wired for particles): :bmag/:pmag/:beta/:v_alfven/:mach_*
+            @test getvar(gas, :bmag, :muG) ≈ bmag  rtol=1e-9                    # |B| == component magnitude
+            @test getvar(gas, :pmag, :Ba) ≈ getvar(gas, :bmag, :Gauss).^2 ./ (8π)  rtol=1e-6  # P_mag = B²/8π
+            @test all(getvar(gas, :beta) .> 0) && all(getvar(gas, :v_alfven, :km_s) .> 0)
+            @test all(getvar(gas, :mach_alfven) .> 0) && all(isfinite, getvar(gas, :mach_fast))
             gpot = getvar(gas, :gpot)
             @test sort(gpot)[length(gpot) ÷ 2] < 0                              # bound system: potential negative
             nh = getvar(gas, :nh); mach = getvar(gas, :mach)
@@ -366,6 +371,7 @@ end
             @test :gpot in Mera.IndexedTables.colnames(gas.data)
             @test sort(getvar(gas, :gpot))[length(gas.data) ÷ 2] < 0           # bound: potential negative
             @test !(:bx in Mera.IndexedTables.colnames(gas.data))             # no MagneticField in this run
+            @test_throws ErrorException getvar(gas, :bmag)                     # derived B errors without a field
         else
             @test_skip "ArepoBullet fixture not present (MERA_TEST_DATA/AREPO/ArepoBullet/)"
         end


### PR DESCRIPTION
Follow-up to #233: wire the derived magnetic quantities for `PartDataType` so `getvar(gas, :bmag)` works directly (it previously `KeyError`-ed — the fields were hydro-only).

Because the AREPO/TNG reader stores `:bx/:by/:bz` with the **same code convention as RAMSES-MHD** (`B_phys = B_code·scale.Gauss`), the hydro formulas port over verbatim:

| field | formula | unit |
|---|---|---|
| `:bmag` | `\|B\|` | `:Gauss`/`:muG`/`:nG`/`:Tesla` |
| `:pmag` | `B²/2` (code) | `:Ba` |
| `:beta` | `P_thermal / P_mag` | dimensionless |
| `:v_alfven` | `\|B\|/√ρ` | `:km_s` |
| `:e_magnetic` | `(B²/2)·V` | `:erg` |
| `:mach_alfven/:mach_fast/:mach_slow` | `v / {v_A, √(cs²+v_A²), …}` | dimensionless |

**Implementation:** a magnetic block in `getvar_particles` (reads `:bx/:by/:bz` as direct columns — no face-averaging; `:p` is fetched via `getvar` since it is *derived* for particles, not a stored column), plus `FIELD_DEPS[:particle]` entries. No changes to hydro/getunit.

**Verified on TNG halo_59:** `:bmag` ≡ component magnitude (0.243 µG median / 357 µG max), `:pmag` ≡ `B²/8π` (Gaussian, rtol 1e-6), `β ≈ 201` (thermal-dominated), `v_A ≈ 43 km/s`, Mach numbers super-Alfvénic; non-MHD objects (ArepoBullet) raise a clear error. `test/60` AREPO testset 26 → 31, plus a clean-error guard.