### PR TITLE
fix(storageoverview): RT/particle prefix collision + non-RAMSES footprint

### DIFF
--- a/src/functions/overview.jl
+++ b/src/functions/overview.jl
@@ -129,6 +129,12 @@ Provide a storage overview for loaded data, showing memory usage and data struct
 Displays comprehensive information about the storage characteristics of the selected simulation
 output. It helps users understand the resource requirements and structure of their data.
 
+For **RAMSES** outputs it tallies the on-disc size per file type — folder total, and the `amr`,
+`hydro`, `gravity`, `particle`, `clump`, `rt` and `sink` files present — returned in a `Dict`. For
+**other codes** (GADGET/AREPO, PLUTO, Athena++, FLASH, Chombo) every quantity is packed into one file
+or folder, so a per-datatype split is not meaningful; instead the snapshot's disc footprint is reported
+under `:snapshot` (the file size for a single-file snapshot, else the folder total).
+
 # Examples
 ```julia
 # Get storage overview for hydro data
@@ -154,9 +160,21 @@ function storageoverview(dataobject::InfoType; verbose::Bool=true)
     #println(fnames)
     fnames = dataobject.fnames
 
-    # External (non-RAMSES) snapshots have no RAMSES output directory to tally — return empty.
+    # External (non-RAMSES) snapshots have no per-datatype RAMSES output directory — those codes pack
+    # every quantity into one file (HDF5) or folder. Report the snapshot's disc footprint instead of
+    # nothing: the file size for a single-file snapshot (GADGET/AREPO/…), else the folder total.
     if !isdefined(fnames, :output) || isempty(fnames.output) || !isdir(fnames.output)
-        verbose && println("(storage overview unavailable — no RAMSES output directory for $(dataobject.simcode))")
+        p = dataobject.path
+        sz, isfolder = isfile(p) ? (filesize(p), false) :
+                       isdir(p)  ? (sum(filesize(f) for f in joinpath.(p, readdir(p)) if isfile(f); init=0), true) :
+                                   (0, false)
+        v, u = usedmemory(sz, false)
+        if verbose
+            println("Snapshot ($(dataobject.simcode)): ", round(v, digits=2), " ", u,
+                    isfolder ? "  (folder total; the per-datatype breakdown is RAMSES-specific)" : "")
+            println(); println("mtime: ", dataobject.mtime); println("ctime: ", dataobject.ctime)
+        end
+        dictoutput[:snapshot] = sz
         return dictoutput
     end
 
@@ -170,7 +188,7 @@ function storageoverview(dataobject::InfoType; verbose::Bool=true)
         println( "Folder:         ", round(folder_value,digits=2),   " ", folder_unit,  " \t<", round(folder_meanvalue, digits=2),  " ", folder_meanunit,">/file" )
     end
 
-    amr_files = all_files[ occursin.( "amr", all_files) ]
+    amr_files = all_files[ startswith.(all_files, "amr_") ]
     amr = filesize.( fnames.output .* "/" .* amr_files )
     amr_size = sum( amr )
     amr_mean = mean( amr )
@@ -181,7 +199,7 @@ function storageoverview(dataobject::InfoType; verbose::Bool=true)
     end
 
     if dataobject.hydro
-        hydro_files = all_files[ occursin.( "hydro", all_files) ]
+        hydro_files = all_files[ startswith.(all_files, "hydro_") ]
         hydro = filesize.( fnames.output .* "/" .* hydro_files )
         hydro_size = sum( hydro )
         hydro_mean = mean( hydro )
@@ -195,7 +213,7 @@ function storageoverview(dataobject::InfoType; verbose::Bool=true)
     end
 
     if dataobject.gravity
-        gravity_files = all_files[ occursin.( "grav", all_files) ]
+        gravity_files = all_files[ startswith.(all_files, "grav_") ]
         gravity = filesize.(fnames.output .* "/" .* gravity_files )
         gravity_size = sum( gravity )
         gravity_mean = mean( gravity )
@@ -209,7 +227,7 @@ function storageoverview(dataobject::InfoType; verbose::Bool=true)
     end
 
     if dataobject.particles
-        particle_files = all_files[ occursin.( "part", all_files) ]
+        particle_files = all_files[ startswith.(all_files, "part_") ]
         particle = filesize.( fnames.output .* "/" .* particle_files )
         particle_size = sum( particle )
         particle_mean = mean( particle )
@@ -223,7 +241,7 @@ function storageoverview(dataobject::InfoType; verbose::Bool=true)
     end
 
     if dataobject.clumps
-        clump_files = all_files[ occursin.( "clump", all_files) ]
+        clump_files = all_files[ startswith.(all_files, "clump_") ]
         clump = filesize.( fnames.output .* "/" .* clump_files )
         clump_size = sum( clump )
         clump_mean = mean( clump )
@@ -237,7 +255,7 @@ function storageoverview(dataobject::InfoType; verbose::Bool=true)
     end
 
     if dataobject.rt
-        rt_files = all_files[ occursin.( "rt", all_files) ]
+        rt_files = all_files[ startswith.(all_files, "rt_") ]
         rt = filesize.( fnames.output .* "/" .* rt_files )
         rt_size = sum( rt )
         rt_mean = mean( rt )
@@ -253,7 +271,7 @@ function storageoverview(dataobject::InfoType; verbose::Bool=true)
 
     # todo: check for sink files
     if dataobject.sinks
-        sink_files = all_files[ occursin.( "sink", all_files) ]
+        sink_files = all_files[ startswith.(all_files, "sink_") ]
         sink = filesize.( fnames.output .* "/" .* sink_files )
         sink_size = sum( sink )
         sink_mean = mean( sink )

--- a/test/13_additional_coverage.jl
+++ b/test/13_additional_coverage.jl
@@ -496,6 +496,20 @@ end
             @test haskey(d, k)
             @test d[k] > 0
         end
+        # the per-datatype tallies are disjoint and fit inside the folder total — guards against the
+        # prefix-collision bug where "rt" ⊂ "part" made the RT tally double-count the particle files.
+        @test d[:amr] + d[:hydro] + d[:gravity] + d[:particle] + d[:clump] + d[:rt] + d[:sink] <= d[:folder]
+    end
+
+    @testset "storageoverview (non-RAMSES reports a snapshot footprint)" begin
+        tng = joinpath(SIMULATION_PATH, "AREPO", "TNGHalo", "TNGHalo", "halo_59.hdf5")
+        if isfile(tng)
+            it = getinfo(59, tng, verbose=false)
+            d = redirect_stdout(devnull) do; storageoverview(it, verbose=false); end
+            @test d isa Dict && haskey(d, :snapshot) && d[:snapshot] > 0   # was an empty dict before
+        else
+            @test_skip "TNGHalo fixture not present (MERA_TEST_DATA/AREPO/TNGHalo/)"
+        end
     end
 
     # File-content accessors: just verify non-crash.


### PR DESCRIPTION
Audit of *"is `storageoverview` up to date for all types and codes?"* found two issues, both fixed.

**1. Type bug — RT tally double-counts particle files.** File types were matched with `occursin("rt", name)`, and **`"rt"` is a substring of `"part"`** (`occursin("rt", "part_00100") == true`). So on a RAMSES run with RT *and* particles, the `RT-Files` line wrongly included every `part_*` file. Fixed by anchoring all matches with `startswith(name, "<prefix>_")` (`amr`/`hydro`/`grav`/`part`/`clump`/`rt`/`sink`). Added a regression invariant: Σ(per-type) ≤ folder total (which the bug violated by double-counting).

**2. Codes gap — it was RAMSES-only.** For every other code (PLUTO, Athena++, FLASH, GADGET, AREPO, Chombo) it returned an **empty dict** + *"unavailable"*. Those codes pack all quantities into one HDF5 file / folder, so a per-datatype split isn't meaningful — but reporting *nothing* is the gap. Now it reports the snapshot disc footprint under `:snapshot` (file size for a single-file snapshot, else the folder total). Verified: **AREPO → 1.21 GB**, **PLUTO → 70 MB** (folder total, clearly labelled).

Docstring clarified (RAMSES per-type breakdown vs `:snapshot` footprint for other codes); `test/13` +2 assertions (sum-invariant + non-RAMSES `:snapshot`).