### PR TITLE
feat(immersive): overlay_grid — coordinate-system / graticule overlay for view planning

### DIFF
--- a/docs/immersive_implementation.md
+++ b/docs/immersive_implementation.md
@@ -1,0 +1,112 @@
+# Immersive ray-caster — how it works, and references
+
+How Mera's immersive 3-D renderer is implemented, how it works **directly on the AMR octree** (no
+uniform-grid resample), and the primary literature behind each technique. Source: `src/functions/immersive.jl`
+(Makie-free core) and `ext/MeraMakieExt.jl` (mp4 / interactive window).
+
+## 1. Why AMR-native
+
+A RAMSES/AREPO box refined to level `lmax` would be `(2^lmax)³` cells as a uniform grid — e.g. `2^14³ ≈
+4×10¹²`, hundreds of TB. Resampling to a uniform grid to ray-cast is therefore impossible for deep AMR.
+Instead the renderer marches the **adaptive mesh itself**: memory is `O(nleaf)` (the actual cell count),
+and each ray samples the *local* leaf at its current point.
+
+## 2. Data structure — `AmrVolume`
+
+`amr_volume(data, var, unit)` builds, once:
+
+- **`dicts::Vector{Dict{NTuple{3,Int32},Float64}}`** — one hash per refinement level `L`, mapping a leaf's
+  integer cell coordinates `(cx,cy,cz)` → its value. Storage is exactly the leaf count (a 167 M-leaf box ≈
+  6.7 GB). Values are `NaN→0`; negatives are clamped to 0 unless `signed=true` (velocity/B/divergence).
+- **`occ::Array{UInt8,3}` + `occL`** — a coarse *occupancy* grid (at level `Lc=min(lmin,8)`): per coarse
+  cell, the **finest leaf level actually present** there (extent-marked so it is correct across cell
+  boundaries). This is the level-skip accelerator (§3). Toggle with `occupancy=`/`set_occupancy`.
+- `lmin,lmax,boxlen,unit,nleaf,scale` (the last for physical units, e.g. `pxsize=[…,:kpc]`, `column_map`).
+
+`derived_volume(data, f, vars; units)` reuses the same indexer with a per-leaf value `f(v₁,v₂,…)`
+(e.g. bremsstrahlung `n²√T`) — for quantitative `:sum` mock-emission maps.
+
+## 3. The marcher
+
+**Point → leaf (`_leaf`).** Convert a world point to a cell index `round(frac·2^L)` and look it up
+**finest-level-first**, descending until a leaf is found (finer leaves win — the cell-centre convention
+matches Mera's `getvar`). The **occupancy grid** is read first to jump straight to the finest level present
+near the point, skipping the failed fine-level hash probes that otherwise dominate deep-AMR cost
+(result-identical; ~3× on an 8-level box).
+
+**Adaptive stepping (`_cast`).** Each ray advances by `stepfrac · h`, where `h` is the **local** leaf size
+from `_leaf` — fine cells get fine steps, coarse cells coarse steps — clamped to `1e-6·boxlen` so it never
+stalls at a void boundary. Ray–box entry/exit is a slab test (`_box_t`).
+
+## 4. Reconstruction (`smooth=`)
+
+- `false` — nearest leaf (piecewise constant; fast, blocky).
+- `true` — **cross-level trilinear** (default): 8-corner interpolation at the local spacing, de-blocked and
+  conservative (Engel et al. 2006, *Real-Time Volume Graphics*).
+- `:kernel` — cubic B-spline over a 4×4×4 neighbourhood (C², softer; **non-conservative** — for beauty
+  frames, not quantitative work).
+
+## 5. Modes and compositing
+
+- **`:max`** — maximum-intensity projection.
+- **`:emission` / `:sum`** — `∫ jᵖᵒʷᵉʳ dl` / `∫ value dl` (identical at `power=1`); the emission–absorption
+  optical model (Max 1995, *Optical models for direct volume rendering*).
+- **`:rt`** — emission **+** self-absorption with early-ray-termination once opaque.
+- **`render_scene`** composites several `field_channel`s **front-to-back** (associated/premultiplied alpha;
+  Porter & Duff 1984), each with its own colormap + opacity; the "coloured-density" transfer function
+  (opacity from one field, hue from another) follows Levoy 1988, *Display of surfaces from volume data*.
+  HDR is tone-mapped with the ACES filmic curve (Narkowicz 2016), saturation/gamma graded in linear light.
+- **Pre-integration** (`preintegrate=true`, single field) integrates each ray *segment* from its two endpoint
+  values via precomputed tables, so a sharp transfer-function feature is never missed between samples
+  (Engel, Kraus & Ertl 2001).
+
+## 6. Isosurfaces (`mode=:iso`, `render_isosurfaces`)
+
+Surface crossings of `level` are linearly refined along the ray and **gradient-shaded** (central-difference
+normal + Blinn–Phong); `iso_alpha<1` composites every crossing (translucent nested shells), a vector of
+`level`s draws several shells in one pass (depth-ordered), and `render_isosurfaces` gives each shell its own
+colour. Depth cues beyond what volume renderers like yt provide: **`ao`** = vicinity/ambient occlusion
+(Stewart 2003, *Vicinity shading*) and **`shadow`** = a directional self-shadow probe. `render_scene(...;
+shade=)` applies the same gradient lighting to the *foggy* volume (ParaView's "Shade").
+
+## 7. Cameras & projections
+
+A `Camera` is a point + orthonormal basis (gimbal-safe). `_raydir` maps a pixel to a **normalized** world
+direction; `_project` is its inverse (used by point splats and `overlay_grid`):
+
+- **perspective** — pinhole (Snyder 1987 for the math of the panoramic ones below).
+- **equirectangular** — full-sphere 2:1 panorama (longitude/latitude).
+- **fisheye** — hemispherical/dome (Bourke 2004).
+
+Fly-throughs interpolate the camera through keyframes with Catmull–Rom splines (Catmull & Rom 1974).
+
+## 8. Anti-aliasing & a caveat
+
+`aa` supersamples per pixel; **`jitter`** dithers each sample within its segment (per-pixel deterministic
+hash) so fixed-step sampling can't beat against the cell grid into moiré (applied only to accumulating
+modes). **Caveat:** placing the camera exactly on a grid symmetry axis (e.g. straight down `z`, or at the
+exact box centre) makes rays related by that symmetry sample the axis-aligned cells identically → concentric
+rings / lattice dots that supersampling cannot remove. Keep a small lateral offset (`eye(…)`).
+
+## 9. Quantitative wrappers
+
+`column_map` (`:sum × scale` → N_H cm⁻²), `derived_volume` (mock emissivity → `:sum`), and `moment_maps`
+(density-weighted line-of-sight moment-0/1/2, evaluated **per ray** so they are correct for perspective and
+fisheye, using three signed velocity volumes). `view_colorbar` shows any scalar map with an aligned,
+labelled value bar.
+
+## References
+
+| Technique | Reference |
+|---|---|
+| Emission–absorption optical model | Max 1995, *IEEE TVCG* |
+| Front-to-back compositing | Porter & Duff 1984, *SIGGRAPH* |
+| Gradient shading / transfer functions / coloured-density | Levoy 1988, *IEEE CG&A* |
+| Pre-integrated volume rendering | Engel, Kraus & Ertl 2001, *HWWS* |
+| Trilinear reconstruction (real-time VR) | Engel et al. 2006, *Real-Time Volume Graphics* |
+| Marching-cubes isosurfaces (for context) | Lorensen & Cline 1987, *SIGGRAPH* |
+| Vicinity / ambient occlusion | Stewart 2003, *IEEE Vis* |
+| ACES filmic tone-map (fit) | Narkowicz 2016 |
+| Equirectangular projection | Snyder 1987, *Map Projections* |
+| Fisheye / dome projection | Bourke 2004 |
+| Catmull–Rom spline paths | Catmull & Rom 1974 |

--- a/src/Mera.jl
+++ b/src/Mera.jl
@@ -213,6 +213,7 @@ export
     save_view,
     save_scene,
     save_figure,
+    overlay_grid,
     orbit_keyframes,
     flythrough_montage,
     flythrough,

--- a/src/functions/immersive.jl
+++ b/src/functions/immersive.jl
@@ -758,6 +758,90 @@ save_figure(img::AbstractMatrix{<:Colorant}, filename::AbstractString; kw...) =
     (FileIO.save(filename, as_image(img)); filename)
 
 # -------------------------------------------------------------------------------------
+#  Coordinate / graticule overlay (planning aid) — drawn in the renderer's own (i,j) frame so it aligns
+# -------------------------------------------------------------------------------------
+# rasterize a segment (in (u,v)∈[0,1]² render coords) into the un-oriented overlay buffer O[i,j]
+@inline function _oline!(Or,Og,Ob,Oa, nx,ny, u0,v0,u1,v1, cr,cg,cb)
+    abs(u1-u0) > 0.5 && return                          # equirect longitude-wrap guard
+    i0=u0*nx; j0=v0*ny; i1=u1*nx; j1=v1*ny
+    n = ceil(Int, max(abs(i1-i0), abs(j1-j0))) + 1
+    @inbounds for t in range(0.0, 1.0; length=n)
+        i=round(Int, i0+t*(i1-i0)); j=round(Int, j0+t*(j1-j0))
+        (1<=i<=nx && 1<=j<=ny) || continue
+        Or[i,j]=cr; Og[i,j]=cg; Ob[i,j]=cb; Oa[i,j]=1.0
+    end
+end
+# draw a world-space segment pA→pB through the camera (sampled, so it curves correctly in equirect/fisheye)
+function _wedge!(Or,Og,Ob,Oa, nx,ny, cam, pA, pB, cr,cg,cb; n=48)
+    prev=nothing
+    for t in range(0.0, 1.0; length=n)
+        p=(pA[1]+t*(pB[1]-pA[1]), pA[2]+t*(pB[2]-pA[2]), pA[3]+t*(pB[3]-pA[3]))
+        pr=_project(cam, p...); cur = pr===nothing ? nothing : (pr[1],pr[2])
+        prev!==nothing && cur!==nothing && _oline!(Or,Og,Ob,Oa,nx,ny, prev[1],prev[2],cur[1],cur[2], cr,cg,cb)
+        prev=cur
+    end
+end
+
+"""
+    overlay_grid(img, cam; vol=nothing, boxlen=nothing, box=true, axes=true, graticule=true,
+                 graticule_deg=30, color=(1,1,1), axis_colors=…, alpha=0.6, axis_len=0.4) -> Matrix{RGB}
+
+Draw the **coordinate system** of the view onto a rendered image — for planning camera placement/orientation.
+`box` = the simulation bounding-box wireframe, `axes` = world x/y/z axes (red/green/blue) from the origin
+(both need `vol` or `boxlen` for the scale), `graticule` = a longitude/latitude sphere grid (for
+`:equirect`/`:fisheye`). Lines are projected through `cam`, so they curve correctly in panoramas. Returns
+an RGB image (the input may be a scalar [`render_view`](@ref) or an RGB [`render_scene`](@ref) result).
+"""
+function overlay_grid(img, cam::Camera; vol=nothing, boxlen=nothing, box::Bool=true, axes::Bool=true,
+        graticule::Bool=true, graticule_deg::Real=30, color=(1.,1.,1.),
+        axis_colors=((1.,.35,.35),(.35,1.,.35),(.45,.6,1.)), alpha::Real=0.6, axis_len::Real=0.4)
+    D = Matrix{RGB{Float64}}(as_image(img))            # working RGB copy, display-oriented [ny,nx]
+    ny,nx = size(D); Or=zeros(nx,ny); Og=zeros(nx,ny); Ob=zeros(nx,ny); Oa=zeros(nx,ny)
+    bl = boxlen !== nothing ? Float64(boxlen) : vol !== nothing ? vol.boxlen : nothing
+    cr,cg,cb = Float64(color[1]),Float64(color[2]),Float64(color[3]); gd=Float64(graticule_deg)
+    if graticule && cam.kind in (:equirect, :fisheye)  # sphere graticule via world directions
+        for lon in 0:gd:359.0                          # meridians
+            prev=nothing
+            for lat in -90:5:90
+                la=deg2rad(lon); lb=deg2rad(lat)
+                p=(cam.pos[1]+cos(lb)*cos(la), cam.pos[2]+cos(lb)*sin(la), cam.pos[3]+sin(lb))
+                pr=_project(cam,p...); cur=pr===nothing ? nothing : (pr[1],pr[2])
+                prev!==nothing && cur!==nothing && _oline!(Or,Og,Ob,Oa,nx,ny,prev[1],prev[2],cur[1],cur[2],cr,cg,cb)
+                prev=cur
+            end
+        end
+        for lat in (-90+gd):gd:(90-gd)                 # parallels
+            prev=nothing
+            for lon in 0:5:360
+                la=deg2rad(lon); lb=deg2rad(lat)
+                p=(cam.pos[1]+cos(lb)*cos(la), cam.pos[2]+cos(lb)*sin(la), cam.pos[3]+sin(lb))
+                pr=_project(cam,p...); cur=pr===nothing ? nothing : (pr[1],pr[2])
+                prev!==nothing && cur!==nothing && _oline!(Or,Og,Ob,Oa,nx,ny,prev[1],prev[2],cur[1],cur[2],cr,cg,cb)
+                prev=cur
+            end
+        end
+    end
+    if bl !== nothing && box                            # bounding-box wireframe (12 edges)
+        cs=[(0.,0.,0.),(bl,0.,0.),(bl,bl,0.),(0.,bl,0.),(0.,0.,bl),(bl,0.,bl),(bl,bl,bl),(0.,bl,bl)]
+        for (a,b) in ((1,2),(2,3),(3,4),(4,1),(5,6),(6,7),(7,8),(8,5),(1,5),(2,6),(3,7),(4,8))
+            _wedge!(Or,Og,Ob,Oa,nx,ny,cam,cs[a],cs[b],cr,cg,cb)
+        end
+    end
+    if bl !== nothing && axes                           # world axes from the origin (R=x, G=y, B=z)
+        L=axis_len*bl
+        _wedge!(Or,Og,Ob,Oa,nx,ny,cam,(0.,0.,0.),(L,0.,0.),axis_colors[1]...)
+        _wedge!(Or,Og,Ob,Oa,nx,ny,cam,(0.,0.,0.),(0.,L,0.),axis_colors[2]...)
+        _wedge!(Or,Og,Ob,Oa,nx,ny,cam,(0.,0.,0.),(0.,0.,L),axis_colors[3]...)
+    end
+    Rr=_orient(Or); Gg=_orient(Og); Bb=_orient(Ob); Aa=_orient(Oa); a=Float64(alpha)
+    @inbounds for idx in eachindex(D)
+        oa=Aa[idx]*a; oa<=0 && continue
+        p=D[idx]; D[idx]=RGB{Float64}((1-oa)*red(p)+oa*Rr[idx], (1-oa)*green(p)+oa*Gg[idx], (1-oa)*blue(p)+oa*Bb[idx])
+    end
+    return D
+end
+
+# -------------------------------------------------------------------------------------
 #  Multi-channel compositing — several tracers, each its own colormap + opacity, blended
 # -------------------------------------------------------------------------------------
 """

--- a/test/61_immersive_tests.jl
+++ b/test/61_immersive_tests.jl
@@ -180,6 +180,17 @@ end
     ocam = perspective_camera((0.5,0.5,2.6),(0.5,0.5,0.5); fov_deg=40, aspect=1.0)
     Lsum(M)=sum(x->Float64(Mera.red(x))+Float64(Mera.green(x))+Float64(Mera.blue(x)), M)
     @test Lsum(render_scene([star], ocam; res=40)) > Lsum(render_scene([gblk, star], ocam; res=40))
+    # coordinate overlay (planning aid): box+axes on perspective, graticule on equirect → draws onto the image
+    volu = _imm_uniform(3, (i,j,k)->1.0); cu = boxcenter(volu)
+    pcam = perspective_camera(cu .+ (1.6,1.6,1.6), cu; fov_deg=45)
+    base = render_view(volu, pcam; res=32, mode=:max)
+    ov = overlay_grid(base, pcam; vol=volu, box=true, axes=true, graticule=false)
+    @test eltype(ov) <: Mera.Colorant && size(ov) == (32,32)
+    @test all(x -> 0≤Mera.red(x)≤1 && 0≤Mera.green(x)≤1 && 0≤Mera.blue(x)≤1, ov)
+    @test !isequal(ov, as_image(base))                                   # the box/axes were drawn
+    oe = overlay_grid(render_view(volu, equirect_camera(cu); res=20, mode=:max), equirect_camera(cu);
+                      graticule=true, graticule_deg=30, box=false, axes=false)
+    @test eltype(oe) <: Mera.Colorant && size(oe) == (20,40)             # graticule on the panorama
 end
 
 @testset "immersive: camera paths, montage, flythrough fallback (data-free)" begin


### PR DESCRIPTION
Adds `overlay_grid(img, cam; vol/boxlen, box, axes, graticule, …)` — draws the **view's coordinate system** onto a rendered image, for planning camera placement/orientation:
- **box** — the simulation bounding-box wireframe (12 edges),
- **axes** — world x/y/z axes (red/green/blue) from the origin,
- **graticule** — a longitude/latitude sphere grid for `:equirect`/`:fisheye`.

Lines are projected through the camera (sampled, so they curve correctly in panoramas) and rasterized in the renderer's own (i,j) frame so they align exactly with the image. Returns an RGB image (input may be a scalar `render_view` or RGB `render_scene` result; display/save with `scene_figure`/`save_scene`).

Verified on spiral_clumps (box+axes over a perspective view, graticule over an equirect); unit tests in gamut + draw confirmed.