### PR TITLE
fix(rotation_sequence): orbit/FOV works for particles & RT (max_threads hydro-only)

### DIFF
--- a/src/functions/projection/projection.jl
+++ b/src/functions/projection/projection.jl
@@ -632,9 +632,12 @@ function rotation_sequence(dataobject, var, unit::Symbol=:standard; sweep::Symbo
     # (`Threads.@threads`) and each projection is single-threaded — this fills all cores when there
     # are ≳ nthreads frames (and the internal deposit's per-frame setup/sync no longer serialises),
     # typically ~1.5–2× faster for an orbit movie. It runs N projections at once, so it uses ~N×
-    # the transient memory; results are identical to round-off. We set `max_threads` here, so drop
-    # any user-supplied one.
+    # the transient memory; results are identical to round-off.
+    # NB: only the hydro-grid `projection` accepts `max_threads` — particle / gravity / RT projections
+    # do not, so we pass it ONLY for HydroDataType (and drop any user-supplied one). This works for
+    # every data type; for non-hydro, parallel_frames still parallelises over the frames.
     mt = parallel_frames ? 1 : Threads.nthreads()
+    mtkw = src isa HydroDataType ? (; max_threads = mt) : (;)
     kw = Base.structdiff((; kwargs...), (; max_threads = 0))
     maps = Vector{Any}(undef, length(angles))
     frame!(k) = begin
@@ -645,7 +648,7 @@ function rotation_sequence(dataobject, var, unit::Symbol=:standard; sweep::Symbo
         szkw = pxsize === nothing ? (res=res,) : (pxsize=pxsize,)   # prefer physical pxsize
         m = projection(src, var, unit; center=center, range_unit=fov_unit,
                        xrange=win, yrange=win, zrange=win, verbose=false, show_progress=false,
-                       max_threads=mt, szkw..., view..., kw...)
+                       mtkw..., szkw..., view..., kw...)
         aperture === :square && _rotseq_crop_square!(m, fov_code)
         maps[k] = m
     end

--- a/test/06_projections.jl
+++ b/test/06_projections.jl
@@ -2114,6 +2114,16 @@ end
             @test all(k -> size(sp[k].maps[:mass]) == size(seq[k].maps[:mass]), eachindex(seq))
             @test all(k -> maximum(abs.(sp[k].maps[:mass] .- seq[k].maps[:mass])) <=
                            1e-9*max(maximum(abs.(seq[k].maps[:mass])), eps()), eachindex(seq))
+            # orbit ALSO works for PARTICLES (regression: PartDataType projection has no max_threads
+            # kwarg, so the threading hook must be hydro-only), both sequential and frame-parallel
+            pcl = getparticles(hydro.info, verbose=false, show_progress=false)
+            for pf in (false, true)
+                fpart = rotation_sequence(pcl, :sd, :Msol; sweep=:azimuth, angles=[0,90,180,270],
+                                          fov=15, fov_unit=:kpc, res=48, aperture=:square, parallel_frames=pf)
+                @test length(fpart) == 4
+                @test length(unique([size(m.maps[:sd]) for m in fpart])) == 1
+                @test all(m -> all(isfinite, m.maps[:sd]) && sum(m.maps[:sd]) > 0, fpart)
+            end
         end
 
         @testset "off-axis :exact ≡ :overlap per-pixel on real AMR" begin


### PR DESCRIPTION
**Regression fix.** #255 made `rotation_sequence` pass `max_threads` to every `projection`, but only the **hydro-grid** projection accepts it — particle and RT projections do not — so orbit movies / FOV **errored on particle and RT data** (the existing test only used hydro, so it slipped through).

Fix: pass `max_threads` only for `HydroDataType`; other data types use their normal projection (`parallel_frames` still parallelises over frames).

**Answers the data-type question:** orbit/FOV now work for **hydro**, **particles/stars**, and **RT** (use `axis=:z` for RT — it has no angular momentum for `:angmom`). **Gravity** is projected via the combined `projection(hydro, gravity, …)` form (there's no standalone gravity projection), so it isn't directly handled by `rotation_sequence`.

Added a particle-orbit regression test (sequential + `parallel_frames`).