### PR TITLE
feat(rotation_sequence): parallel_frames — frame-level multithreading

### DIFF
--- a/src/functions/projection/projection.jl
+++ b/src/functions/projection/projection.jl
@@ -558,7 +558,7 @@ end
 """
     rotation_sequence(dataobject, var, [unit]; sweep=:azimuth, angles,
                       axis=:angmom, inclination=0, fov=nothing, fov_unit=:standard,
-                      aperture=:circle, center=[:bc], res=256, <projection kwargs>)
+                      aperture=:circle, parallel_frames=false, center=[:bc], res=256, <projection kwargs>)
         -> Vector{AMRMapsType}
 
 Render `var` from a sequence of viewing angles for an **orbit movie**, all sharing ONE truly fixed
@@ -579,11 +579,18 @@ capped so the selection stays inside the box. The aperture chooses how the spher
   every angle) is selected and each frame cropped to that square → a **full rectangular frame** with
   no circular aperture and no data dropped inside it.
 
+**Threading.** By default each frame's `projection` multithreads internally and the frames run
+sequentially. With `parallel_frames=true` the **frames** run concurrently (`Threads.@threads`) and
+each projection is single-threaded — this fills all cores when there are ≳ `nthreads()` frames and
+is typically ~1.5–2× faster for an orbit movie (it runs that many projections at once, so it uses
+proportionally more transient memory; results are identical to round-off).
+
 Returns a `Vector` of map objects — one per angle — ready to montage or animate.
 """
 function rotation_sequence(dataobject, var, unit::Symbol=:standard; sweep::Symbol=:azimuth,
         angles, axis=:angmom, inclination::Real=0, fov=nothing, fov_unit::Symbol=:standard,
-        aperture::Symbol=:circle, center=[:bc], res::Int=256, pxsize=nothing, verbose::Bool=false, kwargs...)
+        aperture::Symbol=:circle, parallel_frames::Bool=false,
+        center=[:bc], res::Int=256, pxsize=nothing, verbose::Bool=false, kwargs...)
     sweep in (:azimuth, :inclination, :position_angle) ||
         throw(ArgumentError("sweep must be :azimuth, :inclination or :position_angle, got :$sweep"))
     aperture in (:circle, :square) ||
@@ -620,17 +627,32 @@ function rotation_sequence(dataobject, var, unit::Symbol=:standard; sweep::Symbo
     rsel = aperture === :square ? rfov * sqrt(2) : rfov
     win  = [-rsel, rsel]
     src = subregion(dataobject, :sphere, radius=rsel, center=center, range_unit=fov_unit, verbose=false)
+    # Two ways to use the threads. By default each frame's `projection` multithreads internally and
+    # the frames run one after another. With `parallel_frames=true` the FRAMES run concurrently
+    # (`Threads.@threads`) and each projection is single-threaded — this fills all cores when there
+    # are ≳ nthreads frames (and the internal deposit's per-frame setup/sync no longer serialises),
+    # typically ~1.5–2× faster for an orbit movie. It runs N projections at once, so it uses ~N×
+    # the transient memory; results are identical to round-off. We set `max_threads` here, so drop
+    # any user-supplied one.
+    mt = parallel_frames ? 1 : Threads.nthreads()
+    kw = Base.structdiff((; kwargs...), (; max_threads = 0))
     maps = Vector{Any}(undef, length(angles))
-    for (k, a) in enumerate(angles)
+    frame!(k) = begin
+        a = angles[k]
         view = sweep === :azimuth        ? (inclination=inclination, azimuth=a, axis=axis) :
                sweep === :inclination    ? (inclination=a, axis=axis) :
                                            (inclination=inclination, axis=axis, position_angle=a)
         szkw = pxsize === nothing ? (res=res,) : (pxsize=pxsize,)   # prefer physical pxsize
         m = projection(src, var, unit; center=center, range_unit=fov_unit,
-                       xrange=win, yrange=win, zrange=win, verbose=verbose, show_progress=false,
-                       szkw..., view..., kwargs...)
+                       xrange=win, yrange=win, zrange=win, verbose=false, show_progress=false,
+                       max_threads=mt, szkw..., view..., kw...)
         aperture === :square && _rotseq_crop_square!(m, fov_code)
         maps[k] = m
+    end
+    if parallel_frames
+        Threads.@threads for k in eachindex(angles); frame!(k); end
+    else
+        for k in eachindex(angles); frame!(k); end
     end
     return identity.(maps)
 end

--- a/test/06_projections.jl
+++ b/test/06_projections.jl
@@ -2107,6 +2107,13 @@ end
             au = rotation_sequence(hydro, :mass, :Msol; sweep=:azimuth, angles=[0,90], res=48)
             @test (au[1].extent[2]-au[1].extent[1]) < 0.9*hydro.boxlen
             @test all(m -> all(isfinite, m.maps[:mass]) && sum(m.maps[:mass]) > 0, au)
+            # parallel_frames (frame-level threading) gives identical frames to round-off
+            sp = rotation_sequence(hydro, :mass, :Msol; sweep=:azimuth, angles=[0,90,180,270],
+                                   fov=15, fov_unit=:kpc, res=64, parallel_frames=true)
+            @test length(sp) == length(seq)
+            @test all(k -> size(sp[k].maps[:mass]) == size(seq[k].maps[:mass]), eachindex(seq))
+            @test all(k -> maximum(abs.(sp[k].maps[:mass] .- seq[k].maps[:mass])) <=
+                           1e-9*max(maximum(abs.(seq[k].maps[:mass])), eps()), eachindex(seq))
         end
 
         @testset "off-axis :exact ≡ :overlap per-pixel on real AMR" begin


### PR DESCRIPTION
You asked whether the orbit-movie loop can use the cores better. Each frame's `projection` already multithreads, but the **frames** ran one after another. `parallel_frames=true` now runs the frames concurrently (`Threads.@threads`), each projection single-threaded — so all cores stay busy when there are ≳ `nthreads()` frames.

**Benchmark** (12 threads, 18 frames, spiral_clumps): sequential inner-threaded **0.96 s** → frame-parallel **0.52 s** (~1.86×), with **identical results** (max diff/peak ≈ 2e-15).

- Default unchanged (`parallel_frames=false`). It runs N projections at once → proportionally more transient memory (documented).
- Sets `max_threads` internally (drops a user-supplied one to avoid a duplicate kwarg).
- Test: `parallel_frames` matches sequential frame sizes + values to round-off. Docstring documents the trade-off.