### PR TITLE
feat(immersive): P1 batch + science wrappers (signed fields, tone-map, movies, column_map/derived_volume/moment_maps)

### DIFF
--- a/ext/MeraMakieExt.jl
+++ b/ext/MeraMakieExt.jl
@@ -507,6 +507,32 @@ function Mera.flythrough(vol::Mera.AmrVolume, kind::Symbol, keyframes;
     return filename
 end
 
+# multi-tracer fly-through: a vector of field_channel/points_channel layers rendered with render_scene
+# (coloured-density + stars) per frame → mp4. `_disp` maps render_scene's display-oriented RGB to Makie's
+# image! convention (i→x, j→y-up) so the movie matches save_scene / inline display.
+_disp(D) = reverse(permutedims(D), dims=2)
+function Mera.flythrough(channels::AbstractVector, kind::Symbol, keyframes;
+        nframes::Int=120, filename::AbstractString="flythrough.mp4", res::Int=480, pxsize=nothing,
+        aa::Int=1, smooth=true, fov_deg=60, up=(0.,0.,1.), framerate::Int=24,
+        exposure::Real=1.0, saturation::Real=1.15, gamma::Real=1.0, bg=(0.,0.,0.),
+        show_progress::Bool=true)
+    poss = [k[1] for k in keyframes]; tgts = [k[2] for k in keyframes]
+    mk(s) = Mera._immcam(kind, Mera._spline(poss, s), Mera._spline(tgts, s), up, fov_deg)
+    rs(s) = Mera.render_scene(channels, mk(s); res=res, pxsize=pxsize, aa=aa, smooth=smooth,
+                              exposure=exposure, saturation=saturation, gamma=gamma, bg=bg)
+    h, w = size(rs(0.0))
+    fig = Makie.Figure(size=(w, h), figure_padding=0)
+    ax = Makie.Axis(fig[1,1], aspect=Makie.DataAspect()); Makie.hidedecorations!(ax); Makie.hidespines!(ax)
+    prog = show_progress ? Mera.Progress(nframes; desc="flythrough ", dt=0.5) : nothing
+    Makie.record(fig, filename, 1:nframes; framerate=framerate, compression=18) do fr
+        s = nframes == 1 ? 0.0 : (fr-1)/(nframes-1)
+        Makie.empty!(ax); Makie.image!(ax, _disp(rs(s)))
+        prog === nothing || Mera.next!(prog)
+    end
+    return filename
+end
+Mera.flythrough(ch::Mera.ImmersiveChannel, kind::Symbol, keyframes; kw...) = Mera.flythrough([ch], kind, keyframes; kw...)
+
 """
     interactive_view(vol; target=boxcenter(vol), distance=0.6·boxlen, azimuth=0.6, elevation=0.5,
                      fov_deg=55, mode=:max, level=1.0, res=420, drag_res=170, smooth=true,
@@ -551,5 +577,45 @@ function Mera.interactive_view(vol::Mera.AmrVolume; target=Mera.boxcenter(vol),
     end
     Makie.display(fig); return fig
 end
+
+# multi-tracer interactive orbit: render_scene (coloured-density + stars) live, RGB via image!
+function Mera.interactive_view(channels::AbstractVector; target=nothing, distance=nothing,
+        azimuth::Real=0.6, elevation::Real=0.5, fov_deg=55, res::Int=420, drag_res::Int=160, smooth=true,
+        exposure::Real=1.0, saturation::Real=1.15, gamma::Real=1.0, bg=(0.,0.,0.))
+    vc = findfirst(c -> c isa Mera.VolumeChannel, channels)
+    vc === nothing && error("interactive_view needs at least one field_channel (volume layer)")
+    vol = channels[vc].vol
+    tg = target === nothing ? Mera.boxcenter(vol) : (Float64(target[1]),Float64(target[2]),Float64(target[3]))
+    az = Ref(float(azimuth)); el = Ref(float(elevation))
+    dist = Ref(float(distance === nothing ? 0.6*vol.boxlen : distance))
+    eye() = (tg[1]+dist[]*cos(el[])*cos(az[]), tg[2]+dist[]*cos(el[])*sin(az[]), tg[3]+dist[]*sin(el[]))
+    shoot(r) = _disp(Mera.render_scene(channels, Mera.perspective_camera(eye(), tg; fov_deg=fov_deg);
+                     res=r, smooth=smooth, exposure=exposure, saturation=saturation, gamma=gamma, bg=bg))
+    frame = Makie.Observable(shoot(res))
+    fig = Makie.Figure(size=(res, res))
+    ax = Makie.Axis(fig[1,1], aspect=Makie.DataAspect()); Makie.hidedecorations!(ax); Makie.hidespines!(ax)
+    Makie.image!(ax, frame)
+    sc = fig.scene; drag = Ref(false); last = Ref((0.0, 0.0))
+    Makie.on(Makie.events(sc).mousebutton) do ev
+        if ev.button == Makie.Mouse.left
+            if ev.action == Makie.Mouse.press
+                drag[] = true; last[] = Tuple(Float64.(Makie.events(sc).mouseposition[]))
+            else
+                drag[] = false; frame[] = shoot(res)
+            end
+        end
+    end
+    Makie.on(Makie.events(sc).mouseposition) do p
+        if drag[]
+            dx = p[1]-last[][1]; dy = p[2]-last[][2]; last[] = Tuple(Float64.(p))
+            az[] -= 0.01*dx; el[] = clamp(el[] + 0.01*dy, -1.4, 1.4); frame[] = shoot(drag_res)
+        end
+    end
+    Makie.on(Makie.events(sc).scroll) do (sx, sy)
+        dist[] = clamp(dist[]*(1 - 0.12*sy), 0.05*vol.boxlen, 3*vol.boxlen); frame[] = shoot(res)
+    end
+    Makie.display(fig); return fig
+end
+Mera.interactive_view(ch::Mera.ImmersiveChannel; kw...) = Mera.interactive_view([ch]; kw...)
 
 end # module

--- a/src/Mera.jl
+++ b/src/Mera.jl
@@ -189,6 +189,9 @@ export
     # immersive 3-D visualisation (volume ray-caster)
     AmrVolume,
     amr_volume,
+    derived_volume,
+    column_map,
+    moment_maps,
     set_occupancy,
     boxcenter,
     boxspan,

--- a/src/functions/immersive.jl
+++ b/src/functions/immersive.jl
@@ -97,8 +97,15 @@ level present near a point — a real speed-up for deep AMR (it skips failed fin
 result-identical. Set `occupancy=false` to disable it, or toggle later with [`set_occupancy`](@ref).
 """
 function amr_volume(dataobject, var::Symbol, unit::Symbol=:standard; signed::Bool=false, occupancy::Bool=true, verbose::Bool=true)
+    val = getvar(dataobject, var, unit)
+    return _index_volume(dataobject, val, unit; signed=signed, occupancy=occupancy, verbose=verbose)
+end
+
+# core indexer: build the per-level leaf hash + occupancy from precomputed per-cell `val` (shared by
+# amr_volume and derived_volume). `cx/cy/cz/level` come from the dataobject; `val` is any per-cell vector.
+function _index_volume(dataobject, val, unit::Symbol; signed::Bool=false, occupancy::Bool=true, verbose::Bool=true)
     cx = getvar(dataobject, :cx); cy = getvar(dataobject, :cy); cz = getvar(dataobject, :cz)
-    lv = getvar(dataobject, :level); val = getvar(dataobject, var, unit)
+    lv = getvar(dataobject, :level)
     lmax = Int(maximum(lv)); lmin = Int(minimum(lv))
     dicts = [Dict{NTuple{3,Int32},Float64}() for _ in 1:lmax]
     Lc = min(lmin, 8); Nc = 1 << Lc                                   # coarse max-level occupancy (level-skip accel)
@@ -116,6 +123,28 @@ function amr_volume(dataobject, var::Symbol, unit::Symbol=:standard; signed::Boo
         "lookups descend $(lmax-lmin+1) levels). For a big box, `subregion(data, …)` before amr_volume " *
         "indexes only the zoom region — far less RAM and much faster."
     return AmrVolume(dicts, lmin, lmax, Float64(dataobject.boxlen), unit, n, dataobject.scale, occ, occupancy ? Lc : 0)
+end
+
+"""
+    derived_volume(data, f, vars; units=:standard, signed=false, occupancy=true, verbose=true) -> AmrVolume
+
+Build an [`AmrVolume`](@ref) whose per-leaf value is `f(v₁, v₂, …)` evaluated at index time, where `vᵢ =
+getvar(data, vars[i], units[i])`. For quantitative emissivity maps render the result with `mode=:sum` (a
+column integral). `units` is one symbol (applied to all) or a vector aligned with `vars`.
+
+Examples — thermal bremsstrahlung `∝ n²√T`, then a `:sum` surface-brightness map:
+```julia
+em = derived_volume(gas, (n,T)->n^2*sqrt(T), [:rho, :T]; units=[:nH, :K])
+sb = render_view(em, cam; mode=:sum)            # ∝ ∫ n²√T dl  (×scale for physical units)
+```
+"""
+function derived_volume(data, f, vars::AbstractVector{Symbol};
+        units=:standard, signed::Bool=false, occupancy::Bool=true, verbose::Bool=true)
+    us = units isa Symbol ? fill(units, length(vars)) : collect(units)
+    length(us) == length(vars) || throw(ArgumentError("units must be one symbol or match vars length"))
+    cols = [getvar(data, v, u) for (v, u) in zip(vars, us)]
+    val = f.(cols...)
+    return _index_volume(data, val, :derived; signed=signed, occupancy=occupancy, verbose=verbose)
 end
 
 "Centre of the simulation box in code units, as an NTuple{3}."
@@ -469,6 +498,76 @@ function render_view(vol::AmrVolume, cam::Camera; res::Int=512, pxsize=nothing, 
         prog === nothing || next!(prog)
     end
     return img
+end
+
+"""
+    column_map(vol, cam; length_unit=:cm, kwargs...) -> Matrix{Float64}
+
+Quantitative line-of-sight column of the field: `∫ value · dl`, with the path length converted to
+`length_unit` via the volume's `scale`. For `amr_volume(gas, :rho, :nH)` with `length_unit=:cm` this is the
+hydrogen column density N_H [cm⁻²]; choose `:pc`/`:kpc` for surface densities. Extra kwargs (`pxsize`,
+`smooth`, `aa`, `jitter`, `show_progress`, …) pass to [`render_view`](@ref). Background (ray miss) stays
+`NaN`. Colour/save with [`as_image`](@ref)/[`save_view`](@ref) (use `vmin/vmax` in log10 units).
+"""
+function column_map(vol::AmrVolume, cam::Camera; length_unit::Symbol=:cm, kwargs...)
+    vol.scale === nothing && error("column_map needs a volume built from a dataobject (for the length scale)")
+    return render_view(vol, cam; mode=:sum, kwargs...) .* getfield(vol.scale, length_unit)
+end
+
+# one ray, density-weighted LOS-velocity moments. Accumulates S=∫ρdl, Sv=∫ρ v∥ dl, Sv2=∫ρ v∥² dl with
+# v∥ = v·d̂ (ray direction, + = away from camera) evaluated per sample (correct for fanned-out rays).
+@inline function _cast_moment(ρ::AmrVolume, vx,vy,vz, ox,oy,oz, dx,dy,dz, stepfrac, sm::Int, jit=0.0)
+    t0,t1 = _box_t(ρ, ox,oy,oz, dx,dy,dz); t1 <= t0 && return (NaN,NaN,NaN)
+    floor_dt = 1e-6*ρ.boxlen; S=0.0; Sv=0.0; Sv2=0.0; t=t0
+    @inbounds while t < t1
+        x=ox+t*dx; y=oy+t*dy; z=oz+t*dz; _, h = _leaf(ρ, x,y,z)
+        dt = max(stepfrac*h, floor_dt); tend = min(t+dt, t1); seg = tend-t
+        ts = jit>0 ? t+jit*seg : t; sx=ox+ts*dx; sy=oy+ts*dy; sz=oz+ts*dz
+        w = _sample_at(ρ, sx,sy,sz, h, sm)
+        if w > 0
+            vl = _sample_at(vx,sx,sy,sz,h,sm)*dx + _sample_at(vy,sx,sy,sz,h,sm)*dy + _sample_at(vz,sx,sy,sz,h,sm)*dz
+            ws = w*seg; S += ws; Sv += ws*vl; Sv2 += ws*vl*vl
+        end
+        t = tend
+    end
+    S <= 0 && return (NaN,NaN,NaN)
+    m1 = Sv/S; return (S, m1, sqrt(max(Sv2/S - m1*m1, 0.0)))
+end
+
+"""
+    moment_maps(ρ, vx, vy, vz, cam; res/pxsize, smooth, aa, jitter, stepfrac, show_progress)
+        -> (moment0, moment1, moment2)
+
+Density-weighted line-of-sight kinematics, evaluated **per ray** (so it is correct for perspective/fisheye,
+where the LOS direction varies across the image — unlike a single precomputed `v_los` volume). Returns three
+images: `moment0 = ∫ρ dl` (intensity), `moment1 = ∫ρ v∥ dl / ∫ρ dl` (mean LOS velocity, **+ = receding**),
+`moment2` (velocity dispersion). Build the inputs with `amr_volume(gas, :rho, :nH)` and
+`amr_volume(gas, :vx, :km_s; signed=true)` (likewise `:vy`,`:vz`); moment1/2 come out in the velocity unit.
+Colour moment1 with a diverging colormap + `logscale=false` + symmetric `vmin/vmax`.
+"""
+function moment_maps(ρ::AmrVolume, vx::AmrVolume, vy::AmrVolume, vz::AmrVolume, cam::Camera;
+        res::Int=512, pxsize=nothing, aa::Int=1, smooth=true, jitter::Bool=true,
+        stepfrac::Real=0.5, show_progress::Bool=false)
+    res = _resolve_res(ρ, cam, res, pxsize)
+    nx,ny = cam.kind===:equirect ? (2res,res) : cam.kind===:fisheye ? (res,res) : (round(Int,res*cam.aspect),res)
+    M0=fill(NaN,nx,ny); M1=fill(NaN,nx,ny); M2=fill(NaN,nx,ny); sf=Float64(stepfrac); ia=1.0/aa; sm=_smode(smooth)
+    prog = show_progress ? Progress(ny; desc="moment_maps ", dt=0.3) : nothing
+    Threads.@threads for j in 1:ny
+        @inbounds for i in 1:nx
+            s0=0.0; s1=0.0; s2=0.0; n=0
+            for sj in 1:aa, si in 1:aa
+                uu=(i-1+(si-0.5)*ia)/nx; vv=(j-1+(sj-0.5)*ia)/ny
+                rd=_raydir(cam,uu,vv); rd===nothing && continue
+                jt = jitter ? _hash01((i-1)*aa+si, (j-1)*aa+sj) : 0.0
+                a,b,c = _cast_moment(ρ, vx,vy,vz, cam.pos..., rd..., sf, sm, jt)
+                isnan(a) && continue
+                s0+=a; s1+=b; s2+=c; n+=1
+            end
+            if n>0; M0[i,j]=s0/n; M1[i,j]=s1/n; M2[i,j]=s2/n; end
+        end
+        prog === nothing || next!(prog)
+    end
+    return (M0, M1, M2)
 end
 
 # -------------------------------------------------------------------------------------

--- a/src/functions/immersive.jl
+++ b/src/functions/immersive.jl
@@ -88,13 +88,15 @@ end
 Index AMR cell data for ray-casting **without resampling to a uniform grid**. Each leaf is stored
 once in a per-level hash keyed by its integer cell coordinates; memory is the data size, not
 `(2^lmax)³`. To zoom, pass a Mera [`subregion`](@ref) of `dataobject` first — only those leaves are
-indexed. Negative/NaN values are clamped to 0 (so voids and outside-data add nothing).
+indexed. NaN→0; negatives are clamped to 0 too **unless `signed=true`** — set it for signed fields
+(velocity components, `B_z`, divergence, radial velocity) and display them with `logscale=false` + a
+diverging colormap + symmetric `vmin/vmax` (or, in a scene, `color_logscale=false` + `color_vmin/vmax`).
 
 `occupancy=true` (default) also builds a coarse max-level map so `_leaf` starts its descent at the finest
 level present near a point — a real speed-up for deep AMR (it skips failed fine-level lookups), and
 result-identical. Set `occupancy=false` to disable it, or toggle later with [`set_occupancy`](@ref).
 """
-function amr_volume(dataobject, var::Symbol, unit::Symbol=:standard; occupancy::Bool=true, verbose::Bool=true)
+function amr_volume(dataobject, var::Symbol, unit::Symbol=:standard; signed::Bool=false, occupancy::Bool=true, verbose::Bool=true)
     cx = getvar(dataobject, :cx); cy = getvar(dataobject, :cy); cz = getvar(dataobject, :cz)
     lv = getvar(dataobject, :level); val = getvar(dataobject, var, unit)
     lmax = Int(maximum(lv)); lmin = Int(minimum(lv))
@@ -103,7 +105,7 @@ function amr_volume(dataobject, var::Symbol, unit::Symbol=:standard; occupancy::
     occ = occupancy ? zeros(UInt8, Nc, Nc, Nc) : nothing
     @inbounds for i in eachindex(lv)
         L = Int(lv[i]); cxi = cx[i]; cyi = cy[i]; czi = cz[i]
-        vv = val[i]; vv = (isnan(vv) || vv < 0) ? 0.0 : Float64(vv)
+        vv = val[i]; vv = isnan(vv) ? 0.0 : Float64(vv); (!signed && vv < 0) && (vv = 0.0)
         dicts[L][(Int32(cxi), Int32(cyi), Int32(czi))] = vv
         occupancy && _mark_occ!(occ, Nc, cxi, cyi, czi, L)
     end
@@ -522,7 +524,7 @@ function as_image(img::AbstractMatrix{<:Real}; colormap=:inferno, logscale::Bool
     end
     return _orient(out)
 end
-as_image(rgb::AbstractMatrix{<:Colorant}) = _orient(rgb)
+as_image(rgb::AbstractMatrix{<:Colorant}) = rgb   # render_scene already returns a display-oriented image — pass through (don't re-orient)
 
 "Inline-display alias of [`as_image`](@ref) (kept for convenience)."
 view_figure(img; kw...) = as_image(img; kw...)
@@ -589,8 +591,13 @@ const ImmersiveChannel = Union{VolumeChannel,PointChannel}
 # auto value range from the leaf values (percentiles), unless given
 function _autorange(vol::AmrVolume, logscale, vmin, vmax)
     (vmin !== nothing && vmax !== nothing) && return (Float64(vmin), Float64(vmax))
-    vals = Float64[]
-    for d in vol.dicts; isempty(d) || append!(vals, values(d)); end
+    cap = 100_000                                  # systematic subsample → percentiles without copying/sorting
+    stride = max(1, vol.nleaf ÷ cap)               # all 167M leaves (sort 1e5 not 1e8, ~1 MB not ~1 GB)
+    vals = Float64[]; sizehint!(vals, min(vol.nleaf, cap) + 1); c = 0
+    for d in vol.dicts
+        isempty(d) && continue
+        for v in values(d); c += 1; (c % stride == 0) && push!(vals, v); end
+    end
     vals = logscale ? log10.(filter(x -> x > 0, vals)) : vals
     isempty(vals) && return (0.0, 1.0)
     sort!(vals); q(p) = vals[clamp(round(Int, p*length(vals)), 1, length(vals))]
@@ -612,11 +619,12 @@ function field_channel(data, var::Symbol, unit::Symbol=:standard; color_by=nothi
         colormap=:inferno, reverse::Bool=false, vmin=nothing, vmax=nothing,
         color_vmin=nothing, color_vmax=nothing, absorb_vmin=nothing, absorb_vmax=nothing,
         logscale::Bool=true, color_logscale::Bool=true, absorb_logscale::Bool=true,
+        signed::Bool=false, color_signed::Bool=false, absorb_signed::Bool=false,
         opacity::Real=4.0, gamma::Real=1.0, label::String=string(var), verbose::Bool=false)
-    vol = amr_volume(data, var, unit; verbose=verbose)
+    vol = amr_volume(data, var, unit; signed=signed, verbose=verbose)
     lo, hi = _autorange(vol, logscale, vmin, vmax); cmap = _to_cmap(colormap; reverse=reverse)
-    cvol = color_by  === nothing ? nothing : amr_volume(data, color_by,  color_unit;  verbose=verbose)
-    avol = absorb_by === nothing ? nothing : amr_volume(data, absorb_by, absorb_unit; verbose=verbose)
+    cvol = color_by  === nothing ? nothing : amr_volume(data, color_by,  color_unit;  signed=color_signed,  verbose=verbose)
+    avol = absorb_by === nothing ? nothing : amr_volume(data, absorb_by, absorb_unit; signed=absorb_signed, verbose=verbose)
     clo, chi = cvol === nothing ? (lo, hi) : _autorange(cvol, color_logscale,  color_vmin,  color_vmax)
     alo, ahi = avol === nothing ? (lo, hi) : _autorange(avol, absorb_logscale, absorb_vmin, absorb_vmax)
     VolumeChannel(vol, cvol, avol, cmap, lo, hi, clo, chi, alo, ahi,
@@ -749,14 +757,16 @@ function render_scene(channels, cam::Camera; res::Int=512, pxsize=nothing, aa::I
         end
         for (br,bg,bb) in bufs; R .+= br; G .+= bg; B .+= bb; end
     end
-    e=Float64(exposure); sat=Float64(saturation); ginv=1.0/Float64(gamma)
+    e=Float64(exposure); sat=Float64(saturation); ginv=1.0/Float64(gamma); wr,wg,wb=0.2126,0.7152,0.0722
     out = Matrix{RGB{Float64}}(undef, nx, ny)
     @inbounds for idx in eachindex(R)
-        r=_aces(e*R[idx]); g=_aces(e*G[idx]); b=_aces(e*B[idx])
-        if sat != 1.0
-            L=0.2126r+0.7152g+0.0722b
-            r=L+sat*(r-L); g=L+sat*(g-L); b=L+sat*(b-L)
+        r=e*R[idx]; g=e*G[idx]; b=e*B[idx]
+        if sat != 1.0                                   # saturate in LINEAR light, before tone-mapping
+            L=wr*r+wg*g+wb*b; r=max(L+sat*(r-L),0.); g=max(L+sat*(g-L),0.); b=max(L+sat*(b-L),0.)
         end
+        L=wr*r+wg*g+wb*b                                # luminance-preserving ACES: tone-map L, keep chroma
+        s = L > 1e-12 ? _aces(L)/L : 0.0                # ratios → no hue→white wash in highlights
+        r*=s; g*=s; b*=s
         if ginv != 1.0; r=r^ginv; g=g^ginv; b=b^ginv; end
         out[idx] = RGB{Float64}(clamp(r+bg[1],0,1), clamp(g+bg[2],0,1), clamp(b+bg[3],0,1))
     end

--- a/test/61_immersive_tests.jl
+++ b/test/61_immersive_tests.jl
@@ -149,6 +149,17 @@ end
     tmp6 = tempname()*".png"
     @test save_view(sv, tmp6; colormap=:inferno, vmin=0.0, vmax=1.0) == tmp6 && filesize(tmp6) > 0
     rm(tmp6, force=true)
+    # orientation: render_scene is already display-oriented → scene_figure/save must NOT re-orient it,
+    # and it must agree with the render_view(scalar) path. Bright slab at LOW x:
+    vola = _imm_uniform(4, (i,j,k)-> i ≤ 4 ? 9.0 : 0.02)
+    cam2 = perspective_camera((0.5,0.5,2.4),(0.5,0.5,0.5); fov_deg=30, aspect=1.0)
+    sv2  = view_figure(render_view(vola, cam2; res=30, mode=:max))
+    ch2  = Mera.VolumeChannel(vola, nothing,nothing, Mera._to_cmap(:grays), 0.,9., 0.,9., 0.,9., false,false,false, 40.,1., "x")
+    sd2  = render_scene([ch2], cam2; res=30)
+    @test isequal(scene_figure(sd2), sd2)                         # no double-orientation (identity passthrough)
+    lum(x)=Float64(Mera.red(x))+Float64(Mera.green(x))+Float64(Mera.blue(x))
+    leftbright(M)=sum(lum, @view M[:,1:end÷2]) > sum(lum, @view M[:,end÷2+1:end])
+    @test leftbright(sv2) == leftbright(sd2)                      # scalar & scene paths share orientation
 end
 
 @testset "immersive: camera paths, montage, flythrough fallback (data-free)" begin
@@ -244,12 +255,25 @@ if @isdefined(DATA_AVAILABLE) && DATA_AVAILABLE && haskey(DATASETS, :spiral_clum
         # pxsize with a physical unit resolves via the volume's scale (like projection)
         imgpx = render_view(vol, cam; pxsize=[2.0, :kpc], mode=:max)
         @test size(imgpx, 1) == size(imgpx, 2) && size(imgpx, 1) > 4          # perspective square, sane dims
+        # signed fields: signed=true keeps negatives (velocity), signed=false clamps them to 0
+        neg(v) = any(x -> x < 0, Iterators.flatten(values(d) for d in v.dicts))
+        vsgn = amr_volume(gas, :vx, :km_s; signed=true,  verbose=false)
+        vclp = amr_volume(gas, :vx, :km_s; signed=false, verbose=false)
+        @test neg(vsgn) && !neg(vclp)                                        # signed retains inflow/blueshift
+        # _autorange (subsampled) returns a sane increasing range
+        alo, ahi = Mera._autorange(vol, true, nothing, nothing)
+        @test isfinite(alo) && isfinite(ahi) && alo < ahi
         # multi-tracer composite (coloured-density: opacity from ρ, hue from T) + RGB output
         ch = field_channel(gas, :rho, :nH; color_by=:T, color_unit=:K, vmin=-0.5, vmax=2.3,
                            color_vmin=3.5, color_vmax=6.5, opacity=10, verbose=false)
         sc = render_scene([ch], perspective_camera(c .+ (30,20,24), c; fov_deg=55); res=80, exposure=2.0)
         @test eltype(sc) <: Mera.Colorant && size(sc) == (80, 80)
         @test any(x -> Mera.red(x)+Mera.green(x)+Mera.blue(x) > 0.05, sc)     # the galaxy shows up
+        # luminance-preserving tone-map: even pushed hard, output stays in gamut [0,1] and finite
+        schot = render_scene([ch], perspective_camera(c .+ (30,20,24), c; fov_deg=55);
+                             res=48, exposure=8.0, saturation=1.8)
+        @test all(x -> all(isfinite, (Mera.red(x),Mera.green(x),Mera.blue(x))) &&
+                       0 ≤ Mera.red(x) ≤ 1 && 0 ≤ Mera.green(x) ≤ 1 && 0 ≤ Mera.blue(x) ≤ 1, schot)
     end
 else
     @warn "Skipping immersive data-backed tests — simulation data not available"

--- a/test/61_immersive_tests.jl
+++ b/test/61_immersive_tests.jl
@@ -274,6 +274,25 @@ if @isdefined(DATA_AVAILABLE) && DATA_AVAILABLE && haskey(DATASETS, :spiral_clum
                              res=48, exposure=8.0, saturation=1.8)
         @test all(x -> all(isfinite, (Mera.red(x),Mera.green(x),Mera.blue(x))) &&
                        0 ≤ Mera.red(x) ≤ 1 && 0 ≤ Mera.green(x) ≤ 1 && 0 ≤ Mera.blue(x) ≤ 1, schot)
+        # --- science wrappers (C) ---
+        # derived_volume: per-leaf f(ρ,T) ∝ bremsstrahlung; renders a non-empty :sum map
+        em = derived_volume(gas, (n,T)->n^2*sqrt(T), [:rho,:T]; units=[:nH,:K], verbose=false)
+        @test em isa Mera.AmrVolume && em.nleaf == vol.nleaf
+        emap = render_view(em, cam; res=48, mode=:sum); @test any(x -> isfinite(x) && x > 0, emap)
+        # column_map: N_H [cm⁻²] = ∫nH dl · (cm per code length); = render_view(:sum) × scale.cm
+        col = column_map(vol, cam; res=48)
+        cfin = filter(isfinite, col)
+        @test !isempty(cfin) && maximum(cfin) > 0
+        @test isapprox(col[.!isnan.(col)], (render_view(vol, cam; res=48, mode=:sum) .* gas.scale.cm)[.!isnan.(col)])
+        # moment_maps: density-weighted LOS kinematics; m0≥0, m1 has both signs (rotation), m2≥0
+        vx = amr_volume(gas,:vx,:km_s; signed=true, verbose=false)
+        vy = amr_volume(gas,:vy,:km_s; signed=true, verbose=false)
+        vz = amr_volume(gas,:vz,:km_s; signed=true, verbose=false)
+        m0,m1,m2 = moment_maps(vol, vx,vy,vz, cam; res=48)
+        @test size(m0)==(48,48) && size(m1)==(48,48) && size(m2)==(48,48)
+        f0=filter(isfinite,m0); f1=filter(isfinite,m1); f2=filter(isfinite,m2)
+        @test !isempty(f0) && all(≥(0), f0) && all(≥(0), f2)                  # intensity & dispersion ≥ 0
+        @test minimum(f1) < 0 && maximum(f1) > 0                              # blue- and red-shifted gas
     end
 else
     @warn "Skipping immersive data-backed tests — simulation data not available"


### PR DESCRIPTION
Implements the **P1 roadmap batch** and the **C science wrappers** from the expert panel (C depends on P1's signed fields, so they ship together).

### P1
1. Signed fields — `amr_volume(...; signed=true)`, `field_channel` `signed/color_signed/absorb_signed`.
2. Fast `_autorange` (systematic subsample, no full copy+sort).
3. Luminance-preserving tone map (no highlight wash-to-white).
4. Multi-channel `flythrough`/`interactive_view` (ρ+T+stars).
+ Orientation fix: `as_image(::Colorant)` passes through (no double-orient in scene_figure/save_scene/save_figure).

### C — science wrappers
- `column_map(vol, cam; length_unit=:cm)` → N_H [cm⁻²] (`:sum × scale`).
- `derived_volume(data, f, vars; units)` → per-leaf `f(ρ,T,…)` (bremsstrahlung, Hα) for `:sum` mock surface brightness.
- `moment_maps(ρ, vx, vy, vz, cam)` → moment-0/1/2 LOS kinematics, evaluated per-ray (correct for perspective/fisheye).

All immersive tests green (data-backed 19/19); multi-channel mp4 + orientation verified with CairoMakie.