### PR TITLE
feat(immersive): isosurface + shading + field-driven absorption + interactive AMR window

### DIFF
--- a/docs/src/immersive.md
+++ b/docs/src/immersive.md
@@ -233,6 +233,9 @@ then `amr_volume(data, var, unit)` (any `getvar` quantity). Camera positions are
 | View type | `perspective_camera` / `equirect_camera` (360°) / `fisheye_camera` (dome) | — |
 | Resolution / smoothness | `res`, `aa` (1–3), `smooth=true` | `render_view` / `render_scene` |
 | What accumulates | `mode=` `:max` (crisp MIP) / `:emission` / `:rt` / `:sum` | `render_view` |
+| **Isosurface** at a value | `mode=:iso`, `level=` (+ `light`, `ambient`, `diffuse`, `specular`) | `render_view` |
+| **Gradient shading** (3-D form) | built into `:iso`; `shade=…` lighting controls | `render_view` |
+| **Physical RT absorption** from a field | `absorb_by=` (e.g. dust/`n_H`) + `absorb_vmin/vmax` | `field_channel` |
 | Which density range shows | `vmin` / `vmax` (log of the opacity field) | `field_channel` |
 | Colour from a 2nd field (coloured-density) | `color_by=:T`, `color_vmin` / `color_vmax`, `colormap`, `reverse` | `field_channel` |
 | How solid / wispy | `opacity` (higher = solider), `gamma` (>1 = wispier) | `field_channel` |
@@ -251,6 +254,19 @@ extrema(log10.(filter(>(0), getvar(gas, :T,   :K))))    # → color_vmin/color_v
 Then iterate: render a low-`res` still, adjust the dials, re-render. `smooth=false`/lower `res` for
 fast previews; raise `res`/`aa` for the final frame. Diffuse channels (a hot halo) should use a low
 `opacity` so you see *through* them; raise `gamma` to thin them further.
+
+
+
+## Interactive window (live, pure AMR)
+
+`interactive_view(vol)` opens a live window that **ray-casts the AMR data directly** (no uniform grid)
+and re-renders as you orbit (left-drag) and zoom (scroll) — low resolution while dragging, crisp on
+release. It needs an interactive backend:
+
+```julia
+using GLMakie                       # interactive backend (CairoMakie can't show live windows)
+interactive_view(vol; mode=:max)    # or :emission / :rt / :iso (with level=…)
+```
 
 ## Concepts & references
 

