### PR TITLE
test: skip particle magnetic fields in FIELD_DEPS compute-branch guard

### DIFF
--- a/test/37_derived_fields_tests.jl
+++ b/test/37_derived_fields_tests.jl
@@ -133,7 +133,9 @@
                                   :bmag, :pmag, :beta, :v_alfven, :e_magnetic,# need magnetic field
                                   :mach_alfven, :mach_fast, :mach_slow]),     # need magnetic field
                 :gravity  => Set{Symbol}(),
-                :particle => Set([:formation_redshift, :formation_time, :zform]),  # cosmological only
+                :particle => Set([:formation_redshift, :formation_time, :zform,    # cosmological only
+                                  :bmag, :pmag, :beta, :v_alfven, :e_magnetic,     # need magnetic field (AREPO/TNG gas)
+                                  :mach_alfven, :mach_fast, :mach_slow]),
             )
             for (kind, obj) in [(:hydro, gas), (:gravity, grav), (:particle, part)]
                 for k in keys(Mera.FIELD_DEPS[kind])


### PR DESCRIPTION
Full-suite regression sweep after the GADGET/AREPO MHD work (#233/#234) surfaced **one real regression**, fixed here.

`test/37` (`every registered FIELD_DEPS field has a working compute branch`) iterates every `FIELD_DEPS` field and asserts it computes on a plain RAMSES fixture, with an explicit per-type **skip-set** for fields that legitimately need data the fixture lacks (cosmology, magnetic field — the hydro magnetic fields are already listed). #234 registered the particle magnetic fields in `FIELD_DEPS[:particle]`, but the RAMSES particle fixture has no `MagneticField`, so `getvar(:bmag)` correctly errors. Adds the eight particle magnetic fields (`:bmag/:pmag/:beta/:v_alfven/:e_magnetic/:mach_alfven/:mach_fast/:mach_slow`) to the `:particle` skip-set, mirroring `:hydro`.

Verified: `test/37` 105/105 in isolation.

**Sweep result (full data suite, 55 files):** 4910 passed · **1 regression (this) fixed** · 3 intentional `@test_broken`. The remaining 12 "errors" (test/07 ×2, test/46 ×10) are **pre-existing full-suite namespace collisions** (`GeometryBasics.Sphere` vs `Mera.Sphere`; a `timeseries` shadow from accumulated `using` across files) — both files **pass cleanly in isolation**, so they are test-isolation artifacts, not logic bugs, and unrelated to this session. Tracked separately.