### PR TITLE
fix(projection): off-axis :overlap holes/moiré on capped AMR cells (LOS cubes)

### DIFF
--- a/src/functions/projection/projection_hydro.jl
+++ b/src/functions/projection/projection_hydro.jl
@@ -504,8 +504,10 @@ default** (`angle_unit=:rad` to switch).
 - **`angle_unit::Symbol`**: `:deg` (default) or `:rad`
 - **`binning::Symbol`**: how rotated cells are deposited onto the camera plane —
   - `:overlap` (default) — per-cell footprint supersampling (`ns = ceil(cellsize/pixel)` sub-points
-    per cube axis, capped at `nmax`); AMR-aligned (no moiré, no holes), converges to `:exact`, and
-    is usually *faster* than `:exact`. Cells coarser than the `nmax` cap stay mildly blocky.
+    per cube axis, capped at `nmax`); AMR-aligned (no moiré, no interior holes), converges to
+    `:exact`, and is usually *faster* than `:exact`. Cells coarser than the `nmax` cap (`ns` would
+    exceed `nmax`) deposit each sub-cell as a footprint-sized top-hat so they still tile the camera
+    plane without gaps — fine cells keep the sharp ±1px deposit.
   - `:exact` — analytic box-spline footprint: integrates the line-of-sight column (chord length
     through the cube) over each pixel exactly; no supersampling cap, the reference for fidelity.
   - `:cic` — fast preview, bilinear deposit of cell centres; speckles/moiré on coarse AMR cells
