### PR TITLE
feat(immersive): pre-integrated transfer function (single-field render_scene)

### DIFF
--- a/src/functions/immersive.jl
+++ b/src/functions/immersive.jl
@@ -785,6 +785,54 @@ function points_channel(data; weight::Symbol=:mass, unit::Symbol=:standard, filt
                  (Float64(color[1]),Float64(color[2]),Float64(color[3])), Float64(size), Float64(opacity), label)
 end
 
+# normalized [0,1] field value for a channel's opacity field (log + vmin/vmax, clamped)
+@inline function _nval(ch::VolumeChannel, val)
+    s = ch.logscale ? (val > 0 ? log10(val) : -Inf) : val
+    n = (s-ch.vmin)/(ch.vmax-ch.vmin); n < 0 ? 0.0 : n > 1 ? 1.0 : n
+end
+
+# PRE-INTEGRATION tables (Engel, Kraus & Ertl 2001): cumulative ∫τ(n)dn and ∫c(n)τ(n)dn over the
+# normalized field n∈[0,1], so a ray SEGMENT [n_f,n_b] is integrated analytically (no missing a sharp
+# transfer-function feature between samples). τ(n) is the per-length extinction matching _cast_rgb.
+function _preint(ch::VolumeChannel; N::Int=512)
+    bl = ch.vol.boxlen; Tint=zeros(N+1); Cr=zeros(N+1); Cg=zeros(N+1); Cb=zeros(N+1); dn=1/N
+    @inbounds for i in 1:N
+        n=(i-0.5)*dn; ng = ch.gamma == 1.0 ? n : n^ch.gamma
+        tau = ch.opacity*ng*100/bl
+        cr,cg,cb = _cmcol(ch.cmap, n)
+        Tint[i+1]=Tint[i]+tau*dn; Cr[i+1]=Cr[i]+cr*tau*dn; Cg[i+1]=Cg[i]+cg*tau*dn; Cb[i+1]=Cb[i]+cb*tau*dn
+    end
+    return Tint, Cr, Cg, Cb
+end
+
+# pre-integrated single-channel cast (colour+opacity from one field's colormap). Samples the field at each
+# segment's endpoints and looks up the integrated extinction/emission → smooth even at coarse stepfrac.
+@inline function _cast_rgb_pi(ch::VolumeChannel, Tint, Cr, Cg, Cb, ox,oy,oz, dx,dy,dz, stepfrac, sm::Int, jit=0.0)
+    v=ch.vol; t0,t1=_box_t(v,ox,oy,oz,dx,dy,dz); t1<=t0 && return (0.,0.,0.,0.,Inf)
+    floor_dt=1e-6*v.boxlen; N=length(Tint)-1; bl=v.boxlen
+    R=0.;G=0.;B=0.;A=0.;t=t0; dhalf=Inf
+    _,h0=_leaf(v,ox+t0*dx,oy+t0*dy,oz+t0*dz); nf=_nval(ch,_sample_at(v,ox+t0*dx,oy+t0*dy,oz+t0*dz,h0,sm))
+    @inbounds while t<t1 && A<0.997
+        x=ox+t*dx;y=oy+t*dy;z=oz+t*dz; _,h=_leaf(v,x,y,z)
+        dt=max(stepfrac*h,floor_dt); tend=min(t+dt,t1); seg=tend-t
+        nb=_nval(ch,_sample_at(v,ox+tend*dx,oy+tend*dy,oz+tend*dz,h,sm))
+        dnn=nb-nf
+        if abs(dnn) < 1e-6                                   # ~flat segment → point value
+            ng=ch.gamma==1.0 ? nf : nf^ch.gamma; tau=ch.opacity*ng*100/bl
+            cr,cg,cb=_cmcol(ch.cmap,nf); τs=tau*seg; Csr=cr*tau*seg; Csg=cg*tau*seg; Csb=cb*tau*seg
+        else                                                # integrate the TF across the segment
+            fi=clamp(round(Int,nf*N),0,N)+1; bi=clamp(round(Int,nb*N),0,N)+1
+            τs =seg*(Tint[bi]-Tint[fi])/dnn
+            Csr=seg*(Cr[bi]-Cr[fi])/dnn; Csg=seg*(Cg[bi]-Cg[fi])/dnn; Csb=seg*(Cb[bi]-Cb[fi])/dnn
+        end
+        α=1-exp(-τs); α<0 && (α=0.0)
+        R+=(1-A)*Csr; G+=(1-A)*Csg; B+=(1-A)*Csb; A+=(1-A)*α
+        (dhalf==Inf && A>=0.5) && (dhalf=t)
+        nf=nb; t=tend
+    end
+    return (R,G,B,A,dhalf)
+end
+
 # composite all volume channels front-to-back along one ray → (R,G,B,A)
 @inline function _cast_rgb(vols::Vector{VolumeChannel}, ox,oy,oz, dx,dy,dz, stepfrac, sm::Int, jit=0.0)
     v1 = vols[1].vol
