### PR TITLE
fix(immersive): mode-aware jitter (smooth :max) + save_figure + montage pxsize

### DIFF
--- a/src/Mera.jl
+++ b/src/Mera.jl
@@ -207,6 +207,7 @@ export
     scene_figure,
     save_view,
     save_scene,
+    save_figure,
     orbit_keyframes,
     flythrough_montage,
     flythrough,

--- a/src/functions/immersive.jl
+++ b/src/functions/immersive.jl
@@ -451,7 +451,8 @@ function render_view(vol::AmrVolume, cam::Camera; res::Int=512, pxsize=nothing, 
             for sj in 1:aa, si in 1:aa
                 uu = (i-1 + (si-0.5)*ia)/nx; vv = (j-1 + (sj-0.5)*ia)/ny
                 rd = _raydir(cam, uu, vv); rd === nothing && continue
-                jt = jitter ? _hash01((i-1)*aa+si, (j-1)*aa+sj) : 0.0
+                # jitter only helps accumulating modes; on :max / :iso it just adds speckle → skip there
+                jt = (jitter && !iso && mode !== :max) ? _hash01((i-1)*aa+si, (j-1)*aa+sj) : 0.0
                 val = iso ? _cast_iso(vol, cam.pos..., rd..., lv, sm, ln..., am, di, sp, sh, ia_, jt) :
                             _cast(vol, cam.pos..., rd..., mode, sf, pw, kp, sm, jt)
                 isnan(val) || (acc += val; n += 1)
@@ -522,6 +523,17 @@ scene_figure(img) = as_image(img)
 
 Colour a scalar [`render_view`](@ref) image and write it to PNG (via FileIO)."""
 save_view(img, filename::AbstractString; kw...) = (FileIO.save(filename, as_image(img; kw...)); filename)
+
+"""
+    save_figure(img, filename; colormap=:inferno, logscale=true, bg=:black, reverse=false) -> filename
+
+Write any immersive image to a file — the saving counterpart of [`view_figure`](@ref)/[`scene_figure`](@ref).
+A scalar [`render_view`](@ref) result is coloured via `colormap`; an already-RGB
+[`render_scene`](@ref)/`view_figure`/`scene_figure` result is written as-is (colour kwargs ignored)."""
+save_figure(img::AbstractMatrix{<:Real}, filename::AbstractString; kw...) =
+    (FileIO.save(filename, as_image(img; kw...)); filename)
+save_figure(img::AbstractMatrix{<:Colorant}, filename::AbstractString; kw...) =
+    (FileIO.save(filename, as_image(img)); filename)
 
 # -------------------------------------------------------------------------------------
 #  Multi-channel compositing — several tracers, each its own colormap + opacity, blended
@@ -783,10 +795,11 @@ function flythrough_montage(vol::AmrVolume, kind::Symbol, keyframes; nframes::In
         res::Int=240, pxsize=nothing, mode::Symbol=:max, smooth=true, aa::Int=1, fov_deg=60, up=(0.,0.,1.),
         colormap=:inferno, logscale::Bool=true)
     poss = [k[1] for k in keyframes]; tgts = [k[2] for k in keyframes]
-    tiles = [as_image(render_view(vol, _immcam(kind, _spline(poss, nframes==1 ? 0.0 : (k-1)/(nframes-1)),
-                                                     _spline(tgts, nframes==1 ? 0.0 : (k-1)/(nframes-1)), up, fov_deg);
-                                  res=res, pxsize=pxsize, mode=mode, smooth=smooth, aa=aa); colormap=colormap, logscale=logscale)
-             for k in 1:nframes]
+    sof(k) = nframes == 1 ? 0.0 : (k-1)/(nframes-1)
+    mk(k) = _immcam(kind, _spline(poss, sof(k)), _spline(tgts, sof(k)), up, fov_deg)
+    rfix = pxsize === nothing ? res : _resolve_res(vol, mk(1), res, pxsize)   # one tile size for all frames
+    tiles = [as_image(render_view(vol, mk(k); res=rfix, mode=mode, smooth=smooth, aa=aa);
+                      colormap=colormap, logscale=logscale) for k in 1:nframes]
     rows = cld(nframes, cols); th, tw = size(tiles[1])             # tiles already oriented (row,col)
     canvas = fill(RGB{Float64}(0,0,0), rows*th, cols*tw)
     for k in 1:nframes

--- a/test/61_immersive_tests.jl
+++ b/test/61_immersive_tests.jl
@@ -135,7 +135,11 @@ end
     @test eltype(vf) <: Mera.Colorant
     tmp3 = tempname() * ".png"
     @test save_view(vf, tmp3) == tmp3 && isfile(tmp3) && filesize(tmp3) > 0
-    rm(tmp, force=true); rm(tmp2, force=true); rm(tmp3, force=true)
+    # save_figure: unified saver — scalar (coloured) AND RGB (as-is)
+    tmp4 = tempname()*".png"; tmp5 = tempname()*".png"
+    @test save_figure(sv, tmp4; colormap=:viridis) == tmp4 && filesize(tmp4) > 0
+    @test save_figure(scene_figure(rgb), tmp5) == tmp5 && filesize(tmp5) > 0
+    rm(tmp, force=true); rm(tmp2, force=true); rm(tmp3, force=true); rm(tmp4, force=true); rm(tmp5, force=true)
     # the show_progress flag is accepted and the render still returns a correct image
     pp = render_view(vol, perspective_camera((1.6,1.6,1.6), c; fov_deg=45); res=12, mode=:max, show_progress=true)
     @test size(pp) == (12, 12)
@@ -149,6 +153,9 @@ end
     vol = _imm_uniform(3, (i,j,k)->Float64(i)); c = boxcenter(vol)
     mont = flythrough_montage(vol, :perspective, [(c.+(1.,1.,1.), c), (c.+(0.6,0.,0.3), c)]; nframes=4, cols=2, res=16)
     @test eltype(mont) <: Mera.Colorant && size(mont) == (32, 32)             # 2 rows × 2 cols of 16×16
+    # pxsize varies per-frame dims → montage must still tile (uniform tile size), not DimensionMismatch
+    montpx = flythrough_montage(vol, :perspective, [(c.+(1.,1.,1.), c), (c.+(0.6,0.,0.3), c)]; nframes=4, cols=2, pxsize=0.1)
+    @test eltype(montpx) <: Mera.Colorant && size(montpx,1) > 0 && size(montpx,1) == 2*(size(montpx,1)÷2)
     # mp4 flythrough + interactive window need a Makie backend; without one the core errors helpfully
     @test_throws ErrorException flythrough(vol, :perspective, [(c.+(1.,1.,1.), c), (c, c)])
     @test_throws ErrorException interactive_view(vol)


### PR DESCRIPTION
Three fixes from running the notebook on a deep-AMR sim (AVALON, 167M cells):

1. **Smoothness regression** — `jitter` (default on) was speckling `:max`/`:iso` renders (each pixel grabbed a different MIP peak). Jitter is now **mode-aware**: applied only to accumulating modes (`:emission`/`:rt`/`:sum`), where it breaks moiré; `:max`/`:iso` are smooth again.
2. **`save_figure(img, file; …)`** — unified saver, the counterpart to `view_figure`/`scene_figure`. Colours a scalar render via `colormap`, writes an RGB result as-is. Exported.
3. **`flythrough_montage` + `pxsize`** threw `DimensionMismatch` (per-frame distance → different tile sizes). Now uses one tile size for all frames.

Tests: save_figure (scalar+RGB), montage with pxsize, all immersive green.