@@ -2404,36 +2406,62 @@ function deposit_rotated_cells_overlap!(grid::Matrix{Float64}, weight_grid::Matr
             g = gbufs[t]; wg = wbufs[t]
             @inbounds for i in bounds[t]:(bounds[t+1]-1)
                 s = cellsize[i]
-                ns = clamp(ceil(Int, s * inv_px), 1, nmax)   # sub-points per cube axis
+                ns_full = ceil(Int, s * inv_px)
+                capped  = ns_full > nmax                      # coarse cell: supersampling would be capped
+                ns = capped ? nmax : max(ns_full, 1)          # sub-points per cube axis
                 share = 1.0 / (ns^3)
                 w_i  = weights[i] * share
                 vw_i = values[i] * weights[i] * share
                 xc = x_cam[i]; yc = y_cam[i]
                 inv_ns = 1.0 / ns
+                # Capped (coarse) cells deposit each sub-cell as a top-hat over the camera-plane bounding
+                # box of the ROTATED sub-cube (half-extents along cam_right/cam_up), so the ns³ tiles
+                # overlap — hole-free at any view angle, fixing the moiré/holes the old fixed-±1px CIC
+                # left on coarse AMR cells. Fine (un-capped) cells keep the sharp ±1px CIC (already
+                # hole-free, since their sub-points are ≤1px apart). Weight 1/ns³ ⇒ conservation kept.
+                ss = s * inv_ns
+                hx = 0.5 * ss * (abs(rx) + abs(ry) + abs(rz))
+                hy = 0.5 * ss * (abs(ux) + abs(uy) + abs(uz))
                 for ka in 0:ns-1
                     oa = (-0.5 + (ka + 0.5)*inv_ns) * s
                     for kb in 0:ns-1
                         ob = (-0.5 + (kb + 0.5)*inv_ns) * s
-                        # partial camera offsets from the (a,b) cube axes
                         dxab = oa*rx + ob*ry
                         dyab = oa*ux + ob*uy
                         for kc in 0:ns-1
                             oc = (-0.5 + (kc + 0.5)*inv_ns) * s
                             xs = xc + dxab + oc*rz
                             ys = yc + dyab + oc*uz
-                            # CIC deposit of this sub-point
-                            fx = (xs - x_min)*inv_px - 0.5
-                            fy = (ys - y_min)*inv_py - 0.5
-                            ix0 = floor(Int, fx); iy0 = floor(Int, fy)
-                            wx = fx - ix0; wy = fy - iy0
-                            ixl = clamp(ix0+1, 1, nx); ixr = clamp(ix0+2, 1, nx)
-                            iyl = clamp(iy0+1, 1, ny); iyr = clamp(iy0+2, 1, ny)
-                            wll = (1.0-wx)*(1.0-wy); wrl = wx*(1.0-wy)
-                            wlr = (1.0-wx)*wy;       wrr = wx*wy
-                            g[ixl,iyl] += vw_i*wll; wg[ixl,iyl] += w_i*wll
-                            g[ixr,iyl] += vw_i*wrl; wg[ixr,iyl] += w_i*wrl
-                            g[ixl,iyr] += vw_i*wlr; wg[ixl,iyr] += w_i*wlr
-                            g[ixr,iyr] += vw_i*wrr; wg[ixr,iyr] += w_i*wrr
+                            if capped
+                                gxl = (xs - hx - x_min)*inv_px; gxr = (xs + hx - x_min)*inv_px
+                                gyl = (ys - hy - y_min)*inv_py; gyr = (ys + hy - y_min)*inv_py
+                                pxa = clamp(floor(Int, gxl)+1, 1, nx); pxb = clamp(floor(Int, gxr)+1, 1, nx)
+                                pya = clamp(floor(Int, gyl)+1, 1, ny); pyb = clamp(floor(Int, gyr)+1, 1, ny)
+                                invwx = 1.0/max(gxr-gxl, 1e-30); invwy = 1.0/max(gyr-gyl, 1e-30)
+                                for px in pxa:pxb
+                                    fxov = (min(gxr, Float64(px)) - max(gxl, Float64(px-1))) * invwx
+                                    fxov <= 0.0 && continue
+                                    for py in pya:pyb
+                                        fyov = (min(gyr, Float64(py)) - max(gyl, Float64(py-1))) * invwy
+                                        fyov <= 0.0 && continue
+                                        f = fxov*fyov
+                                        g[px,py]  += vw_i*f; wg[px,py] += w_i*f
+                                    end
+                                end
+                            else
+                                fx = (xs - x_min)*inv_px - 0.5
+                                fy = (ys - y_min)*inv_py - 0.5
+                                ix0 = floor(Int, fx); iy0 = floor(Int, fy)
+                                wx = fx - ix0; wy = fy - iy0
+                                ixl = clamp(ix0+1, 1, nx); ixr = clamp(ix0+2, 1, nx)
+                                iyl = clamp(iy0+1, 1, ny); iyr = clamp(iy0+2, 1, ny)
+                                wll = (1.0-wx)*(1.0-wy); wrl = wx*(1.0-wy)
+                                wlr = (1.0-wx)*wy;       wrr = wx*wy
+                                g[ixl,iyl] += vw_i*wll; wg[ixl,iyl] += w_i*wll
+                                g[ixr,iyl] += vw_i*wrl; wg[ixr,iyl] += w_i*wrl
+                                g[ixl,iyr] += vw_i*wlr; wg[ixl,iyr] += w_i*wlr
+                                g[ixr,iyr] += vw_i*wrr; wg[ixr,iyr] += w_i*wrr
+                            end
                         end
                     end
                 end

--- a/test/42_kernel_oracle_tests.jl
+++ b/test/42_kernel_oracle_tests.jl
@@ -156,6 +156,25 @@ using Statistics, LinearAlgebra, Random
         @test sum(ge) ≈ Σvw rtol=1e-12
     end
 
+    @testset ":overlap fills coarse (capped) cells with no interior holes" begin
+        # A coarse AMR cell whose footprint spans many pixels forces the nmax supersampling cap. The
+        # old fixed-±1px CIC then left a sparse lattice of spikes with gaps between them (the "AMR not
+        # overlapping" artefact); the capped top-hat deposit must tile the footprint hole-free.
+        nx = ny = 40; ext = (-2.0, 2.0, -2.0, 2.0); px = (ext[2]-ext[1]) / nx     # pixel = 0.1
+        r, u, w = Mera.build_camera_basis([0.0,0.0,1.0])                          # face-on
+        xc = [0.0]; yc = [0.0]; cs = [1.0]; vals = [1.0]; wts = [1.0]             # one 10×10-px cell
+        g = zeros(nx, ny); wg = zeros(nx, ny)
+        # ns_full = ceil(1.0/0.1) = 10 > nmax=2  ⇒  capped path
+        Mera.deposit_rotated_cells_overlap!(g, wg, xc, yc, cs, vals, wts, r, u, ext, (nx, ny); nmax=2, max_threads=1)
+        @test sum(wg) ≈ 1.0 rtol=1e-12                                            # still conserves
+        interior_zeros = 0
+        for i in 1:nx, j in 1:ny
+            xcen = ext[1] + (i-0.5)*px; ycen = ext[3] + (j-0.5)*px
+            (abs(xcen) < 0.5-px && abs(ycen) < 0.5-px && wg[i,j] == 0.0) && (interior_zeros += 1)
+        end
+        @test interior_zeros == 0                                                 # hole-free interior (the fix)
+    end
+
     @testset "projection deposit conserves mass off-axis (rotation invariance)" begin
         nx = ny = 48; ext = (-2.0, 2.0, -2.0, 2.0)
         rng = MersenneTwister(5); n = 25


### PR DESCRIPTION
The user reported LOS-cube image artefacts — "AMR cells not overlapping well". An orchestrated multi-agent evaluation pinned the root cause.

**Root cause.** The off-axis `:overlap` deposit (`deposit_rotated_cells_overlap!`) supersamples each cell into `ns = clamp(ceil(cellsize/pixel), 1, nmax)` sub-points, each deposited with a **fixed ±1px CIC stencil** and a **count-only weight** `1/ns³`. When `cellsize/pixel > nmax` (coarse AMR cells / big level jumps), sub-point spacing `s/ns` exceeds a pixel, so the CIC tents stop overlapping → moiré (1<d<2) then **hard zero-valued holes** (d≥2). Conservation held throughout (`Σ pixel == msum`), confirming a purely *spatial* bug.

**Reproduced** on real AMR (`spiral_clumps`, `los=[1,1,1]`): `:overlap` nmax=4 → **12,758 interior holes** vs `:exact` → **0**, Σ-ratio 1.0.

**Fix.** Branch per cell:
- **Fine (un-capped) cells** keep the sharp ±1px CIC (already hole-free — sub-points ≤1px apart).
- **Capped coarse cells** deposit each sub-cell as a **top-hat (area-overlap)** sized to the camera-plane bounding box of the *rotated* sub-cube (half-extents along `cam_right`/`cam_up`), so the `ns³` tiles overlap and fill the footprint at any view angle. Weight stays `1/ns³` ⇒ conservation unchanged.

**Verified:** interior holes **0** at res 512 *and* 2048 (capping active; was holey); remaining edge pixels are cosmetic data-boundary only; `:exact` agreement ~6% median on bright pixels; test/35 (off-axis accuracy) + test/42 (conservation) still pass. **Data-free regression** added in test/42 (a capped coarse cell must fill with 0 interior holes). Docstring updated.

Part of a broader LOS-cube evaluation (features/docs/demos) — a refreshed docs notebook follows.