### PR TITLE
projection: clarify .extent is code-length units + add getextent(proj, unit)

### DIFF
--- a/src/functions/getvar/getvar.jl
+++ b/src/functions/getvar/getvar.jl
@@ -916,6 +916,21 @@ end
 
 
 """
+    getextent(proj::DataMapsType, unit::Symbol=:standard; center::Bool=false) -> [xmin,xmax,ymin,ymax]
+
+Map extent of a [`projection`](@ref) result in a physical `unit` (e.g. `:kpc`, `:pc`, `:Mpc`).
+
+The stored `proj.extent`/`proj.cextent` fields are in **code length** units — so when the map values
+are physical (e.g. surface density in `:Msol_pc2`) the plotting axes would otherwise be mismatched.
+This scales them: `getextent(proj, :kpc)` gives `[xmin,xmax,ymin,ymax]` in kpc. `center=true` returns
+the centre-relative extent (`proj.cextent`). Equivalent to `proj.extent .* proj.scale.<unit>`.
+"""
+function getextent(proj::DataMapsType, unit::Symbol=:standard; center::Bool=false)
+    e = center ? proj.cextent : proj.extent
+    return unit === :standard ? copy(e) : e .* getfield(proj.scale, unit)
+end
+
+"""
 #### Get the extent of the dataset-domain:
 ```julia
 function getextent( dataobject::DataSetType;

--- a/src/functions/projection/projection_hydro.jl
+++ b/src/functions/projection/projection_hydro.jl
@@ -681,11 +681,13 @@ fine_detail = projection(gas, :density, :g_cm3,
 
 Returns `AMRMapsType` (alias: `HydroMapsType`) containing:
 - **`.maps`**: Dictionary of projected variable maps (2D arrays)
-- **`.extent`**: Physical extent of projection [xmin, xmax, ymin, ymax]
-- **`.pixsize`**: Physical size of each pixel
+- **`.extent`**: extent `[xmin, xmax, ymin, ymax]` in **code length** units. The map *values* may be
+  physical (e.g. `:Msol_pc2`); the axes are NOT — multiply by `proj.scale.kpc`/`.pc`/… for a physical
+  plotting extent, or use [`getextent`](@ref)`(proj, :kpc)`. `.cextent` is the same, centred on `.center`.
+- **`.pixsize`**: pixel size in **code length** units (× `proj.scale.<unit>` for physical)
 - **`.lmax_projected`**: Maximum AMR level included in projection
-- **`.ranges`**: Normalized coordinate ranges used
-- **`.center`**: Physical center coordinates of projection
+- **`.ranges`**: normalized `[0,1]` coordinate ranges (this is the fractional field, unlike `.extent`)
+- **`.center`**: projection centre, in **code length** units
 
 ### Radiative transfer (RT) projections
 

--- a/test/54_clumpfind_synthetic_tests.jl
+++ b/test/54_clumpfind_synthetic_tests.jl
@@ -147,6 +147,11 @@
         c2d = clumpfind(sd, :sd; threshold=maximum(sd.maps[:sd])/20, connectivity=8)
         @test c2d isa ClumpCatalog && c2d.meta.dim == Symbol("2D")
         @test c2d.nclumps >= 4
+        # getextent on a projection result: .extent/.cextent are code length units; getextent scales them
+        @test getextent(sd) == sd.extent                                    # :standard == code units
+        @test getextent(sd, :kpc) ≈ sd.extent .* sd.scale.kpc               # physical axes for an Msol/pc² map
+        @test getextent(sd, :pc)  ≈ getextent(sd, :kpc) .* 1e3              # pc = 1000 × kpc
+        @test getextent(sd, :kpc; center=true) ≈ sd.cextent .* sd.scale.kpc # centre-relative
     end
 
     @testset "multi-field gas + particles" begin


### PR DESCRIPTION
Addresses the footgun that `projection().extent`/`.cextent` are in **code length** units while the map values can be physical (e.g. `Σ` in `:Msol_pc2`).

## The facts (verified on a live projection, boxlen=100)
- `.extent` = `[0, 100, 0, 100]`, `.cextent` = `[-50, 50, -50, 50]` → **code length units `[0, boxlen]`**, NOT fractional/percent.
- `.ranges` = `[0,1,0,1,0,1]` → *this* is the normalized `[0,1]` field (the "percent" one), separate from `.extent`.
- The authoritative type docstring (`types.jl`) already said code units; but the **`projection_hydro` return-value docstring wrongly labelled `.extent`/`.pixsize`/`.center` as "Physical"** — the actual footgun.

## Changes
1. **Doc fix** — `projection_hydro.jl` return-value list now states `.extent`/`.pixsize`/`.center` are **code length** (× `proj.scale.<unit>` for physical), and notes `.ranges` is the normalized `[0,1]` field.
2. **New accessor** — `getextent(proj::DataMapsType, unit=:standard; center=false)` returns the map extent in a physical unit, e.g. `getextent(p, :kpc)` → `[xmin,xmax,ymin,ymax]` in kpc (`center=true` for the centre-relative `cextent`). Symmetric with the existing `getextent(dataobject, unit)`; works on hydro **and** particle projections.

Data-free regression test in `test/54` (+4 asserts: `:standard`==code, `:kpc`==`extent·scale.kpc`, `:pc`==`1e3·:kpc`, centred).

NB our tutorial notebooks are currently mixed — some use `proj.extent .* gas.scale.kpc` (physical) and many use raw `proj.cextent` (code-unit axes); `getextent(proj, :kpc)` gives them one clear idiom.