--- a/ext/MeraMakieExt.jl
+++ b/ext/MeraMakieExt.jl
@@ -504,4 +504,49 @@ function Mera.flythrough(vol::Mera.AmrVolume, kind::Symbol, keyframes;
     return filename
 end
 
+"""
+    interactive_view(vol; target=boxcenter(vol), distance=0.6·boxlen, azimuth=0.6, elevation=0.5,
+                     fov_deg=55, mode=:max, level=1.0, res=420, drag_res=170, smooth=true,
+                     colormap=:inferno, logscale=true) -> Figure
+
+Open a live window that **ray-casts the pure AMR data directly** (no uniform grid) and re-renders as you
+orbit (left-drag) and zoom (scroll) — low resolution while dragging, crisp on release. Needs an
+interactive backend (`using GLMakie`). `mode` is any `render_view` mode (`:max`/`:emission`/`:rt`/`:iso`…).
+"""
+function Mera.interactive_view(vol::Mera.AmrVolume; target=Mera.boxcenter(vol),
+        distance::Real=0.6*vol.boxlen, azimuth::Real=0.6, elevation::Real=0.5, fov_deg=55,
+        mode::Symbol=:max, level::Real=1.0, res::Int=420, drag_res::Int=170, smooth::Bool=true,
+        colormap=:inferno, logscale::Bool=true)
+    az = Ref(float(azimuth)); el = Ref(float(elevation)); dist = Ref(float(distance))
+    tg = (Float64(target[1]), Float64(target[2]), Float64(target[3]))
+    eye() = (tg[1]+dist[]*cos(el[])*cos(az[]), tg[2]+dist[]*cos(el[])*sin(az[]), tg[3]+dist[]*sin(el[]))
+    shoot(r) = Mera._prep(Mera.render_view(vol, Mera.perspective_camera(eye(), tg; fov_deg=fov_deg);
+                          res=r, mode=mode, smooth=smooth, level=level); logscale=logscale)
+    frame = Makie.Observable(shoot(res))
+    fig = Makie.Figure(size=(res, res))
+    ax = Makie.Axis(fig[1,1], aspect=Makie.DataAspect()); Makie.hidedecorations!(ax); Makie.hidespines!(ax)
+    Makie.heatmap!(ax, frame; colormap=colormap, nan_color=:black)
+    sc = fig.scene; drag = Ref(false); last = Ref((0.0, 0.0))
+    Makie.on(Makie.events(sc).mousebutton) do ev
+        if ev.button == Makie.Mouse.left
+            if ev.action == Makie.Mouse.press
+                drag[] = true; last[] = Tuple(Float64.(Makie.events(sc).mouseposition[]))
+            else
+                drag[] = false; frame[] = shoot(res)                 # crisp render on release
+            end
+        end
+    end
+    Makie.on(Makie.events(sc).mouseposition) do p
+        if drag[]
+            dx = p[1]-last[][1]; dy = p[2]-last[][2]; last[] = Tuple(Float64.(p))
+            az[] -= 0.01*dx; el[] = clamp(el[] + 0.01*dy, -1.4, 1.4)
+            frame[] = shoot(drag_res)                                # fast render while dragging
+        end
+    end
+    Makie.on(Makie.events(sc).scroll) do (sx, sy)
+        dist[] = clamp(dist[]*(1 - 0.12*sy), 0.05*vol.boxlen, 3*vol.boxlen); frame[] = shoot(res)
+    end
+    Makie.display(fig); return fig
+end
+
 end # module

--- a/src/Mera.jl
+++ b/src/Mera.jl
@@ -209,6 +209,7 @@ export
     orbit_keyframes,
     flythrough_montage,
     flythrough,
+    interactive_view,
     fluxbudget,
     fluxtimeseries,
     fluxprofile,

--- a/src/functions/immersive.jl
+++ b/src/functions/immersive.jl
@@ -103,6 +103,48 @@ end
     return a0*(1-tz)+a1*tz
 end
 
+# central-difference gradient of the (trilinear) field at a point, step ~ half the local cell → unit
+# normal (for isosurface / gradient shading). Returns (0,0,0) where the field is flat.
+@inline function _grad(v::AmrVolume, x, y, z, h)
+    e = 0.5h
+    gx = _trilin(v, x+e,y,z,h) - _trilin(v, x-e,y,z,h)
+    gy = _trilin(v, x,y+e,z,h) - _trilin(v, x,y-e,z,h)
+    gz = _trilin(v, x,y,z+e,h) - _trilin(v, x,y,z-e,h)
+    n = sqrt(gx^2+gy^2+gz^2)
+    n < 1e-30 ? (0.0,0.0,0.0) : (gx/n, gy/n, gz/n)
+end
+
+# Lambert + Blinn specular shading. Normal lit from both sides (abs) so isosurfaces are never black.
+@inline function _shade(nx,ny,nz, vx,vy,vz, lx,ly,lz, ambient, diffuse, specular, shininess)
+    diff = diffuse*abs(nx*lx+ny*ly+nz*lz)
+    hx=lx-vx; hy=ly-vy; hz=lz-vz; hn=sqrt(hx^2+hy^2+hz^2); hn<1e-12 && (hn=1.0)
+    spec = specular*abs(nx*hx/hn+ny*hy/hn+nz*hz/hn)^shininess
+    return clamp(ambient+diff+spec, 0.0, 1.0)
+end
+
+# march for an ISOSURFACE at `level`: first crossing along the ray, linearly refined, then shaded by
+# the field gradient (surface normal). NaN if the ray never crosses the level.
+@inline function _cast_iso(v::AmrVolume, ox,oy,oz, dx,dy,dz, level, smooth, lx,ly,lz, ambient, diffuse, specular, shininess)
+    t0, t1 = _box_t(v, ox,oy,oz, dx,dy,dz); t1 <= t0 && return NaN
+    floor_dt = 1e-6*v.boxlen
+    prev = NaN; pt = t0; t = t0
+    @inbounds while t < t1
+        x=ox+t*dx; y=oy+t*dy; z=oz+t*dz
+        _, h = _leaf(v, x, y, z)
+        val = smooth ? _trilin(v,x,y,z,h) : _leaf(v,x,y,z)[1]
+        if !isnan(prev) && (prev-level)*(val-level) <= 0 && prev != val
+            frac = (level-prev)/(val-prev); tc = pt + frac*(t-pt)
+            cx=ox+tc*dx; cy=oy+tc*dy; cz=oz+tc*dz; _, hc = _leaf(v,cx,cy,cz)
+            nx,ny,nz = _grad(v,cx,cy,cz,hc)
+            (nx==0.0 && ny==0.0 && nz==0.0) && return ambient
+            return _shade(nx,ny,nz, dx,dy,dz, lx,ly,lz, ambient, diffuse, specular, shininess)
+        end
+        prev = val; pt = t
+        t += max(0.5*h, floor_dt)
+    end
+    return NaN
+end
+
 # ray ∩ box [0,boxlen]³ → (t_enter, t_exit); t_exit<t_enter when missed
 @inline function _box_t(v::AmrVolume, ox,oy,oz, dx,dy,dz)
     bl = v.boxlen; t0 = 0.0; t1 = Inf
@@ -244,17 +286,22 @@ trilinear reconstruction (de-blocked); `aa` is jittered supersampling. Backgroun
 is `NaN`. Turn it into an image with [`as_image`](@ref)/[`save_view`](@ref).
 """
 function render_view(vol::AmrVolume, cam::Camera; res::Int=512, mode::Symbol=:emission,
-        stepfrac::Real=0.5, power::Real=1.0, kappa::Real=0.1, smooth::Bool=true, aa::Int=1)
+        stepfrac::Real=0.5, power::Real=1.0, kappa::Real=0.1, smooth::Bool=true, aa::Int=1,
+        level::Real=1.0, light=(-1.,-1.,1.), ambient::Real=0.25, diffuse::Real=0.8,
+        specular::Real=0.3, shininess::Real=16.0)
     nx, ny = cam.kind === :equirect ? (2res, res) :
              cam.kind === :fisheye  ? (res, res)  : (round(Int, res*cam.aspect), res)
     img = fill(NaN, nx, ny); sf = Float64(stepfrac); pw = Float64(power); kp = Float64(kappa); ia = 1.0/aa
+    lv = Float64(level); ln = _imm_n(_imm_T(light)); am=Float64(ambient); di=Float64(diffuse); sp=Float64(specular); sh=Float64(shininess)
+    iso = mode === :iso
     Threads.@threads for j in 1:ny
         @inbounds for i in 1:nx
             acc = 0.0; n = 0
             for sj in 1:aa, si in 1:aa
                 uu = (i-1 + (si-0.5)*ia)/nx; vv = (j-1 + (sj-0.5)*ia)/ny
                 rd = _raydir(cam, uu, vv); rd === nothing && continue
-                val = _cast(vol, cam.pos..., rd..., mode, sf, pw, kp, smooth)
+                val = iso ? _cast_iso(vol, cam.pos..., rd..., lv, smooth, ln..., am, di, sp, sh) :
+                            _cast(vol, cam.pos..., rd..., mode, sf, pw, kp, smooth)
                 isnan(val) || (acc += val; n += 1)
             end
             n > 0 && (img[i,j] = acc/n)
@@ -334,12 +381,14 @@ field driving colour (`cvol`, the coloured-density technique), a colormap, value
 strength and a transfer `gamma`. Construct with [`field_channel`](@ref).
 """
 struct VolumeChannel
-    vol::AmrVolume
-    cvol::Union{Nothing,AmrVolume}
+    vol::AmrVolume                    # drives OPACITY (and emission if avol is set)
+    cvol::Union{Nothing,AmrVolume}   # drives COLOUR (coloured-density); nothing → use vol
+    avol::Union{Nothing,AmrVolume}   # drives ABSORPTION (field-driven RT); nothing → absorption from vol
     cmap::Vector{RGB{Float64}}
     vmin::Float64; vmax::Float64
     cvmin::Float64; cvmax::Float64
-    logscale::Bool; clogscale::Bool
+    avmin::Float64; avmax::Float64
+    logscale::Bool; clogscale::Bool; alogscale::Bool
     opacity::Float64
     gamma::Float64
     label::String
@@ -384,18 +433,19 @@ channel). `vmin/vmax` (and `color_vmin/color_vmax`) default to the 50ᵗʰ/99.9�
 makes faint gas wispier. Combine several in [`render_scene`](@ref).
 """
 function field_channel(data, var::Symbol, unit::Symbol=:standard; color_by=nothing,
-        color_unit::Symbol=:standard, colormap=:inferno, reverse::Bool=false, vmin=nothing, vmax=nothing,
-        color_vmin=nothing, color_vmax=nothing, logscale::Bool=true, color_logscale::Bool=true,
+        color_unit::Symbol=:standard, absorb_by=nothing, absorb_unit::Symbol=:standard,
+        colormap=:inferno, reverse::Bool=false, vmin=nothing, vmax=nothing,
+        color_vmin=nothing, color_vmax=nothing, absorb_vmin=nothing, absorb_vmax=nothing,
+        logscale::Bool=true, color_logscale::Bool=true, absorb_logscale::Bool=true,
         opacity::Real=4.0, gamma::Real=1.0, label::String=string(var), verbose::Bool=false)
     vol = amr_volume(data, var, unit; verbose=verbose)
     lo, hi = _autorange(vol, logscale, vmin, vmax); cmap = _to_cmap(colormap; reverse=reverse)
-    if color_by === nothing
-        VolumeChannel(vol, nothing, cmap, lo, hi, lo, hi, logscale, logscale, Float64(opacity), Float64(gamma), label)
-    else
-        cvol = amr_volume(data, color_by, color_unit; verbose=verbose)
-        clo, chi = _autorange(cvol, color_logscale, color_vmin, color_vmax)
-        VolumeChannel(vol, cvol, cmap, lo, hi, clo, chi, logscale, color_logscale, Float64(opacity), Float64(gamma), label)
-    end
+    cvol = color_by  === nothing ? nothing : amr_volume(data, color_by,  color_unit;  verbose=verbose)
+    avol = absorb_by === nothing ? nothing : amr_volume(data, absorb_by, absorb_unit; verbose=verbose)
+    clo, chi = cvol === nothing ? (lo, hi) : _autorange(cvol, color_logscale,  color_vmin,  color_vmax)
+    alo, ahi = avol === nothing ? (lo, hi) : _autorange(avol, absorb_logscale, absorb_vmin, absorb_vmax)
+    VolumeChannel(vol, cvol, avol, cmap, lo, hi, clo, chi, alo, ahi,
+                  logscale, color_logscale, absorb_logscale, Float64(opacity), Float64(gamma), label)
 end
 
 """
