### PR TITLE
docs: explain what Chombo is (AMR framework / file format, not a code)

### DIFF
--- a/docs/src/multicode.md
+++ b/docs/src/multicode.md
@@ -40,6 +40,12 @@ Data is loaded **per type**, exactly as for RAMSES: [`gethydro`](@ref) always, a
 [`getparticles`](@ref) where the code wrote particles (PLUTO). Only what a code actually stored is
 available — e.g. an Athena++/FLASH plot file is hydro + cell-centred MHD only.
 
+!!! note "“Chombo” is a format, not a code"
+    The **Chombo** row above is a *file format*, not a physics code: Chombo is a block-structured AMR
+    **framework** (Lawrence Berkeley National Laboratory) whose HDF5 output is shared by PLUTO (AMR
+    mode), Orion, Charm, BISICLES and others. Mera reads any Chombo-format `.hdf5` the same way — see
+    [PLUTO-AMR (Chombo)](pluto_reader.md#PLUTO-AMR-(Chombo)).
+
 **Self-gravity** rides along the same way: where a code writes a gravitational potential into its
 snapshot (Athena++ `phi`, FLASH `gpot`, Chombo `gravitational-potential`) the reader exposes it as
 a single canonical field, so `getvar(gas, :gpot)` — and `projection`, `timeseries`, … on it — runs

--- a/docs/src/pluto_reader.md
+++ b/docs/src/pluto_reader.md
@@ -160,9 +160,18 @@ extra fields keep their names.
 
 ## PLUTO-AMR (Chombo)
 
-PLUTO's **AMR** output uses the Chombo box-structured HDF5 format (shared with Orion and other Chombo
-codes). The frontend reads it too — `getinfo` auto-detects a `.hdf5` snapshot and loads the level
-hierarchy as a Mera **AMR** `HydroDataType`:
+!!! info "What is Chombo?"
+    **Chombo** is not a simulation code but a **block-structured adaptive-mesh-refinement (AMR)
+    framework** — a library from Lawrence Berkeley National Laboratory (the Applied Numerical Algorithms
+    Group) that supplies the grid hierarchy, parallel data structures and HDF5 I/O that many simulation
+    codes are built on. Because they share Chombo's machinery they also share its **HDF5 output format**
+    (a hierarchy of refined rectangular *boxes*): **PLUTO** in AMR mode, **Orion**, **Charm** and
+    **BISICLES**, among others, all write the same layout. So Mera's `Code: CHOMBO` labels the **file
+    format**, not a single physics code — any Chombo-format `.hdf5` is read the same way, with the
+    per-code variable-name maps (PLUTO vs Orion conventions) layered on top.
+
+PLUTO's **AMR** output uses this Chombo format. The frontend reads it — `getinfo` auto-detects a
+`.hdf5` snapshot and loads the level hierarchy as a Mera **AMR** `HydroDataType`:
 
 ```julia
 info = getinfo(0, "/data/chombo_run")     # detects the Chombo .hdf5 → "Code: CHOMBO"


### PR DESCRIPTION
`Chombo` shows up in the supported-codes table and the capability matrix as though it were a simulation code. It is actually a **block-structured AMR framework** (Lawrence Berkeley National Laboratory / ANAG) whose **HDF5 output format** is shared by many codes — PLUTO in AMR mode, Orion, Charm, BISICLES, … So Mera's `Code: CHOMBO` labels the *file format*, not one physics code.

- Adds a **"What is Chombo?"** admonition to the *PLUTO-AMR (Chombo)* section of `pluto_reader.md`, explaining the framework → shared-HDF5-format → `Code: CHOMBO` relationship and that any Chombo-format `.hdf5` is read the same way (with per-code variable-name maps on top).
- Adds a short clarifying note next to the supported-codes table in `multicode.md` so readers scanning the matrix know the `Chombo` column is a format.

Docs-only; no code blocks added (doc-codeblocks test unaffected).