### PR TITLE
feat(immersive): view_colorbar — scalar maps with an aligned value colorbar

### DIFF
--- a/ext/MeraMakieExt.jl
+++ b/ext/MeraMakieExt.jl
@@ -622,4 +622,24 @@ function Mera.interactive_view(channels::AbstractVector; target=nothing, distanc
 end
 Mera.interactive_view(ch::Mera.ImmersiveChannel; kw...) = Mera.interactive_view([ch]; kw...)
 
+# Scalar render_view map (column_map / moment / single field) shown WITH an aligned, labelled colorbar so
+# values are readable. `logscale=true` (default) maps log₁₀(value); set `vmin/vmax` (same units) to fix the
+# range, `label` for the axis text, `filename` to also save. Same colormapping as the heatmap path.
+function Mera.view_colorbar(img::AbstractMatrix{<:Real}; colormap=:inferno, logscale::Bool=true,
+        vmin=nothing, vmax=nothing, label=nothing, reverse::Bool=false, bg=:black,
+        size=(620, 480), filename=nothing)
+    A = Mera._prep(img; logscale=logscale)                      # oriented + log₁₀ when logscale
+    ff = filter(isfinite, vec(A))
+    lo = vmin === nothing ? (isempty(ff) ? 0.0 : minimum(ff)) : Float64(vmin)
+    hi = vmax === nothing ? (isempty(ff) ? 1.0 : maximum(ff)) : Float64(vmax)
+    lo == hi && (hi = lo + 1.0)
+    cmap = reverse ? Makie.Reverse(colormap) : colormap
+    fig = Makie.Figure(; size=size)
+    ax = Makie.Axis(fig[1,1], aspect=Makie.DataAspect()); Makie.hidedecorations!(ax); Makie.hidespines!(ax)
+    hm = Makie.heatmap!(ax, A; colormap=cmap, colorrange=(lo, hi), nan_color=bg)
+    Makie.Colorbar(fig[1,2], hm; label = label === nothing ? (logscale ? "log₁₀ value" : "value") : label)
+    filename === nothing || Makie.save(filename, fig)
+    Makie.display(fig); return fig
+end
+
 end # module

--- a/src/Mera.jl
+++ b/src/Mera.jl
@@ -208,6 +208,7 @@ export
     as_image,
     view_figure,
     scene_figure,
+    view_colorbar,
     save_view,
     save_scene,
     save_figure,

--- a/src/functions/immersive.jl
+++ b/src/functions/immersive.jl
@@ -951,3 +951,10 @@ function interactive_view end
 interactive_view(args...; kwargs...) = error(
     "`interactive_view` opens a live, mouse-controlled window and needs an INTERACTIVE Makie backend — " *
     "run `using GLMakie` (CairoMakie cannot show interactive windows). It re-renders the AMR data directly.")
+
+# `view_colorbar` shows a SCALAR render_view map (column_map / moment / single field) with a labelled,
+# aligned colorbar so you can read values off it → real method in MeraMakieExt (needs a Makie backend).
+function view_colorbar end
+view_colorbar(args...; kwargs...) = error(
+    "`view_colorbar` draws a scalar map with a value colorbar and needs a Makie backend — run " *
+    "`using CairoMakie`. For a bare image (no axes/bar) use `view_figure`/`as_image`.")

--- a/test/61_immersive_tests.jl
+++ b/test/61_immersive_tests.jl
@@ -184,6 +184,7 @@ end
     # mp4 flythrough + interactive window need a Makie backend; without one the core errors helpfully
     @test_throws ErrorException flythrough(vol, :perspective, [(c.+(1.,1.,1.), c), (c, c)])
     @test_throws ErrorException interactive_view(vol)
+    @test_throws ErrorException view_colorbar(render_view(vol, perspective_camera(c.+(1.,1.,1.),c;fov_deg=45); res=8))
 end
 
 @testset "immersive: isosurface + gradient shading + field-driven absorption (data-free)" begin


### PR DESCRIPTION
Adds `view_colorbar(map; colormap, logscale, vmin, vmax, label, reverse, bg, filename)` — shows a scalar `render_view` map (e.g. `column_map`, `moment_maps`, a single field) as a heatmap **with an aligned, labelled Makie colorbar** so the numbers are readable (log₁₀ by default; `logscale=false` for linear units like km/s). Makie-extension (needs CairoMakie); the core stub errors helpfully without a backend.

Verified with CairoMakie: N_H [cm⁻²] and v_los [km/s] colorbars render and save. Notebook science cells updated to use it.