@@ -430,8 +480,17 @@ end
             val = smooth ? _trilin(ch.vol,x,y,z,h) : _leaf(ch.vol,x,y,z)[1]
             s = ch.logscale ? (val > 0 ? log10(val) : -Inf) : val
             n = (s-ch.vmin)/(ch.vmax-ch.vmin); n = n<0 ? 0. : n>1 ? 1. : n
-            n <= 0 && continue
-            ng = ch.gamma == 1.0 ? n : n^ch.gamma
+            # absorption from a separate field (field-driven RT) or from the opacity field itself
+            if ch.avol === nothing
+                na = n; em = 1.0
+            else
+                av = smooth ? _trilin(ch.avol,x,y,z,h) : _leaf(ch.avol,x,y,z)[1]
+                as = ch.alogscale ? (av > 0 ? log10(av) : -Inf) : av
+                na = (as-ch.avmin)/(ch.avmax-ch.avmin); na = na<0 ? 0. : na>1 ? 1. : na
+                em = n                                          # main field = emissivity when absorption is separate
+            end
+            (na <= 0 || em <= 0) && continue
+            ng = ch.gamma == 1.0 ? na : na^ch.gamma
             a = 1 - exp(-ch.opacity*ng*seg/ch.vol.boxlen*100); a <= 0 && continue
             if ch.cvol === nothing
                 nc = n
