### PR TITLE
feat(immersive): toggle the occupancy acceleration (occupancy= / set_occupancy)

### DIFF
--- a/src/Mera.jl
+++ b/src/Mera.jl
@@ -189,6 +189,7 @@ export
     # immersive 3-D visualisation (volume ray-caster)
     AmrVolume,
     amr_volume,
+    set_occupancy,
     boxcenter,
     boxspan,
     Camera,

--- a/src/functions/immersive.jl
+++ b/src/functions/immersive.jl
@@ -65,32 +65,55 @@ function _build_occ(v::AmrVolume)
 end
 
 """
+    set_occupancy(vol, on::Bool) -> AmrVolume
+
+Turn the occupancy acceleration on/off on an existing [`amr_volume`](@ref), **reusing the leaf hash** (so
+it is cheap — no re-indexing). `on=true` builds the coarse map; `on=false` drops it (full level descent).
+Handy for benchmarking the speed-up. (Equivalent at build time: `amr_volume(…; occupancy=false)`.)
+"""
+function set_occupancy(vol::AmrVolume, on::Bool)
+    if on
+        vol.occ === nothing || return vol
+        occ, Lc = _build_occ(vol)
+        return AmrVolume(vol.dicts, vol.lmin, vol.lmax, vol.boxlen, vol.unit, vol.nleaf, vol.scale, occ, Lc)
+    else
+        vol.occ === nothing && return vol
+        return AmrVolume(vol.dicts, vol.lmin, vol.lmax, vol.boxlen, vol.unit, vol.nleaf, vol.scale, nothing, 0)
+    end
+end
+
+"""
     amr_volume(dataobject, var, [unit]; verbose=true) -> AmrVolume
 
 Index AMR cell data for ray-casting **without resampling to a uniform grid**. Each leaf is stored
 once in a per-level hash keyed by its integer cell coordinates; memory is the data size, not
 `(2^lmax)³`. To zoom, pass a Mera [`subregion`](@ref) of `dataobject` first — only those leaves are
 indexed. Negative/NaN values are clamped to 0 (so voids and outside-data add nothing).
+
+`occupancy=true` (default) also builds a coarse max-level map so `_leaf` starts its descent at the finest
+level present near a point — a real speed-up for deep AMR (it skips failed fine-level lookups), and
+result-identical. Set `occupancy=false` to disable it, or toggle later with [`set_occupancy`](@ref).
 """
-function amr_volume(dataobject, var::Symbol, unit::Symbol=:standard; verbose::Bool=true)
+function amr_volume(dataobject, var::Symbol, unit::Symbol=:standard; occupancy::Bool=true, verbose::Bool=true)
     cx = getvar(dataobject, :cx); cy = getvar(dataobject, :cy); cz = getvar(dataobject, :cz)
     lv = getvar(dataobject, :level); val = getvar(dataobject, var, unit)
     lmax = Int(maximum(lv)); lmin = Int(minimum(lv))
     dicts = [Dict{NTuple{3,Int32},Float64}() for _ in 1:lmax]
-    Lc = min(lmin, 8); Nc = 1 << Lc; occ = zeros(UInt8, Nc, Nc, Nc)   # coarse max-level occupancy (level-skip accel)
+    Lc = min(lmin, 8); Nc = 1 << Lc                                   # coarse max-level occupancy (level-skip accel)
+    occ = occupancy ? zeros(UInt8, Nc, Nc, Nc) : nothing
     @inbounds for i in eachindex(lv)
         L = Int(lv[i]); cxi = cx[i]; cyi = cy[i]; czi = cz[i]
         vv = val[i]; vv = (isnan(vv) || vv < 0) ? 0.0 : Float64(vv)
         dicts[L][(Int32(cxi), Int32(cyi), Int32(czi))] = vv
-        _mark_occ!(occ, Nc, cxi, cyi, czi, L)
+        occupancy && _mark_occ!(occ, Nc, cxi, cyi, czi, L)
     end
     n = length(lv)
     verbose && println("amr_volume: $n leaves, levels $(lmin)–$(lmax), boxlen $(dataobject.boxlen) " *
-                       "[code]  (no uniform grid — native AMR marching)")
+                       "[code]  (no uniform grid — native AMR marching$(occupancy ? "" : ", occupancy OFF"))")
     n > 50_000_000 && @warn "amr_volume indexed $n leaves (~$(round(n*40/1e9, digits=1)) GB of index, " *
         "lookups descend $(lmax-lmin+1) levels). For a big box, `subregion(data, …)` before amr_volume " *
         "indexes only the zoom region — far less RAM and much faster."
-    return AmrVolume(dicts, lmin, lmax, Float64(dataobject.boxlen), unit, n, dataobject.scale, occ, Lc)
+    return AmrVolume(dicts, lmin, lmax, Float64(dataobject.boxlen), unit, n, dataobject.scale, occ, occupancy ? Lc : 0)
 end
 
 "Centre of the simulation box in code units, as an NTuple{3}."

--- a/test/61_immersive_tests.jl
+++ b/test/61_immersive_tests.jl
@@ -37,6 +37,10 @@ end
         same &= Mera._leaf(v2, x, y, z) == Mera._leaf(v2o, x, y, z)
     end
     @test same
+    # toggle on/off (reuses the leaf hash), result unchanged
+    @test set_occupancy(v2, true).occ !== nothing
+    @test set_occupancy(v2o, false).occ === nothing
+    @test Mera._leaf(set_occupancy(v2, true), 0.5, 0.5, 0.5) == Mera._leaf(v2, 0.5, 0.5, 0.5)
 end
 
 @testset "immersive: ray–box intersection (data-free)" begin
@@ -210,10 +214,16 @@ if @isdefined(DATA_AVAILABLE) && DATA_AVAILABLE && haskey(DATASETS, :spiral_clum
         @test vol.nleaf == length(getvar(gas, :rho))                          # one leaf per cell, no resample
         @test vol.boxlen ≈ gas.boxlen
         c = boxcenter(vol)
+        @test vol.occ !== nothing                                            # occupancy accel on by default
         cam = perspective_camera(c .+ (30,20,24), c; fov_deg=55)
         img = render_view(vol, cam; res=80, mode=:max, smooth=true)
         fin = filter(isfinite, img)
         @test !isempty(fin) && maximum(fin) > 0                               # non-empty, real signal
+        # occupancy on vs off: identical render (accel only skips failed probes), and a no-occ build works
+        voloff = amr_volume(gas, :rho, :nH; occupancy=false, verbose=false)
+        @test voloff.occ === nothing
+        @test isequal(render_view(voloff, cam; res=64, mode=:max, smooth=true),
+                      render_view(vol,    cam; res=64, mode=:max, smooth=true))
         # pxsize with a physical unit resolves via the volume's scale (like projection)
         imgpx = render_view(vol, cam; pxsize=[2.0, :kpc], mode=:max)
         @test size(imgpx, 1) == size(imgpx, 2) && size(imgpx, 1) > 4          # perspective square, sane dims


### PR DESCRIPTION
Makes the deep-AMR occupancy accel **controllable** (it was always-on):

- `amr_volume(gas, var; occupancy=false)` — build without the coarse map (full level descent).
- `set_occupancy(vol, on::Bool)` — flip it on an existing volume, **reusing the leaf hash** (cheap, no re-indexing). Exported. Great for benchmarking the speed-up (the notebook now has a section timing OFF vs ON).

On by default; **result-identical** either way (it only skips *failed* fine-level probes). Tested: toggle round-trips + render(occ on) == render(occ off) on spiral_clumps.