### PR TITLE
feat(getextent): support LosCubeType (cube sky extent)

### DIFF
--- a/src/functions/getvar/getvar.jl
+++ b/src/functions/getvar/getvar.jl
@@ -931,6 +931,16 @@ function getextent(proj::DataMapsType, unit::Symbol=:standard; center::Bool=fals
 end
 
 """
+    getextent(cube::LosCubeType, unit::Symbol=:standard) -> [xmin,xmax,ymin,ymax]
+
+Sky-plane extent of a [`los_cube`](@ref) / [`velocity_cube`](@ref) result in a physical `unit`
+(e.g. `:kpc`). The stored `cube.x`/`cube.y` pixel edges are in **code length**; this scales them so
+the spatial axes match a physical map — `getextent(cube, :kpc)` → `[xmin,xmax,ymin,ymax]` in kpc.
+"""
+getextent(cube::LosCubeType, unit::Symbol=:standard) =
+    (unit === :standard ? 1.0 : getfield(cube.scale, unit)) .* [cube.x[1], cube.x[end], cube.y[1], cube.y[end]]
+
+"""
 #### Get the extent of the dataset-domain:
 ```julia
 function getextent( dataobject::DataSetType;

--- a/test/06_projections.jl
+++ b/test/06_projections.jl
@@ -2099,6 +2099,9 @@ end
             nx, ny, nv = size(vc.cube)
             @test nv == 32 && length(vc.velocity) == 33 && length(vc.x) == nx+1
             @test isapprox(sum(vc.cube), sum(getvar(hydro, :mass)); rtol=1e-6)   # cube conserves total mass
+            # getextent on a cube: code-unit edges → physical sky extent (matches the DataMapsType accessor)
+            @test getextent(vc) == [vc.x[1], vc.x[end], vc.y[1], vc.y[end]]
+            @test getextent(vc, :kpc) ≈ [vc.x[1], vc.x[end], vc.y[1], vc.y[end]] .* vc.scale.kpc
             mom = velocity_moments(vc)
             @test size(mom.Σ) == (nx, ny) && size(mom.vlos) == (nx, ny) && size(mom.σlos) == (nx, ny)
             @test isapprox(sum(mom.Σ), sum(vc.cube); rtol=1e-9)                 # moment-0 == column sum


### PR DESCRIPTION
Follow-up to #237 — `getextent` worked on projection maps (`DataMapsType`) but not on **cubes**. `los_cube`/`velocity_cube` results store sky-pixel *edges* (`cube.x`/`cube.y`, code length) rather than `.extent`, so `getextent(cube, :kpc)` errored. Adds the method so channel/moment-map plots get physical axes consistently. Verified + tested in the `velocity_cube` testset (`test/06`). Used throughout the refreshed LOS-cube notebook.