@@ -440,8 +499,8 @@ end
                 cs = ch.clogscale ? (cv > 0 ? log10(cv) : -Inf) : cv
                 nc = (cs-ch.cvmin)/(ch.cvmax-ch.cvmin); nc = nc<0 ? 0. : nc>1 ? 1. : nc
             end
-            cr,cg,cb = _cmcol(ch.cmap, nc); w = (1-A)*a
-            R += w*cr; G += w*cg; B += w*cb; A += w
+            cr,cg,cb = _cmcol(ch.cmap, nc); w = (1-A)*a*em
+            R += w*cr; G += w*cg; B += w*cb; A += (1-A)*a
         end
         t = tend
     end
@@ -571,3 +630,11 @@ function flythrough end
 flythrough(args...; kwargs...) = error(
     "`flythrough` records an mp4 and needs a Makie backend — run `using CairoMakie` (loads MeraMakieExt). " *
     "For a Makie-free still summary of the path use `flythrough_montage`.")
+
+# `interactive_view` opens a live window that re-ray-casts the AMR data on orbit/zoom → real method in
+# MeraMakieExt (needs an INTERACTIVE backend, GLMakie). It marches the pure AMR octree per frame — no
+# uniform grid — at a low resolution while dragging and a crisp one on release.
+function interactive_view end
+interactive_view(args...; kwargs...) = error(
+    "`interactive_view` opens a live, mouse-controlled window and needs an INTERACTIVE Makie backend — " *
+    "run `using GLMakie` (CairoMakie cannot show interactive windows). It re-renders the AMR data directly.")

