### PR TITLE
docs(offaxis_slice): explain tilted non-square cells in inclined slices

### DIFF
--- a/docs/src/06_offaxis_Projection.md
+++ b/docs/src/06_offaxis_Projection.md
@@ -547,6 +547,16 @@ the bounding box of the rotated view and its corners — where the plane∩box p
 come back `NaN` (expected geometry, shown black). The few black specks in the thin edge-on cut are
 the inherent sub-percent nearest-cell gaps at AMR refinement boundaries.
 
+!!! note "Why inclined slices show tilted, non-square cells"
+    A slice is the **intersection of the camera plane with each cubic cell**, so each cell is drawn
+    as that intersection. Cut **face-on** a cube gives a square; cut **at an angle** it gives a
+    polygon (a parallelogram, or a hexagon in general), elongated along the tilt direction — a pixel
+    belongs to a cell when `|x'·r̂ₖ + y'·ûₖ − cellₖ| ≤ ½·cellsize` on all three axes `k`, i.e. the
+    intersection of three tilted slabs. So the tilted, elongated blocks in an inclined slice are the
+    **true shape of the cut, not an artefact**; they are largest for the coarse, low-density cells
+    and shrink with refinement (the dense, finely-refined midplane looks smooth). For a smooth,
+    resolution-independent map use [`projection`](@ref) (a line-of-sight integral) instead of a slice.
+
 Not line-of-sight specific, but often used alongside projections: `profile` (1D) and `phase` (2D
 weighted histograms, e.g. density–temperature) are general reductions over any field — see
 [Profiles & Phase Diagrams](profiles_phase.md).

--- a/docs/src/14_multi_OffAxis_Features.md
+++ b/docs/src/14_multi_OffAxis_Features.md
@@ -110,6 +110,11 @@ fig
 
 ![Off-axis density slices of the same galaxy at three orientations: face-on midplane, edge-on vertical cut, and an inclined 60° cut.](assets/offaxis/offaxis_slice.png)
 
+The **tilted, non-square cells** in the inclined panel are not an artefact: a slice draws each cell
+as the *intersection of the camera plane with the cube*, which is a square only face-on and a
+polygon (parallelogram/hexagon, elongated along the tilt) at an angle. They are largest for the
+coarse low-density cells and shrink with refinement.
+
 Empty (black) pixels are expected geometry: without a window the auto-fit frame's corners (the
 plane∩box polygon) have no cell, and the few specks in the thin edge-on cut are the inherent
 sub-percent nearest-cell gaps at AMR refinement boundaries. For a gap-free, conserved map use


### PR DESCRIPTION
Documents *why* an inclined  shows tilted, non-square cells (a recurring question): a slice draws each cell as the **intersection of the camera plane with the cube** — a square only face-on, a polygon (parallelogram/hexagon, elongated along the tilt) at an angle. It's the true geometry of the cut, not an artefact; largest for coarse low-density cells, shrinks with refinement; use `projection` for a smooth resolution-independent map. Added as a `!!! note` on page 06 and a paragraph on page 14 (matching notebook slice sections updated in the Notebooks repo). Docs build clean.