### PR TITLE
test: resolve full-suite namespace collisions (Sphere/timeseries vs CairoMakie)

### DIFF
--- a/test/07_regions.jl
+++ b/test/07_regions.jl
@@ -74,6 +74,11 @@
 #
 # If DATA_AVAILABLE is false the whole file is skipped via @test_skip.
 
+# Explicit import: in the full suite an earlier figure test loads CairoMakie, which re-exports
+# `Sphere`/`Cylinder` from GeometryBasics and would shadow Mera's region types. The explicit
+# `using` overrides that ambiguity so bare `Sphere(...)`/`Cylinder(...)` resolve to Mera's here.
+using Mera: Sphere, Cylinder
+
 if !DATA_AVAILABLE
     @warn "Skipping Region Operations tests - simulation data not available"
     @test_skip "Simulation data not available"

--- a/test/46_timeseries_tests.jl
+++ b/test/46_timeseries_tests.jl
@@ -14,6 +14,11 @@
 # Fully-qualified accessor so the test needs only `using Mera`.
 _cols(t) = Mera.IndexedTables.columns(t)
 
+# Explicit import: in the full suite an earlier figure test loads CairoMakie, which also exports
+# `timeseries` (a Makie recipe) and would shadow Mera's function. The explicit `using` overrides
+# that ambiguity so bare `timeseries(...)` resolves to Mera's here.
+using Mera: timeseries
+
 const TS_RAMSES = joinpath(SIMULATION_PATH, "RAMSES/timeseries_sedov3d")
 const TS_MERA   = joinpath(SIMULATION_PATH, "MERA-FILES/timeseries_sedov3d_mera")
 const RT_RAMSES = joinpath(SIMULATION_PATH, "RAMSES/rt_stromgren")


### PR DESCRIPTION
Cleanup of the pre-existing full-suite failures the regression sweep surfaced (the 12 "errors" beyond the #235 fix).

**Root cause (confirmed):** the figure tests (38/39/43) load **CairoMakie**, which re-exports both `Sphere`/`Cylinder` (from GeometryBasics) **and** `timeseries` (a Makie plotting recipe). Once loaded, those shadow `Mera.Sphere`/`Mera.Cylinder`/`Mera.timeseries` in `Main`, so later data-backed tests using the bare names hit `UndefVarError`/ambiguity:
- `test/07_regions` ×2 (`Sphere`/`Cylinder`)
- `test/46_timeseries` ×10 (`timeseries`)

Both pass **in isolation**, and CI never runs them (`MERA_SMOKE_ONLY=1` skips data tests), so this was invisible until a full local data run. `isdefined(CairoMakie, :Sphere)` and `isdefined(CairoMakie, :timeseries)` are both `true`, confirming the source.

**Fix:** explicit `using Mera: Sphere, Cylinder` / `using Mera: timeseries` at the top of each file — an explicit import overrides the implicit `using` ambiguity (standard Julia resolution).

**Verified:** loading CairoMakie *before* including both files (reproducing the full-suite condition) now yields **137/137 pass** (previously errored). Together with #235, the full local data suite is green.