--- a/test/61_immersive_tests.jl
+++ b/test/61_immersive_tests.jl
@@ -80,7 +80,7 @@ end
     @test Mera._aces(1e6) ≤ 1.0 && Mera._aces(1e6) > 0.95     # saturates ≤ 1
     @test Mera._aces(0.2) < Mera._aces(0.8)                   # monotone increasing
     vol = _imm_uniform(3, (i,j,k)->5.0); c = boxcenter(vol)
-    ch = Mera.VolumeChannel(vol, nothing, Mera._to_cmap(:viridis), -1.0, 1.0, -1.0, 1.0, true, true, 12.0, 1.0, "x")
+    ch = Mera.VolumeChannel(vol, nothing, nothing, Mera._to_cmap(:viridis), -1.0,1.0, -1.0,1.0, -1.0,1.0, true,true,true, 12.0, 1.0, "x")
     sc = render_scene([ch], perspective_camera((1.6,1.6,1.6), c; fov_deg=45); res=24, exposure=2.0)
     @test eltype(sc) <: Mera.Colorant && size(sc) == (24, 24)
     @test all(x -> 0 ≤ Mera.red(x) ≤ 1 && 0 ≤ Mera.green(x) ≤ 1 && 0 ≤ Mera.blue(x) ≤ 1, sc)  # in gamut
@@ -98,7 +98,7 @@ end
     @test eltype(im) <: Mera.Colorant && size(im) == (24, 24)
     tmp = tempname() * ".png"
     @test save_view(sv, tmp) == tmp && isfile(tmp) && filesize(tmp) > 0