@@ -844,7 +892,7 @@ top with a core+halo PSF. The HDR result is ACES filmic tone-mapped, then `satur
 """
 function render_scene(channels, cam::Camera; res::Int=512, pxsize=nothing, aa::Int=1, smooth=true,
         stepfrac::Real=0.6, bg=(0.,0.,0.), exposure::Real=1.0, saturation::Real=1.15, gamma::Real=1.0,
-        jitter::Bool=true, show_progress::Bool=false)
+        preintegrate::Bool=false, jitter::Bool=true, show_progress::Bool=false)
     chs = channels isa ImmersiveChannel ? ImmersiveChannel[channels] : collect(channels)
     vols = VolumeChannel[c for c in chs if c isa VolumeChannel]
     pts  = PointChannel[c for c in chs if c isa PointChannel]
@@ -853,6 +901,10 @@ function render_scene(channels, cam::Camera; res::Int=512, pxsize=nothing, aa::I
              (round(Int, res*cam.aspect), res)
     R=zeros(nx,ny); G=zeros(nx,ny); B=zeros(nx,ny); sf=Float64(stepfrac); ia=1.0/aa; sm=_smode(smooth)
     Amat=zeros(nx,ny); Dmat=fill(Inf,nx,ny)        # per-pixel gas opacity + ½-opacity depth → star occlusion
+    # pre-integration (Engel et al. 2001): single-field channel only (colour+opacity from one colormap)
+    usePI = preintegrate && length(vols) == 1 && vols[1].cvol === nothing && vols[1].avol === nothing
+    preintegrate && !usePI && @warn "preintegrate ignored — only a single field_channel with no color_by/absorb_by is supported"
+    PIt = usePI ? _preint(vols[1]) : (Float64[],Float64[],Float64[],Float64[])
     if !isempty(vols)
         prog = show_progress ? Progress(ny; desc="render_scene ", dt=0.3) : nothing
         Threads.@threads for j in 1:ny
@@ -862,7 +914,8 @@ function render_scene(channels, cam::Camera; res::Int=512, pxsize=nothing, aa::I
                     uu=(i-1+(si-0.5)*ia)/nx; vv=(j-1+(sj-0.5)*ia)/ny
                     rd=_raydir(cam,uu,vv); rd===nothing && continue
                     jt = jitter ? _hash01((i-1)*aa+si, (j-1)*aa+sj) : 0.0
-                    cr,cg,cb,ca,cd = _cast_rgb(vols, cam.pos..., rd..., sf, sm, jt)
+                    cr,cg,cb,ca,cd = usePI ? _cast_rgb_pi(vols[1], PIt..., cam.pos..., rd..., sf, sm, jt) :
+                                             _cast_rgb(vols, cam.pos..., rd..., sf, sm, jt)
                     r+=cr; g+=cg; b+=cb; asum+=ca; isfinite(cd) && (dsum+=cd; nd+=1); n+=1
                 end
                 if n>0; R[i,j]=r/n; G[i,j]=g/n; B[i,j]=b/n; Amat[i,j]=asum/n; nd>0 && (Dmat[i,j]=dsum/nd); end

--- a/src/functions/immersive.jl
+++ b/src/functions/immersive.jl
@@ -280,6 +280,31 @@ end
     return clamp(ambient+diff+spec, 0.0, 1.0)
 end
 
+# vicinity / ambient-occlusion probe (Stewart 2003, "Vicinity shading"): fraction of nearby directions
+# whose field is INSIDE the surface (val>level). Crevices/enclosed points read as more occluded and get
+# darkened → isosurfaces gain real 3-D depth. NOT done by yt's volume renderer; cheap (12 samples per hit).
+const _AO_DIRS = (let s = 1/sqrt(3.0)
+    ((1.,0.,0.),(-1.,0.,0.),(0.,1.,0.),(0.,-1.,0.),(0.,0.,1.),(0.,0.,-1.),
+     (s,s,s),(-s,-s,-s),(s,-s,s),(-s,s,-s),(s,s,-s),(-s,-s,s)) end)
+@inline function _ao(v::AmrVolume, x,y,z, h, level, radius, sm::Int)
+    r = radius*h; inside = 0
+    @inbounds for d in _AO_DIRS
+        _sample_at(v, x+r*d[1], y+r*d[2], z+r*d[3], h, sm) > level && (inside += 1)
+    end
+    return inside / length(_AO_DIRS)
+end
+
+# directional self-shadow probe: march from the surface toward the light; fraction of steps that hit
+# material (val>level) ⇒ the point is in shadow of a denser clump. Gives cast shadows (depth), not in yt.
+@inline function _shadow(v::AmrVolume, x,y,z, h, level, lx,ly,lz, nsteps::Int, sm::Int)
+    occ = 0
+    @inbounds for k in 1:nsteps
+        s = k*h
+        _sample_at(v, x+s*lx, y+s*ly, z+s*lz, h, sm) > level && (occ += 1)
+    end
+    return occ / nsteps
+end
+
 # march for an ISOSURFACE at `level`: each crossing is linearly refined and gradient-shaded. With
 # `alpha >= 1` it is OPAQUE (first crossing wins — solid surface). With `alpha < 1` it is TRANSLUCENT:
 # every crossing is composited front-to-back with that per-surface opacity, so nested shells and the
@@ -287,7 +312,7 @@ end
 # `levels` is a sorted Vector{Float64} of one or more iso values (nested shells). Per segment we test every
 # level; crossings are composited in front-to-back order (within a segment that order follows the field's
 # sign, so no sort/alloc needed). Opaque (alpha≥1) returns the nearest surface of any level.
-@inline function _cast_iso(v::AmrVolume, ox,oy,oz, dx,dy,dz, levels, sm::Int, lx,ly,lz, ambient, diffuse, specular, shininess, alpha, jit=0.0)
+@inline function _cast_iso(v::AmrVolume, ox,oy,oz, dx,dy,dz, levels, sm::Int, lx,ly,lz, ambient, diffuse, specular, shininess, alpha, jit=0.0, ao=0.0, aorad=2.0, shadow=0.0, nshadow=6)
     t0, t1 = _box_t(v, ox,oy,oz, dx,dy,dz); t1 <= t0 && return NaN
     floor_dt = 1e-6*v.boxlen
     nlev = length(levels)
@@ -306,6 +331,8 @@ end
                 nx,ny,nz = _grad(v,cx,cy,cz,hc)
                 sh = (nx==0.0 && ny==0.0 && nz==0.0) ? ambient :
                      _shade(nx,ny,nz, dx,dy,dz, lx,ly,lz, ambient, diffuse, specular, shininess)
+                ao > 0     && (sh *= 1.0 - ao*_ao(v, cx,cy,cz, hc, lev, aorad, sm))            # vicinity AO: crevices
+                shadow > 0 && (sh *= 1.0 - shadow*_shadow(v, cx,cy,cz, hc, lev, lx,ly,lz, nshadow, sm))  # cast shadows
                 alpha >= 1.0 && return sh                     # opaque: nearest surface of any level wins
                 I += (1-A)*alpha*sh; A += (1-A)*alpha; hit = true   # translucent: composite each shell
                 A >= 0.997 && return I
@@ -462,7 +489,10 @@ follow the camera: equirect → `2res×res`, fisheye → `res×res`, perspective
 gradient-shaded; `iso_alpha=1` opaque first-hit, `iso_alpha<1` **translucent** — every crossing
 composited front-to-back, so nested shells / front+back faces show through). `level` is the field's
 physical value (linear, in the volume's unit) and may be a **vector of values** for several nested
-shells in one pass (e.g. `level=[0.1, 1, 10]`; best with `iso_alpha<1`). `smooth` = `true` (cross-level trilinear, de-blocked — default), `false` (nearest-leaf,
+shells in one pass (e.g. `level=[0.1, 1, 10]`; best with `iso_alpha<1`). For 3-D depth on isosurfaces,
+`ao` (0–1, ambient/vicinity occlusion — darkens crevices, radius `ao_radius` in cells) and `shadow` (0–1,
+cast shadows toward `light`, `shadow_steps` long) add depth cues volume renderers like yt don't.
+`smooth` = `true` (cross-level trilinear, de-blocked — default), `false` (nearest-leaf,
 fast preview), or `:kernel` (cubic B-spline blur — softer than trilinear but **cosmetic and
 NON-conservative**: it spreads coarse-cell values beyond their volume, so use it for beauty frames, not
 quantitative emission/column work). `aa` is jittered supersampling. `kappa` (`:rt` opacity) and `power`
@@ -473,7 +503,8 @@ image with [`as_image`](@ref)/[`save_view`](@ref).
 function render_view(vol::AmrVolume, cam::Camera; res::Int=512, pxsize=nothing, mode::Symbol=:emission,
         stepfrac::Real=0.5, power::Real=1.0, kappa::Real=0.1, smooth=true, aa::Int=1,
         level=1.0, iso_alpha::Real=1.0, light=(-1.,-1.,1.), ambient::Real=0.25, diffuse::Real=0.8,
-        specular::Real=0.3, shininess::Real=16.0, jitter::Bool=true, show_progress::Bool=false)
+        specular::Real=0.3, shininess::Real=16.0, ao::Real=0.0, ao_radius::Real=2.0,
+        shadow::Real=0.0, shadow_steps::Int=6, jitter::Bool=true, show_progress::Bool=false)
     res = _resolve_res(vol, cam, res, pxsize)        # pxsize (physical/code) overrides res when given
     nx, ny = cam.kind === :equirect ? (2res, res) :
              cam.kind === :fisheye  ? (res, res)  : (round(Int, res*cam.aspect), res)
@@ -491,7 +522,7 @@ function render_view(vol::AmrVolume, cam::Camera; res::Int=512, pxsize=nothing, 
                 rd = _raydir(cam, uu, vv); rd === nothing && continue
                 # jitter only helps accumulating modes; on :max / :iso it just adds speckle → skip there
                 jt = (jitter && !iso && mode !== :max) ? _hash01((i-1)*aa+si, (j-1)*aa+sj) : 0.0
-                val = iso ? _cast_iso(vol, cam.pos..., rd..., lv, sm, ln..., am, di, sp, sh, ia_, jt) :
+                val = iso ? _cast_iso(vol, cam.pos..., rd..., lv, sm, ln..., am, di, sp, sh, ia_, jt, Float64(ao), Float64(ao_radius), Float64(shadow), shadow_steps) :
                             _cast(vol, cam.pos..., rd..., mode, sf, pw, kp, sm, jt)
                 isnan(val) || (acc += val; n += 1)
             end

--- a/test/61_immersive_tests.jl
+++ b/test/61_immersive_tests.jl
@@ -211,6 +211,13 @@ end
     isom = render_view(vol, perspective_camera((1.6,1.6,1.6), c; fov_deg=45); res=24, mode=:iso, level=[0.5, 1.0, 5.0], iso_alpha=0.4)
     finm = filter(isfinite, isom)
     @test !isempty(finm) && all(0 .≤ finm .≤ 1) && !isequal(isot, isom)
+    # ambient occlusion + self-shadow darken the surface (changes shading, stays in gamut; opt-in, off by default)
+    icam = perspective_camera((1.6,1.6,1.6), c; fov_deg=45)
+    iao = render_view(vol, icam; res=24, mode=:iso, level=1.0, ao=0.9)
+    ish = render_view(vol, icam; res=24, mode=:iso, level=1.0, shadow=0.9)
+    @test all(x -> !isfinite(x) || 0 ≤ x ≤ 1, iao) && all(x -> !isfinite(x) || 0 ≤ x ≤ 1, ish)
+    @test !isequal(iso, iao) && !isequal(iso, ish)                          # AO/shadow change the shading
+    @test sum(filter(isfinite, iao)) < sum(filter(isfinite, iso))          # AO only darkens (never brightens)
     # field-driven absorption: a channel with a separate absorption field renders in gamut & differs
     av  = _imm_uniform(3, (i,j,k)->0.1)                                   # uniform low absorption field
     cm  = Mera._to_cmap(:viridis); cam = perspective_camera((1.6,1.6,1.6), c; fov_deg=45)

--- a/test/61_immersive_tests.jl
+++ b/test/61_immersive_tests.jl
@@ -113,6 +113,14 @@ end
     @test eltype(sc) <: Mera.Colorant && size(sc) == (24, 24)
     @test all(x -> 0 ≤ Mera.red(x) ≤ 1 && 0 ≤ Mera.green(x) ≤ 1 && 0 ≤ Mera.blue(x) ≤ 1, sc)  # in gamut
     @test any(x -> Mera.red(x)+Mera.green(x)+Mera.blue(x) > 0, sc)            # not all black
+    # pre-integration (single field, coarse steps): in gamut, and differs from point sampling on a varying field
+    rv = _imm_uniform(4, (i,j,k)->Float64(i))                                 # x-ramp
+    rc = Mera.VolumeChannel(rv, nothing,nothing, Mera._to_cmap(:viridis), 0.,16., 0.,16., 0.,16., false,false,false, 8.,1., "r")
+    cam2 = perspective_camera((1.6,1.6,1.6), boxcenter(rv); fov_deg=45)
+    pic = render_scene([rc], cam2; res=24, stepfrac=2.0, preintegrate=true)
+    ptc = render_scene([rc], cam2; res=24, stepfrac=2.0, preintegrate=false)
+    @test all(x -> 0≤Mera.red(x)≤1 && 0≤Mera.green(x)≤1 && 0≤Mera.blue(x)≤1, pic)  # in gamut
+    @test !isequal(pic, ptc)                                                  # PI changes the coarse-step result
 end
 
 @testset "immersive: colormaps + image assembly + PNG save (data-free)" begin


### PR DESCRIPTION
Prototypes **pre-integrated volume rendering** (Engel, Kraus & Ertl 2001) — the remaining 'not in yt' quality lever, for the foggy `render_scene` path.

`render_scene(...; preintegrate=true)` for a single `field_channel` (colour+opacity from one colormap, no `color_by`/`absorb_by`): precomputes cumulative integrals of extinction and colour×extinction over the normalized field, then integrates each ray **segment** analytically from its two endpoint values. A sharp transfer-function feature is therefore never missed between samples → smooth even at coarse `stepfrac`. Falls back to point sampling (with a warning) for multi-channel / `color_by` / `absorb_by` scenes.

Tested: in-gamut, and differs from point sampling at coarse steps on a varying field.