-    rgb = render_scene([Mera.VolumeChannel(vol, nothing, Mera._to_cmap(:viridis), 0.0,3.0,0.0,3.0,false,false,10.0,1.0,"x")],
+    rgb = render_scene([Mera.VolumeChannel(vol, nothing, nothing, Mera._to_cmap(:viridis), 0.0,3.0, 0.0,3.0, 0.0,3.0, false,false,false, 10.0,1.0, "x")],
                        perspective_camera((1.6,1.6,1.6), c; fov_deg=45); res=24)
     tmp2 = tempname() * ".png"
     @test save_scene(rgb, tmp2) == tmp2 && isfile(tmp2) && filesize(tmp2) > 0
@@ -113,8 +113,34 @@ end
     vol = _imm_uniform(3, (i,j,k)->Float64(i)); c = boxcenter(vol)
     mont = flythrough_montage(vol, :perspective, [(c.+(1.,1.,1.), c), (c.+(0.6,0.,0.3), c)]; nframes=4, cols=2, res=16)
     @test eltype(mont) <: Mera.Colorant && size(mont) == (32, 32)             # 2 rows × 2 cols of 16×16
-    # mp4 flythrough needs a Makie backend; without one the core errors helpfully
+    # mp4 flythrough + interactive window need a Makie backend; without one the core errors helpfully
     @test_throws ErrorException flythrough(vol, :perspective, [(c.+(1.,1.,1.), c), (c, c)])
+    @test_throws ErrorException interactive_view(vol)
+end
+
+@testset "immersive: isosurface + gradient shading + field-driven absorption (data-free)" begin
+    # gradient of a linear x-ramp points along +x → unit normal ≈ (1,0,0)
+    ramp = _imm_uniform(4, (i,j,k)->Float64(i))
+    gx, gy, gz = Mera._grad(ramp, 0.5, 0.5, 0.5, 1/16)
+    @test isapprox(gx, 1.0; atol=1e-6) && abs(gy) < 1e-6 && abs(gz) < 1e-6
+    # shading is bounded and includes the ambient floor
+    sval = Mera._shade(1.,0.,0., 0.,0.,-1., 1.,0.,0., 0.25, 0.8, 0.3, 16.0)
+    @test 0.25 ≤ sval ≤ 1.0
+    # isosurface: a ray crossing the bright cube's level returns a shade in (0,1]; a miss → NaN
+    vol = _imm_uniform(3, (i,j,k)-> (3<=i<=6 && 3<=j<=6 && 3<=k<=6) ? 10.0 : 0.01); c = boxcenter(vol)
+    hit = Mera._cast_iso(vol, 0.1,0.1,0.1, Mera._imm_n((1.,1.,1.))..., 1.0, true, Mera._imm_n((-1.,-1.,1.))..., 0.25,0.8,0.3,16.0)
+    @test isfinite(hit) && 0 < hit ≤ 1
+    @test isnan(Mera._cast_iso(vol, 2.0,2.0,2.0, 1.,0.,0., 1.0, true, 0.,0.,1., 0.25,0.8,0.3,16.0))  # parallel, outside
+    iso = render_view(vol, perspective_camera((1.6,1.6,1.6), c; fov_deg=45); res=24, mode=:iso, level=1.0)
+    fin = filter(isfinite, iso)
+    @test !isempty(fin) && all(0 .≤ fin .≤ 1) && any(isnan, iso)
+    # field-driven absorption: a channel with a separate absorption field renders in gamut & differs
+    av  = _imm_uniform(3, (i,j,k)->0.1)                                   # uniform low absorption field
+    cm  = Mera._to_cmap(:viridis); cam = perspective_camera((1.6,1.6,1.6), c; fov_deg=45)
+    ch0 = Mera.VolumeChannel(vol, nothing, nothing, cm, -2.,1., -2.,1., -2.,1., true,true,true, 8.,1., "no-abs")
+    cha = Mera.VolumeChannel(vol, nothing, av,      cm, -2.,1., -2.,1., -2.,1., true,true,true, 8.,1., "abs")
+    s0 = render_scene([ch0], cam; res=24); sa = render_scene([cha], cam; res=24)
+    @test all(x -> 0 ≤ Mera.red(x) ≤ 1, sa) && s0 != sa                  # absorption field changes the result
 end
 
 # ---- data-backed integration (only with simulation data) ----


### PR DESCRIPTION
Adds the physically-meaningful + beautiful rendering modes you asked for, on top of the core ray-caster.

## New
- **`mode=:iso`** (`level=`) — first-crossing **isosurface**, gradient-**shaded** (Lambert+specular). Physical value-surfaces (e.g. the nH=1 cm⁻³ shell). `render_view` gains `level`/`light`/`ambient`/`diffuse`/`specular`/`shininess`.
- **Gradient (normal) shading** — central differences of the trilinear field → real 3-D form.
- **`field_channel(absorb_by=…)`** — emission from one field, **absorption from another** (e.g. dust/`n_H`): physical emission + self-absorption RT in `render_scene`.
- **`interactive_view(vol)`** — a live window that **ray-casts the pure AMR data directly (no uniform grid)**, orbit (drag) + zoom (scroll), low-res while moving / crisp on release. In `MeraMakieExt` (needs `using GLMakie`); core errors helpfully without.

## Tests
`test/61`: + isosurface / gradient / shading / field-driven-absorption oracles + the `interactive_view` fallback (all data-free). The iso/shading/absorption set passed locally (6/6); the rest of the suite ran green previously.

## Note
Local **disk is full** (container ~full, not just snapshots), so I couldn't run the final precompile locally — files are parse-checked and CI is the full gate.